### PR TITLE
SoQLPack library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+soql-reference provides type definitions and utilities such as analyzers and parsers for Socrata's SoQL query language.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 soql-reference provides type definitions and utilities such as analyzers and parsers for Socrata's SoQL query language.
+
+### soql-types
+
+This contains the definitions of all the types in SoQL.
+
+### soql-pack
+
+SoQLPack format - an efficient, MessagePack-based SoQL transport medium.
+
+ *   Much more efficient than CJSON, GeoJSON, etc... especially for geometries
+ *   Designed to be very streaming friendly
+ *   MessagePack format means easier to implement clients in any language

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -43,4 +43,10 @@ object Build extends sbt.Build {
     file("soql-toy"),
     settings = SoqlToy.settings
   ) dependsOn(soqlStdlib)
+
+  lazy val soqlPack = Project(
+    "soql-pack",
+    file("soql-pack"),
+    settings = SoqlPack.settings
+  ) dependsOn (soqlTypes)
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,7 +6,7 @@ object Build extends sbt.Build {
     "soql",
     file("."),
     settings = BuildSettings.buildSettings
-  ) aggregate (soqlEnvironment, soqlParser, soqlAnalyzer, soqlTypes, soqlStdlib, soqlToy)
+  ) aggregate (soqlEnvironment, soqlParser, soqlAnalyzer, soqlTypes, soqlStdlib, soqlToy, soqlPack)
 
   lazy val soqlEnvironment = Project(
     "soql-environment",

--- a/project/SoqlPack.scala
+++ b/project/SoqlPack.scala
@@ -6,7 +6,8 @@ object SoqlPack {
     libraryDependencies ++=
       Seq(
         // Only used by serialization
-        "org.velvia"         %% "msgpack4s"                % "0.4.2"
-      )
+        "org.velvia"         %% "msgpack4s"                % "0.4.3"
+      ),
+    resolvers += "velvia maven" at "http://dl.bintray.com/velvia/maven"
   )
 }

--- a/project/SoqlPack.scala
+++ b/project/SoqlPack.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+object SoqlPack {
+  lazy val settings: Seq[Setting[_]] = BuildSettings.projectSettings() ++ Seq(
+    libraryDependencies ++=
+      Seq(
+        // Only used by serialization
+        "org.velvia"         %% "msgpack4s"                % "0.4.2"
+      )
+  )
+}

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,6 +1,5 @@
 resolvers ++= Seq(
-  "socrata releases" at "https://repository-socrata-oss.forge.cloudbees.com/release",
-  "velvia maven" at "http://dl.bintray.com/velvia/maven"
+  "socrata releases" at "https://repository-socrata-oss.forge.cloudbees.com/release"
 )
 
 addSbtPlugin("com.socrata" % "socrata-cloudbees-sbt" % "1.3.2")

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,5 +1,6 @@
 resolvers ++= Seq(
-  "socrata releases" at "https://repository-socrata-oss.forge.cloudbees.com/release"
+  "socrata releases" at "https://repository-socrata-oss.forge.cloudbees.com/release",
+  "velvia maven" at "http://dl.bintray.com/velvia/maven"
 )
 
 addSbtPlugin("com.socrata" % "socrata-cloudbees-sbt" % "1.3.2")

--- a/soql-pack/src/main/scala/com.socrata.soql/SoQLPackDecoder.scala
+++ b/soql-pack/src/main/scala/com.socrata.soql/SoQLPackDecoder.scala
@@ -1,0 +1,34 @@
+package com.socrata.soql
+
+import com.socrata.soql.types._
+import com.vividsolutions.jts.geom.Geometry
+import scala.util.Try
+
+/**
+ * The decoders decode from elements of the Seq[Any] decoded by msgpack4s from
+ * a binary array corresponding to a row of SoQLPack.
+ */
+object SoQLPackDecoder {
+  type Decoder = Any => Option[SoQLValue]
+  val decoderByType: Map[SoQLType, Decoder] = Map(
+    SoQLPoint        -> (decodeGeom(SoQLPoint, _: Any).map(x => SoQLPoint(x))),
+    SoQLMultiLine    -> (decodeGeom(SoQLMultiLine, _: Any).map(x => SoQLMultiLine(x))),
+    SoQLMultiPolygon -> (decodeGeom(SoQLMultiPolygon, _: Any).map(x => SoQLMultiPolygon(x))),
+    SoQLPolygon      -> (decodeGeom(SoQLPolygon, _: Any).map(x => SoQLPolygon(x))),
+    SoQLLine         -> (decodeGeom(SoQLLine, _: Any).map(x => SoQLLine(x))),
+    SoQLMultiPoint   -> (decodeGeom(SoQLMultiPoint, _: Any).map(x => SoQLMultiPoint(x))),
+    SoQLText         -> decodeBinaryString _,
+    SoQLNull         -> (x => Some(SoQLNull)),
+    SoQLBoolean      -> decodeBoolean _
+  )
+
+  def decodeGeom[T <: Geometry](typ: SoQLGeometryLike[T], item: Any): Option[T] =
+    typ.WkbRep.unapply(item.asInstanceOf[Array[Byte]])
+
+  // msgpack4s sometimes does not decode binary as string, when a flag is set
+  def decodeBinaryString(item: Any): Option[SoQLValue] =
+    Try(SoQLText(new String(item.asInstanceOf[Array[Byte]], "UTF-8"))).toOption
+
+  def decodeBoolean(item: Any): Option[SoQLValue] =
+    Some(SoQLBoolean(item.asInstanceOf[Boolean]))
+}

