### PR TITLE
Add concave hull and convex hull as SoQL functions

### DIFF
--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -55,6 +55,10 @@ object SoQLFunctions {
     Seq(VariableType("a"), VariableType("b")), None, FixedType(SoQLBoolean))
   val Extent = Function("extent", FunctionName("extent"), Map ("a" -> GeospatialLike),
     Seq(VariableType("a")), None, FixedType(SoQLMultiPolygon), isAggregate = true)
+  val ConcaveHull = Function("concave_hull", FunctionName("concave_hull"), Map ("a" -> GeospatialLike, "b" -> RealNumLike),
+    Seq(VariableType("a"), VariableType("b")), None, FixedType(SoQLMultiPolygon), isAggregate = true)
+  val ConvexHull = Function("convex_hull", FunctionName("convex_hull"), Map ("a" -> GeospatialLike),
+    Seq(VariableType("a")), None, FixedType(SoQLMultiPolygon), isAggregate = true)
   val Intersects = Function("intersects", FunctionName("intersects"), Map("a" -> GeospatialLike, "b" -> GeospatialLike),
     Seq(VariableType("a"), VariableType("b")), None, FixedType(SoQLBoolean))
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.4-SNAPSHOT"
+version in ThisBuild := "0.4.0-SNAPSHOT"


### PR DESCRIPTION
Background for this is this issue raised from the customer summit first look dataset prep:
https://socrata.atlassian.net/browse/CORE-3607

Basically, we need a smarter way to pull the subset of georegions to display on a choropleth. Obviously, these two functions are going to be more expensive than simply using the extent function, especially on really large georegion datasets; I'm not sure how expensive, but I'm implementing them in order to do some perf comparisons so we can understand the tradeoff.
