### PR TITLE
How about using subtype to support complex column subscript syntax?

### DIFF
--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -34,6 +34,9 @@ object SoQLFunctions {
   val TextToMultiPolygon = new MonomorphicFunction("text to multi polygon", SpecialFunctions.Cast(SoQLMultiPolygon.name), Seq(SoQLText), Seq.empty, SoQLMultiPolygon).function
   val TextToBlob = new MonomorphicFunction("text to blob", SpecialFunctions.Cast(SoQLBlob.name), Seq(SoQLText), Seq.empty, SoQLBlob).function
   val TextToLocation = new MonomorphicFunction("text to location", SpecialFunctions.Cast(SoQLLocation.name), Seq(SoQLText), Seq.empty, SoQLLocation).function
+  val TextToLocationLatitude = new MonomorphicFunction("text to location latitude", SpecialFunctions.Cast(SoQLLocationLatitude.name), Seq(SoQLText), Seq.empty, SoQLLocationLatitude).function
+  val TextToLocationLongitude = new MonomorphicFunction("text to location longitude", SpecialFunctions.Cast(SoQLLocationLongitude.name), Seq(SoQLText), Seq.empty, SoQLLocationLongitude).function
+  val TextToLocationAddress = new MonomorphicFunction("text to location address", SpecialFunctions.Cast(SoQLLocationAddress.name), Seq(SoQLText), Seq.empty, SoQLLocationAddress).function
 
   val Concat = Function("||", SpecialFunctions.Operator("||"), Map.empty, Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLText))
   val Gte = Function(">=", SpecialFunctions.Operator(">="), Map("a" -> Ordered), Seq(VariableType("a"), VariableType("a")), Seq.empty, FixedType(SoQLBoolean))
@@ -164,9 +167,12 @@ object SoQLFunctions {
 
   // Cannot use property subscript syntax (loc.prop) to access properties of different types - number, text, point. Use cast syntax (loc::prop) instead
   val LocationToPoint = new MonomorphicFunction("loc to point", SpecialFunctions.Cast(SoQLPoint.name), Seq(SoQLLocation), Seq.empty, SoQLPoint).function
-  val LocationToLatitude = new MonomorphicFunction("loc to latitude", FunctionName("location_latitude"), Seq(SoQLLocation), Seq.empty, SoQLNumber).function
-  val LocationToLongitude = new MonomorphicFunction("loc to longitude", FunctionName("location_longitude"), Seq(SoQLLocation), Seq.empty, SoQLNumber).function
-  val LocationToAddress = new MonomorphicFunction("loc to address", FunctionName("location_address"), Seq(SoQLLocation), Seq.empty, SoQLText).function
+  val LocationDotLatitude = new MonomorphicFunction("loc dot latitude", SpecialFunctions.Subscript,
+    Seq(SoQLLocation, SoQLLocationLatitude), Seq.empty, SoQLNumber).function
+  val LocationDotLongitude = new MonomorphicFunction("loc dot longitude", SpecialFunctions.Subscript,
+    Seq(SoQLLocation, SoQLLocationLongitude), Seq.empty, SoQLNumber).function
+  val LocationDotAddress = new MonomorphicFunction("loc dot address", SpecialFunctions.Subscript,
+    Seq(SoQLLocation, SoQLLocationAddress), Seq.empty, SoQLText).function
 
   val LocationWithinCircle = Function("location_within_circle", FunctionName("within_circle"),
     Map("a" -> RealNumLike),

--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLTypeConversions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLTypeConversions.scala
@@ -72,6 +72,12 @@ object SoQLTypeConversions {
     Some(SoQLFunctions.TextToBlob.monomorphic.getOrElse(sys.error("text to blob conversion not monomorphic?")))
   private val textToLocationFunc =
     Some(SoQLFunctions.TextToLocation.monomorphic.getOrElse(sys.error("text to location conversion not monomorphic?")))
+  private val textToLocationLatitudeFunc =
+    Some(SoQLFunctions.TextToLocationLatitude.monomorphic.getOrElse(sys.error("text to location latitude conversion not monomorphic?")))
+  private val textToLocationLongitudeFunc =
+    Some(SoQLFunctions.TextToLocationLongitude.monomorphic.getOrElse(sys.error("text to location longitude conversion not monomorphic?")))
+  private val textToLocationAddressFunc =
+    Some(SoQLFunctions.TextToLocationAddress.monomorphic.getOrElse(sys.error("text to location address conversion not monomorphic?")))
 
   private def isNumberLiteral(s: String) = try {
     val lexer = new Lexer(s)
@@ -122,6 +128,12 @@ object SoQLTypeConversions {
         textToBlobFunc
       case (SoQLTextLiteral(s), SoQLLocation) if SoQLLocation.isPossibleLocation(s) =>
         textToLocationFunc
+      case (SoQLTextLiteral(s), SoQLLocationLatitude) if SoQLLocationLatitude.isPossible(s) =>
+        textToLocationLatitudeFunc
+      case (SoQLTextLiteral(s), SoQLLocationLongitude) if SoQLLocationLongitude.isPossible(s) =>
+        textToLocationLongitudeFunc
+      case (SoQLTextLiteral(s), SoQLLocationAddress) if SoQLLocationAddress.isPossible(s) =>
+        textToLocationAddressFunc
       case _ =>
         None
     }

--- a/soql-types/src/main/scala/com/socrata/soql/types/SoQLType.scala
+++ b/soql-types/src/main/scala/com/socrata/soql/types/SoQLType.scala
@@ -346,3 +346,17 @@ case class SoQLNumberLiteral(number: BigDecimal) extends FakeSoQLType(SoQLNumber
 object SoQLNumberLiteral {
   val typeName = TypeName("*number")
 }
+
+// Support accessing individual properties of complex column types especially when
+// these properties have different types.
+// location.latitude, location.longitude, location.address
+sealed abstract class SoQLSubType(val parent: SoQLType, val subTypeName: String) extends
+  SoQLType(s"${parent.name.name}_$subTypeName") {
+  def isPossible(s: CaseInsensitiveString): Boolean = subTypeName == s.getString
+}
+
+case object SoQLLocationLatitude extends SoQLSubType(SoQLLocation, "latitude")
+
+case object SoQLLocationLongitude extends SoQLSubType(SoQLLocation, "longitude")
+
+case object SoQLLocationAddress extends SoQLSubType(SoQLLocation, "human_address")


### PR DESCRIPTION
location.latitude vs location_latitude(location)