--- a/soql-pack/src/main/scala/com.socrata.soql/SoQLPackDecoder.scala
+++ b/soql-pack/src/main/scala/com.socrata.soql/SoQLPackDecoder.scala
@@ -3,7 +3,7 @@ package com.socrata.soql
 import com.socrata.soql.types._
 import com.vividsolutions.jts.geom.Geometry
 import java.math.BigDecimal
-import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.{DateTime, DateTimeZone, LocalDateTime, LocalDate, LocalTime}
 import org.velvia.MsgPackUtils._
 import scala.util.Try
 
@@ -28,7 +28,10 @@ object SoQLPackDecoder {
     SoQLNumber       -> (x => decodeBigDecimal(x).map(SoQLNumber(_))),
     SoQLMoney        -> (x => decodeBigDecimal(x).map(SoQLMoney(_))),
     SoQLDouble       -> (x => Try(x.asInstanceOf[Double]).toOption.map(SoQLDouble(_))),
-    SoQLFixedTimestamp -> (x => decodeDateTime(x).map(SoQLFixedTimestamp(_)))
+    SoQLFixedTimestamp -> (x => decodeDateTime(x).map(SoQLFixedTimestamp(_))),
+    SoQLFloatingTimestamp -> (x => decodeDateTime(x).map(t => SoQLFloatingTimestamp(new LocalDateTime(t)))),
+    SoQLDate         -> (x => decodeDateTime(x).map(t => SoQLDate(new LocalDate(t)))),
+    SoQLTime         -> (x => decodeLong(x).map(t => SoQLTime(LocalTime.fromMillisOfDay(t.toInt))))
   )
 
   def decodeLong(item: Any): Option[Long] = Try(getLong(item)).toOption

--- a/soql-pack/src/main/scala/com.socrata.soql/SoQLPackDecoder.scala
+++ b/soql-pack/src/main/scala/com.socrata.soql/SoQLPackDecoder.scala
@@ -2,6 +2,7 @@ package com.socrata.soql
 
 import com.socrata.soql.types._
 import com.vividsolutions.jts.geom.Geometry
+import org.velvia.MsgPackUtils._
 import scala.util.Try
 
 /**
@@ -19,8 +20,12 @@ object SoQLPackDecoder {
     SoQLMultiPoint   -> (decodeGeom(SoQLMultiPoint, _: Any).map(x => SoQLMultiPoint(x))),
     SoQLText         -> decodeBinaryString _,
     SoQLNull         -> (x => Some(SoQLNull)),
-    SoQLBoolean      -> decodeBoolean _
+    SoQLBoolean      -> decodeBoolean _,
+    SoQLID           -> (x => decodeLong(x).map(SoQLID(_))),
+    SoQLVersion      -> (x => decodeLong(x).map(SoQLVersion(_)))
   )
+
+  def decodeLong(item: Any): Option[Long] = Try(getLong(item)).toOption
 
   def decodeGeom[T <: Geometry](typ: SoQLGeometryLike[T], item: Any): Option[T] =
     typ.WkbRep.unapply(item.asInstanceOf[Array[Byte]])

--- a/soql-pack/src/main/scala/com.socrata.soql/SoQLPackDumper.scala
+++ b/soql-pack/src/main/scala/com.socrata.soql/SoQLPackDumper.scala
@@ -1,0 +1,44 @@
+package com.socrata.soql
+
+import java.io.{DataInputStream, FileInputStream}
+import org.apache.commons.io.input.CountingInputStream
+import org.velvia.MsgPack
+import org.velvia.MsgPackUtils._
+import com.vividsolutions.jts.io.WKBReader
+
+/**
+ * App that takes a SoQLPack stream from STDIN and dumps out the header and rows
+ *
+ * Run in the soql-reference directory like:
+ *  curl ... | sbt 'soql-pack/run'
+ */
+object SoQLPackDumper extends App {
+  val cis = new CountingInputStream(System.in)
+  val dis = new DataInputStream(cis)
+  val headerMap = MsgPack.unpack(dis, MsgPack.UNPACK_RAW_AS_STRING).asInstanceOf[Map[String, Any]]
+  println("--- Schema ---")
+  headerMap.foreach { case (key, value) => println("%25s: %s".format(key, value)) }
+  val types = headerMap.as[Seq[Map[String, String]]]("schema").map { m => m("t") }
+
+  println("\n---")
+
+  val reader = new WKBReader
+
+  while (dis.available > 0) {
+    print("[%10d] ".format(cis.getCount()))
+    // Don't unpack raw byte arrays as Strings - they might be Geometries or other blobs
+    val row = MsgPack.unpack(dis, 0).asInstanceOf[Seq[Any]]
+    for (i <- 0 until row.length) {
+      if (Set("point", "multiline", "multipolygon") contains types(i)) {
+        print(reader.read(row(i).asInstanceOf[Array[Byte]]))
+      } else if (types(i) == "text") {
+        print(new String(row(i).asInstanceOf[Array[Byte]]))
+      } else {
+        print(row(i).toString)
+      }
+      print(", ")
+    }
+    println
+  }
+
+}

