### PR TITLE
Add geo types to Equatable

### DIFF
--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLTypeClasses.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLTypeClasses.scala
@@ -17,12 +17,13 @@ object SoQLTypeClasses {
     SoQLVersion
   )
 
-  val Equatable = Ordered ++ Set[SoQLType](
+  val GeospatialLike = Set[SoQLType](SoQLPoint, SoQLMultiPoint, SoQLLine, SoQLMultiLine, SoQLPolygon, SoQLMultiPolygon)
+
+  val Equatable = Ordered ++ GeospatialLike ++ Set[SoQLType](
     SoQLBlob,
     SoQLLocation
   )
 
   val NumLike = Set[SoQLType](SoQLNumber, SoQLDouble, SoQLMoney)
   val RealNumLike = Set[SoQLType](SoQLNumber, SoQLDouble)
-  val GeospatialLike = Set[SoQLType](SoQLPoint, SoQLMultiPoint, SoQLLine, SoQLMultiLine, SoQLPolygon, SoQLMultiPolygon)
 }


### PR DESCRIPTION
* Allows grouping on geometry columns, which was broken
  in the previous release