### PR TITLE
Remove SoQLLocation from the set of supported types

### DIFF
--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -58,9 +58,6 @@ object SoQLFunctions {
   val Intersects = Function("intersects", FunctionName("intersects"), Map("a" -> GeospatialLike, "b" -> GeospatialLike),
     Seq(VariableType("a"), VariableType("b")), None, FixedType(SoQLBoolean))
 
-  val LatitudeField = new MonomorphicFunction("latitude field", SpecialFunctions.Subscript, Seq(SoQLLocation, SoQLTextLiteral("latitude")), None, SoQLDouble).function
-  val LongitudeField = new MonomorphicFunction("longitude field", SpecialFunctions.Subscript, Seq(SoQLLocation, SoQLTextLiteral("longitude")), None, SoQLDouble).function
-
   val IsNull = Function("is null", SpecialFunctions.IsNull, Map.empty, Seq(VariableType("a")), None, FixedType(SoQLBoolean))
   val IsNotNull = Function("is not null", SpecialFunctions.IsNotNull, Map.empty, Seq(VariableType("a")), None, FixedType(SoQLBoolean))
 

--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLTypeConversions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLTypeConversions.scala
@@ -22,7 +22,6 @@ object SoQLTypeConversions {
     SoQLPoint,
     SoQLMultiLine,
     SoQLMultiPolygon,
-    SoQLLocation,
     SoQLObject,
     SoQLArray,
     SoQLID,

--- a/soql-toy/src/main/scala/com/socrata/soql/SoqlToy.scala
+++ b/soql-toy/src/main/scala/com/socrata/soql/SoqlToy.scala
@@ -24,7 +24,6 @@ object SoqlToy extends (Array[String] => Unit) {
       ColumnName("name_first") -> SoQLText,
       ColumnName("visits") -> SoQLNumber,
       ColumnName("last_visit") -> SoQLFixedTimestamp,
-      ColumnName("address") -> SoQLLocation,
       ColumnName("balance") -> SoQLMoney,
       ColumnName("object") -> SoQLObject,
       ColumnName("array") -> SoQLArray,

--- a/soql-types/src/main/scala/com/socrata/soql/types/SoQLType.scala
+++ b/soql-types/src/main/scala/com/socrata/soql/types/SoQLType.scala
@@ -41,7 +41,7 @@ object SoQLType {
   // I still want to retain pre-2.10 compat.
   val typesByName = Seq(
     SoQLID, SoQLVersion, SoQLText, SoQLBoolean, SoQLNumber, SoQLMoney, SoQLDouble, SoQLFixedTimestamp, SoQLFloatingTimestamp,
-    SoQLDate, SoQLTime, SoQLObject, SoQLArray, SoQLLocation, SoQLJson, SoQLPoint, SoQLMultiLine, SoQLMultiPolygon
+    SoQLDate, SoQLTime, SoQLObject, SoQLArray, SoQLJson, SoQLPoint, SoQLMultiLine, SoQLMultiPolygon
   ).foldLeft(Map.empty[TypeName, SoQLType]) { (acc, typ) =>
     acc + (typ.name -> typ)
   }


### PR DESCRIPTION
I didn't remove the type itself yet, since that will break the data coordinator and postgres adapter build in Jenkins (they both reference a version range for soql-types and so will pick up this snapshot version). I'll remove the type itself from soql-reference once it's been removed everywhere else. 
