### PR TITLE
Allow self-shadowing of columns

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/aliases/AliasAnalysis.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/aliases/AliasAnalysis.scala
@@ -197,12 +197,12 @@ object AliasAnalysis extends AliasAnalysis {
       case _ => false
     }
 
-    val graph = otherRefs.mapValues { expr =>
+    val graph = otherRefs.transform { (targetAlias, expr) =>
       // semi-explicit refs are non-circular, but since they _look_ circular we want to exclude them.
       // We also want to exclude references to things that are not aliased at all (either they're columns
       // on the dataset or they're not -- either way it'll be handled at typechecking).
       expr.allColumnRefs.filterNot { cr =>
-        semiExplicit.contains(cr.column) || !in.contains(cr.column)
+        semiExplicit.contains(cr.column) || !in.contains(cr.column) || targetAlias == cr.column
       }
     }
 

--- a/soql-analyzer/src/test/scala/com/socrata/soql/aliases/AliasAnalysisTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/aliases/AliasAnalysisTest.scala
@@ -208,12 +208,6 @@ class AliasAnalysisTest extends WordSpec with MustMatchers {
       AliasAnalysis.orderAliasesForEvaluation(OrderedMap(ColumnName("x") -> expr("x")), Set(ColumnName("x"))) must equal (Seq(ColumnName("x")))
     }
 
-    "reject directly-circular aliases with complex expressions" in {
-      a [CircularAliasDefinition] must be thrownBy { AliasAnalysis.orderAliasesForEvaluation(OrderedMap(ColumnName("x") -> expr("x + x")), Set.empty) }
-      a [CircularAliasDefinition] must be thrownBy { AliasAnalysis.orderAliasesForEvaluation(OrderedMap(ColumnName("x") -> expr("(x)")), Set.empty) }
-      a [CircularAliasDefinition] must be thrownBy { AliasAnalysis.orderAliasesForEvaluation(OrderedMap(ColumnName("x") -> expr("x")), Set.empty) }
-    }
-
     "reject indirectly-circular aliases" in {
       val aliasMap = OrderedMap(
         ColumnName("x") -> expr("y * 2"),


### PR DESCRIPTION
e.g., `select location(loc, this, that, theother) as loc`

Arbitrary circular references are still disallowed; only self-shadowing
is permitted.