--- a/soql-pack/src/main/scala/com.socrata.soql/SoQLPackEncoder.scala
+++ b/soql-pack/src/main/scala/com.socrata.soql/SoQLPackEncoder.scala
@@ -2,6 +2,7 @@ package com.socrata.soql
 
 import com.socrata.soql.types._
 import com.vividsolutions.jts.geom.Geometry
+import org.joda.time.DateTime
 
 object SoQLPackEncoder {
   type Encoder = PartialFunction[SoQLValue, Any]
@@ -19,7 +20,8 @@ object SoQLPackEncoder {
     SoQLVersion      -> { case SoQLVersion(long) => long },
     SoQLNumber       -> { case SoQLNumber(bd) => encodeBigDecimal(bd) },
     SoQLMoney        -> { case SoQLMoney(bd) => encodeBigDecimal(bd) },
-    SoQLDouble       -> { case SoQLDouble(dbl) => dbl }
+    SoQLDouble       -> { case SoQLDouble(dbl) => dbl },
+    SoQLFixedTimestamp -> { case SoQLFixedTimestamp(dt) => encodeDateTime(dt) }
   )
 
   lazy val geomEncoder: Encoder = {
@@ -33,4 +35,34 @@ object SoQLPackEncoder {
 
   def encodeBigDecimal(bd: java.math.BigDecimal): Any =
     Array(bd.scale, bd.unscaledValue.toByteArray)
+
+  import org.joda.time.chrono._
+
+  val FifteenMinMillis = 15 * 60 * 1000
+
+  val Chronologies = Array(ISOChronology.getInstance,
+                           CopticChronology.getInstance,
+                           EthiopicChronology.getInstance,
+                           GregorianChronology.getInstance,
+                           JulianChronology.getInstance,
+                           IslamicChronology.getInstance,
+                           BuddhistChronology.getInstance,
+                           GJChronology.getInstance)
+  val ChronoClasses = Chronologies.map(_.getClass)
+  val IsoClass = ChronoClasses(0)
+
+  // Encodes a DateTime with timezone and chronology.  The TimeZone info is not fully captured, rather
+  // it is recorded as hh:mm offset in 15-minute granularity (-95 to 95).  It practically holds as much info
+  // as ISO8601 date time string, which records +/-hh:mm.
+  def encodeDateTime(dt: DateTime): Any = {
+    val tz15min = dt.getZone.getOffset(0) / FifteenMinMillis
+    (dt.getChronology.getClass, tz15min) match {
+      case (IsoClass, 0) =>         // UTC timezone, standard chronology.  Encode as aray of len 1
+        Array[Any](dt.getMillis)
+      case (IsoClass, tz) =>        // Non-UTC timezone, standard chrono - encode as [millis, tz]
+        Array[Any](dt.getMillis, tz)
+      case (chronoClass, tz) =>               // Nonstandard everything - encode as [millis, tz, chronos]
+        Array[Any](dt.getMillis, tz, ChronoClasses.indexOf(chronoClass))
+    }
+  }
 }

--- a/soql-pack/src/main/scala/com.socrata.soql/SoQLPackEncoder.scala
+++ b/soql-pack/src/main/scala/com.socrata.soql/SoQLPackEncoder.scala
@@ -26,7 +26,10 @@ object SoQLPackEncoder {
     SoQLFixedTimestamp -> { case SoQLFixedTimestamp(dt) => encodeDateTime(dt) },
     SoQLFloatingTimestamp -> { case SoQLFloatingTimestamp(ldt) => encodeDateTime(ldt.toDateTime(UTC)) },
     SoQLDate         -> { case SoQLDate(date) => encodeDateTime(date.toDateTimeAtStartOfDay(UTC)) },
-    SoQLTime         -> { case SoQLTime(time) => time.getMillisOfDay }
+    SoQLTime         -> { case SoQLTime(time) => time.getMillisOfDay },
+    SoQLObject       -> { case SoQLObject(jObj) => jObj.toString },
+    SoQLArray        -> { case SoQLArray(jAray) => jAray.toString },
+    SoQLJson         -> { case SoQLJson(jValue) => jValue.toString }
   )
 
   lazy val geomEncoder: Encoder = {

--- a/soql-pack/src/main/scala/com.socrata.soql/SoQLPackEncoder.scala
+++ b/soql-pack/src/main/scala/com.socrata.soql/SoQLPackEncoder.scala
@@ -14,7 +14,9 @@ object SoQLPackEncoder {
     SoQLLine         -> geomEncoder,
     SoQLMultiPoint   -> geomEncoder,
     SoQLText         -> { case SoQLText(str) => str },
-    SoQLBoolean      -> { case SoQLBoolean(bool) => bool }
+    SoQLBoolean      -> { case SoQLBoolean(bool) => bool },
+    SoQLID           -> { case SoQLID(long) => long },
+    SoQLVersion      -> { case SoQLVersion(long) => long }
   )
 
   lazy val geomEncoder: Encoder = {

--- a/soql-pack/src/main/scala/com.socrata.soql/SoQLPackEncoder.scala
+++ b/soql-pack/src/main/scala/com.socrata.soql/SoQLPackEncoder.scala
@@ -16,7 +16,10 @@ object SoQLPackEncoder {
     SoQLText         -> { case SoQLText(str) => str },
     SoQLBoolean      -> { case SoQLBoolean(bool) => bool },
     SoQLID           -> { case SoQLID(long) => long },
-    SoQLVersion      -> { case SoQLVersion(long) => long }
+    SoQLVersion      -> { case SoQLVersion(long) => long },
+    SoQLNumber       -> { case SoQLNumber(bd) => encodeBigDecimal(bd) },
+    SoQLMoney        -> { case SoQLMoney(bd) => encodeBigDecimal(bd) },
+    SoQLDouble       -> { case SoQLDouble(dbl) => dbl }
   )
 
   lazy val geomEncoder: Encoder = {
@@ -27,4 +30,7 @@ object SoQLPackEncoder {
     case SoQLLine(l)         => SoQLLine.WkbRep(l)
     case SoQLMultiPoint(mp)  => SoQLMultiPoint.WkbRep(mp)
   }
+
+  def encodeBigDecimal(bd: java.math.BigDecimal): Any =
+    Array(bd.scale, bd.unscaledValue.toByteArray)
 }

--- a/soql-pack/src/main/scala/com.socrata.soql/SoQLPackEncoder.scala
+++ b/soql-pack/src/main/scala/com.socrata.soql/SoQLPackEncoder.scala
@@ -17,6 +17,7 @@ object SoQLPackEncoder {
     SoQLMultiPoint   -> geomEncoder,
     SoQLText         -> { case SoQLText(str) => str },
     SoQLBoolean      -> { case SoQLBoolean(bool) => bool },
+    // meant for internal usage only because SoQLID is not encrypted
     SoQLID           -> { case SoQLID(long) => long },
     SoQLVersion      -> { case SoQLVersion(long) => long },
     SoQLNumber       -> { case SoQLNumber(bd) => encodeBigDecimal(bd) },

--- a/soql-pack/src/main/scala/com.socrata.soql/SoQLPackEncoder.scala
+++ b/soql-pack/src/main/scala/com.socrata.soql/SoQLPackEncoder.scala
@@ -1,0 +1,28 @@
+package com.socrata.soql
+
+import com.socrata.soql.types._
+import com.vividsolutions.jts.geom.Geometry
+
+object SoQLPackEncoder {
+  type Encoder = PartialFunction[SoQLValue, Any]
+
+  val encoderByType: Map[SoQLType, Encoder] = Map(
+    SoQLPoint        -> geomEncoder,
+    SoQLMultiLine    -> geomEncoder,
+    SoQLMultiPolygon -> geomEncoder,
+    SoQLPolygon      -> geomEncoder,
+    SoQLLine         -> geomEncoder,
+    SoQLMultiPoint   -> geomEncoder,
+    SoQLText         -> { case SoQLText(str) => str },
+    SoQLBoolean      -> { case SoQLBoolean(bool) => bool }
+  )
+
+  lazy val geomEncoder: Encoder = {
+    case SoQLPoint(pt)       => SoQLPoint.WkbRep(pt)
+    case SoQLMultiLine(ml)   => SoQLMultiLine.WkbRep(ml)
+    case SoQLMultiPolygon(p) => SoQLMultiPolygon.WkbRep(p)
+    case SoQLPolygon(p)      => SoQLPolygon.WkbRep(p)
+    case SoQLLine(l)         => SoQLLine.WkbRep(l)
+    case SoQLMultiPoint(mp)  => SoQLMultiPoint.WkbRep(mp)
+  }
+}

--- a/soql-pack/src/main/scala/com.socrata.soql/SoQLPackEncoder.scala
+++ b/soql-pack/src/main/scala/com.socrata.soql/SoQLPackEncoder.scala
@@ -3,6 +3,7 @@ package com.socrata.soql
 import com.socrata.soql.types._
 import com.vividsolutions.jts.geom.Geometry
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone.UTC
 
 object SoQLPackEncoder {
   type Encoder = PartialFunction[SoQLValue, Any]
@@ -21,7 +22,10 @@ object SoQLPackEncoder {
     SoQLNumber       -> { case SoQLNumber(bd) => encodeBigDecimal(bd) },
     SoQLMoney        -> { case SoQLMoney(bd) => encodeBigDecimal(bd) },
     SoQLDouble       -> { case SoQLDouble(dbl) => dbl },
-    SoQLFixedTimestamp -> { case SoQLFixedTimestamp(dt) => encodeDateTime(dt) }
+    SoQLFixedTimestamp -> { case SoQLFixedTimestamp(dt) => encodeDateTime(dt) },
+    SoQLFloatingTimestamp -> { case SoQLFloatingTimestamp(ldt) => encodeDateTime(ldt.toDateTime(UTC)) },
+    SoQLDate         -> { case SoQLDate(date) => encodeDateTime(date.toDateTimeAtStartOfDay(UTC)) },
+    SoQLTime         -> { case SoQLTime(time) => time.getMillisOfDay }
   )
 
   lazy val geomEncoder: Encoder = {

--- a/soql-pack/src/main/scala/com.socrata.soql/SoQLPackIterator.scala
+++ b/soql-pack/src/main/scala/com.socrata.soql/SoQLPackIterator.scala
@@ -1,0 +1,72 @@
+package com.socrata.soql
+
+import java.io.DataInputStream
+
+import com.socrata.soql.environment.TypeName
+import com.socrata.soql.types._
+import com.vividsolutions.jts.io.WKBReader
+import org.slf4j.LoggerFactory
+import org.velvia.{MsgPack, InvalidMsgPackDataException}
+import org.velvia.MsgPackUtils._
+
+/**
+ * An Iterator that streams in rows of SoQLValues from a SoQLPack binary stream.
+ * Note that there is no good way to detect the end of a stream, other than to try reading from
+ * it in hasNext and cache the results.....
+ */
+class SoQLPackIterator(dis: DataInputStream) extends Iterator[Array[SoQLValue]] {
+  private val logger = LoggerFactory.getLogger(getClass)
+  private val reader = new WKBReader
+
+  var nextRow: Option[Seq[Any]] = None
+  var rowNum = 0
+
+  val headers = MsgPack.unpack(dis, MsgPack.UNPACK_RAW_AS_STRING).asInstanceOf[Map[String, Any]]
+  logger.debug("Unpacked SoQLPack headers: " + headers)
+
+  val geomIndex = headers.asInt("geometry_index")
+
+  // Schema is a Seq of (ColumnName, SoQLType)
+  val schema = headers("schema").asInstanceOf[Seq[Map[String, String]]].map { colInfo =>
+    colInfo("c") -> SoQLType.typesByName(TypeName(colInfo("t")))
+  }
+
+  private val decoders = schema.map { case (name, typ) => SoQLPackDecoder.decoderByType(typ) }
+
+  // Only allow nextRow to be filled once
+  // NOTE: if IOException is raised during this, make sure the stream hasn't been closed prior
+  // to reading from it.
+  def hasNext: Boolean = {
+    // $COVERAGE-OFF$ For some reason scoverage can't handle this line.
+    if (nextRow.isEmpty) {
+      // $COVERAGE-ON$
+      try {
+        logger.trace("Unpacking row {}", rowNum)
+        nextRow = Some(MsgPack.unpack(dis, 0).asInstanceOf[Seq[Any]])
+        rowNum += 1
+      } catch {
+        case e: InvalidMsgPackDataException =>
+          logger.debug("Probably reached end of data at rowNum {}, got {}", rowNum, e.getMessage)
+          nextRow = None
+        // $COVERAGE-OFF$
+        // This case should ideally never happen, and is caught at a higher level.
+        case e: Exception =>
+          logger.error("Unexpected exception at rowNum {}", rowNum, e)
+          throw e
+          // $COVERAGE-ON$
+      }
+    }
+    nextRow.isDefined
+  }
+
+  def next(): Array[SoQLValue] = {
+    val row = nextRow.get.toArray
+    nextRow = None    // MUST reset to avoid an endless loop
+    var i = 0
+    row.map { item =>
+      val soql = Option(item).flatMap(decoders(i)).getOrElse(SoQLNull)
+      i += 1
+      soql
+    }
+  }
+}

--- a/soql-pack/src/main/scala/com.socrata.soql/SoQLPackWriter.scala
+++ b/soql-pack/src/main/scala/com.socrata.soql/SoQLPackWriter.scala
@@ -12,6 +12,8 @@ import org.velvia.MsgPack
  *   - Designed to be very streaming friendly
  *   - MessagePack format means easier to implement clients in any language
  *
+ * It is currently designed for internal (service to service) use, partly due to SoQLID being not encrypted.
+ *
  * The structure of the content is pretty much identical to CJSON,
  * but framed as follows:
  *   +0000  P bytes - CJSON-like header, MessagePack object/map, currently with the following entries:

--- a/soql-pack/src/main/scala/com.socrata.soql/SoQLPackWriter.scala
+++ b/soql-pack/src/main/scala/com.socrata.soql/SoQLPackWriter.scala
@@ -1,0 +1,94 @@
+package com.socrata.soql
+
+import com.rojoma.simplearm.util._
+import com.socrata.soql.types._
+import com.vividsolutions.jts.io.WKBWriter
+import java.io.{DataOutputStream, OutputStream}
+import org.velvia.MsgPack
+
+/**
+ * Writes a stream of SoQL values in SoQLPack format - an efficient, MessagePack-based SoQL transport medium.
+ *   - Much more efficient than CJSON, GeoJSON, etc... especially for geometries
+ *   - Designed to be very streaming friendly
+ *   - MessagePack format means easier to implement clients in any language
+ *
+ * The structure of the content is pretty much identical to CJSON,
+ * but framed as follows:
+ *   +0000  P bytes - CJSON-like header, MessagePack object/map, currently with the following entries:
+ *                        "row_count" -> integer count of rows
+ *                        "geometry_index" -> index within row of geometry shape
+ *                        "schema" -> MsgPack equiv of [{"c": fieldName1, "t": fieldType1}, ...]
+ *   +P     R bytes - first row - MessagePack array
+ *                        geometries are WKB binary blobs
+ *                        Text fields are strings
+ *                        Number fields are numbers
+ *                        All other fields... TBD
+ *   +P+R           - second row
+ *   All other rows are encoded as MessagePack arrays and follow sequentially.
+ *
+ *   NOTE: Unlike CJSON, the columns are not rearranged in alphabetical field order, but the original
+ *   order in the Array[SoQLValue] and CSchema are retained.
+ *
+ * @param schema a Seq of tuples of (ColumnName, SoQLType)
+ * @oaran extraHeaders a map of extra header info to pass along
+ */
+class SoQLPackWriter(schema: Seq[(String, SoQLType)],
+                     extraHeaders: Map[String, Any] = Map.empty) {
+
+  val geoColumn = getGeoColumnIndex(schema.map(_._2))
+
+  private def getGeoColumnIndex(columns: Seq[SoQLType]): Int = {
+    val geoColumnIndices = columns.zipWithIndex.collect {
+      case (typ, index) if typ.isInstanceOf[SoQLGeometryLike[_]] => index
+    }
+
+    // Just return -1 if no geo column or more than one
+    if (geoColumnIndices.size != 1) return -1
+
+    geoColumnIndices(0)
+  }
+
+  /**
+   * Serializes the rows into SoQLPack binary format, writing it out to the ostream.
+   * The caller must be responsible for closing the output stream.
+=   */
+  def write(ostream: OutputStream, rows: Iterator[Array[SoQLValue]]) {
+    for {
+      dos <- managed(new DataOutputStream(ostream))
+    } yield {
+      val schemaMaps = schema.map { case (name, typ) =>
+        Map("c" -> name, "t" -> typ.toString)
+      }.toSeq
+
+      val headerMap: Map[String, Any] = Map("schema" -> schemaMaps,
+                                            "geometry_index" -> geoColumn) ++ extraHeaders
+      MsgPack.pack(headerMap, dos)
+
+      // end of header
+
+      val wkbWriter = new WKBWriter
+
+      for (row <- rows) {
+        val values: Seq[Any] = (0 until row.length).map { i =>
+          // TODO: turn this logic into a MessagePackColumnRep
+          row(i) match {
+            case SoQLPoint(pt)       => wkbWriter.write(pt)
+            case SoQLMultiLine(ml)   => wkbWriter.write(ml)
+            case SoQLMultiPolygon(p) => wkbWriter.write(p)
+            case SoQLPolygon(p)      => wkbWriter.write(p)
+            case SoQLLine(l)         => wkbWriter.write(l)
+            case SoQLMultiPoint(mp)  => wkbWriter.write(mp)
+            case SoQLText(str)       => str
+            case SoQLNull            => null
+            case null                => null
+            case SoQLBoolean(bool)   => bool
+            // For anything else, we rely on the JsonColumnRep and translate from JValues
+            case other: SoQLValue    => ???
+          }
+        }
+        MsgPack.pack(values, dos)
+      }
+      dos.flush()
+    }
+  }
+}

--- a/soql-pack/src/test/scala/com.socrata.soql/SoQLPackTest.scala
+++ b/soql-pack/src/test/scala/com.socrata.soql/SoQLPackTest.scala
@@ -8,13 +8,15 @@ class SoQLPackTest extends FunSuite with MustMatchers {
   val wkt1 = "POINT (47.123456 -122.123456)"
   val point1 = SoQLPoint.WktRep.unapply(wkt1).get
 
-  val schema1 = Seq("str" -> SoQLText,
+  val schema1 = Seq("id" -> SoQLID,
+                    "ver" -> SoQLVersion,
+                    "str" -> SoQLText,
                     "bool" -> SoQLBoolean,
                     "point" -> SoQLPoint)
 
   val data1: Seq[Array[SoQLValue]] = Seq(
-    Array(SoQLText("first"),  SoQLBoolean(true),  SoQLPoint(point1)),
-    Array(SoQLText("second"), SoQLBoolean(false), SoQLNull)
+    Array(SoQLID(1L), SoQLVersion(11L), SoQLText("first"),  SoQLBoolean(true),  SoQLPoint(point1)),
+    Array(SoQLID(2L), SoQLVersion(12L), SoQLText("second"), SoQLBoolean(false), SoQLNull)
   )
 
   def writeThenRead(writer: java.io.OutputStream => Unit)(reader: java.io.DataInputStream => Unit) {
@@ -40,7 +42,7 @@ class SoQLPackTest extends FunSuite with MustMatchers {
       w.write(os, data1.toIterator)
     } { dis =>
       val r = new SoQLPackIterator(dis)
-      r.geomIndex must equal (2)
+      r.geomIndex must equal (4)
       r.schema must equal (schema1)
       val outRows = r.toList
       outRows must have length (data1.length)

--- a/soql-pack/src/test/scala/com.socrata.soql/SoQLPackTest.scala
+++ b/soql-pack/src/test/scala/com.socrata.soql/SoQLPackTest.scala
@@ -107,4 +107,31 @@ class SoQLPackTest extends FunSuite with MustMatchers {
       outRows(1).mkString(",") must equal (dataDT(1).mkString(","))
     }
   }
+
+  import com.rojoma.json.v3.interpolation._
+
+  val schemaJson = Seq("jobj" -> SoQLObject,
+                       "jarray" -> SoQLArray,
+                       "json" -> SoQLJson)
+
+  val dataJson: Seq[Array[SoQLValue]] = Seq(
+    Array(SoQLObject(j"""{"apple": 5, "bananas": [456, "Chiquitos"]}"""),
+          SoQLArray (j"""[1, true, null, "not really"]"""),
+          SoQLJson  (j"""56.7890"""))
+  )
+
+  test("Can serialize SoQL rows with Json data types") {
+    writeThenRead { os =>
+      val w = new SoQLPackWriter(schemaJson)
+      w.write(os, dataJson.toIterator)
+    } { dis =>
+      val r = new SoQLPackIterator(dis)
+      r.geomIndex must equal (-1)
+      r.schema must equal (schemaJson)
+      val outRows = r.toList
+      outRows must have length (dataJson.length)
+      outRows(0) must equal (dataJson(0))
+    }
+
+  }
 }

--- a/soql-pack/src/test/scala/com.socrata.soql/SoQLPackTest.scala
+++ b/soql-pack/src/test/scala/com.socrata.soql/SoQLPackTest.scala
@@ -1,0 +1,51 @@
+package com.socrata.soql
+
+import com.socrata.soql.types._
+import com.vividsolutions.jts.geom.Polygon
+import org.scalatest.{FunSuite, MustMatchers}
+
+class SoQLPackTest extends FunSuite with MustMatchers {
+  val wkt1 = "POINT (47.123456 -122.123456)"
+  val point1 = SoQLPoint.WktRep.unapply(wkt1).get
+
+  val schema1 = Seq("str" -> SoQLText,
+                    "bool" -> SoQLBoolean,
+                    "point" -> SoQLPoint)
+
+  val data1: Seq[Array[SoQLValue]] = Seq(
+    Array(SoQLText("first"),  SoQLBoolean(true),  SoQLPoint(point1)),
+    Array(SoQLText("second"), SoQLBoolean(false), SoQLNull)
+  )
+
+  def writeThenRead(writer: java.io.OutputStream => Unit)(reader: java.io.DataInputStream => Unit) {
+    val baos = new java.io.ByteArrayOutputStream
+    try {
+      writer(baos)
+      val bais = new java.io.ByteArrayInputStream(baos.toByteArray)
+      val dis = new java.io.DataInputStream(bais)
+      try {
+        reader(dis)
+      } finally {
+        dis.close
+        bais.close
+      }
+    } finally {
+      baos.close
+    }
+  }
+
+  test("Can serialize SoQL rows to and from SoQLPack") {
+    writeThenRead { os =>
+      val w = new SoQLPackWriter(schema1)
+      w.write(os, data1.toIterator)
+    } { dis =>
+      val r = new SoQLPackIterator(dis)
+      r.geomIndex must equal (2)
+      r.schema must equal (schema1)
+      val outRows = r.toList
+      outRows must have length (data1.length)
+      outRows(0) must equal (data1(0))
+      outRows(1) must equal (data1(1))
+    }
+  }
+}

--- a/soql-pack/src/test/scala/com.socrata.soql/SoQLPackTest.scala
+++ b/soql-pack/src/test/scala/com.socrata.soql/SoQLPackTest.scala
@@ -3,6 +3,7 @@ package com.socrata.soql
 import com.socrata.soql.types._
 import com.vividsolutions.jts.geom.Polygon
 import java.math.{BigDecimal => BD}
+import org.joda.time.DateTime
 import org.scalatest.{FunSuite, MustMatchers}
 
 class SoQLPackTest extends FunSuite with MustMatchers {
@@ -71,6 +72,31 @@ class SoQLPackTest extends FunSuite with MustMatchers {
       outRows must have length (data2.length)
       outRows(0) must equal (data2(0))
       outRows(1) must equal (data2(1))
+    }
+  }
+
+  val dt1 = DateTime.parse("2015-03-22T12Z")
+  val dt2 = DateTime.parse("2015-03-22T12:00:00-08:00")
+
+  val schemaDT = Seq("dt" -> SoQLFixedTimestamp)
+
+  val dataDT: Seq[Array[SoQLValue]] = Seq(
+    Array(SoQLFixedTimestamp(dt1)),
+    Array(SoQLFixedTimestamp(dt2))
+  )
+
+  test("Can serialize SoQL rows with date time types to and from SoQLPack") {
+    writeThenRead { os =>
+      val w = new SoQLPackWriter(schemaDT)
+      w.write(os, dataDT.toIterator)
+    } { dis =>
+      val r = new SoQLPackIterator(dis)
+      r.geomIndex must equal (-1)
+      r.schema must equal (schemaDT)
+      val outRows = r.toList
+      outRows must have length (dataDT.length)
+      outRows(0) must equal (dataDT(0))
+      outRows(1) must equal (dataDT(1))
     }
   }
 }

--- a/soql-types/src/main/scala/com/socrata/soql/types/SoQLGeometryLike.scala
+++ b/soql-types/src/main/scala/com/socrata/soql/types/SoQLGeometryLike.scala
@@ -36,14 +36,14 @@ trait SoQLGeometryLike[T <: Geometry] {
   object WkbRep {
     val gf = threadLocal { new GeometryFactory }
     val reader = threadLocal { new WKBReader(gf.get) }
+    val writer = threadLocal { new WKBWriter }
 
     def unapply(bytes: Array[Byte]): Option[T] = {
       Try(Treified.cast(reader.get.read(bytes))).toOption
     }
 
     def apply(geom: T): Array[Byte] = {
-      val writer = new WKBWriter
-      writer.write(geom)
+      writer.get.write(geom)
     }
   }
 


### PR DESCRIPTION
Overall, this PR moves SoQLPack logic from soda-fountain and tileserver to a centralized place here in soql-reference and extends support to far more types.

- Generic API to encode an `Iterator[Array[SoQLValue]]` to a binary SoQLPack stream, and back
- SoQLPackDumper utility to dump out a binary SoQLPack stream on STDIN
- Support for every SoQL type except for the JSON types (SoQLArray, SoQLObject, etc).  These will be added later, in this PR or another one.

The plan after this is to 
a) replace code in soda-fountain and tileserver to use this API
b) enable tileserver to use SoQLPack for all queries
c) enable RegionCoder to pull from soda fountain using SoQLPack

It might be easier to review the individual commits.