### PR TITLE
Nathaliek/en 3726

### DIFF
--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -63,7 +63,7 @@ object SoQLFunctions {
   val DistanceInMeters = f("distance_in_meters", FunctionName("distance_in_meters"), Map("a" -> GeospatialLike, "b" -> GeospatialLike),
     Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLNumber))
   val GeoMakeValid = f("geo_make_valid", FunctionName("geo_make_valid"), Map("a" -> GeospatialLike),
-    Seq(VariableType("a")), Seq.empty, FixedType(SoQLMultiPolygon))
+    Seq(VariableType("a")), Seq.empty, VariableType("a"))
   val GeoMulti = f("geo_multi", FunctionName("geo_multi"), Map("a" -> GeospatialLike),
     Seq(VariableType("a")), Seq.empty, VariableType("a"))
 

--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -62,6 +62,8 @@ object SoQLFunctions {
     Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLBoolean))
   val DistanceInMeters = f("distance_in_meters", FunctionName("distance_in_meters"), Map("a" -> GeospatialLike, "b" -> GeospatialLike),
     Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLNumber))
+  val ValidMultiPolygon = f("valid_multi_polygon", FunctionName("valid_multi_polygon"), Map("a" -> GeospatialLike),
+    Seq(VariableType("a")), Seq.empty, FixedType(SoQLMultiPolygon))
   val NumberOfPoints = f("num_points", FunctionName("num_points"), Map("a" -> GeospatialLike),
     Seq(VariableType("a")), Seq.empty, FixedType(SoQLNumber))
   val Simplify = f("simplify", FunctionName("simplify"), Map("a" -> GeospatialLike, "b" -> NumLike),

--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -62,8 +62,11 @@ object SoQLFunctions {
     Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLBoolean))
   val DistanceInMeters = f("distance_in_meters", FunctionName("distance_in_meters"), Map("a" -> GeospatialLike, "b" -> GeospatialLike),
     Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLNumber))
-  val ValidMultiPolygon = f("valid_multi_polygon", FunctionName("valid_multi_polygon"), Map("a" -> GeospatialLike),
+  val GeoMakeValid = f("geo_make_valid", FunctionName("geo_make_valid"), Map("a" -> GeospatialLike),
     Seq(VariableType("a")), Seq.empty, FixedType(SoQLMultiPolygon))
+  val GeoMulti = f("geo_multi", FunctionName("geo_multi"), Map("a" -> GeospatialLike),
+    Seq(VariableType("a")), Seq.empty, VariableType("a"))
+
   val NumberOfPoints = f("num_points", FunctionName("num_points"), Map("a" -> GeospatialLike),
     Seq(VariableType("a")), Seq.empty, FixedType(SoQLNumber))
   val Simplify = f("simplify", FunctionName("simplify"), Map("a" -> GeospatialLike, "b" -> NumLike),


### PR DESCRIPTION
Notes: 
- geo related functions should start with geo 
- added code path to make a polygon valid and make a type a "multi" type. To be used with caution because the return type is supposed to be the same as the column the function is applied on. 
