### PR TITLE
SoQL Join

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisSerializer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisSerializer.scala
@@ -1,18 +1,16 @@
 package com.socrata.soql
 
 import scala.util.parsing.input.{NoPosition, Position}
-
 import java.io.{ByteArrayOutputStream, OutputStream}
 
 import com.google.protobuf.CodedOutputStream
 import gnu.trove.impl.Constants
 import gnu.trove.map.hash.TObjectIntHashMap
-
 import com.socrata.soql.parsing.SoQLPosition
 import com.socrata.soql.typed._
 import com.socrata.soql.functions.MonomorphicFunction
 import com.socrata.soql.collection.OrderedMap
-import com.socrata.soql.environment.ColumnName
+import com.socrata.soql.environment.{ColumnName, TableName}
 
 private trait SerializationDictionary[C,T] {
   def registerType(typ: T): Int
@@ -216,6 +214,16 @@ class AnalysisSerializer[C,T](serializeColumn: C => String, serializeType: T => 
       }
     }
 
+    private def writeJoins(joins: Option[List[Tuple2[TableName, Expr]]]) {
+      val size = joins.map(_.size).getOrElse(0)
+      out.writeUInt32NoTag(size)
+      joins.toList.flatten.foreach { case(tableName, expr) =>
+        out.writeStringNoTag(tableName.name)
+        maybeWrite(tableName.alias)(alias => out.writeStringNoTag(alias))
+        writeExpr(expr)
+      }
+    }
+
     private def maybeWrite[A](x: Option[A])(f: A => Unit): Unit = x match {
       case Some(a) =>
         out.writeBoolNoTag(true)
@@ -268,6 +276,7 @@ class AnalysisSerializer[C,T](serializeColumn: C => String, serializeType: T => 
       val SoQLAnalysis(isGrouped,
                        distinct,
                        selection,
+                       join,
                        where,
                        groupBy,
                        having,
@@ -278,6 +287,7 @@ class AnalysisSerializer[C,T](serializeColumn: C => String, serializeType: T => 
       writeGrouped(isGrouped)
       writeDistinct(analysis.distinct)
       writeSelection(selection)
+      writeJoins(join)
       writeWhere(where)
       writeGroupBy(groupBy)
       writeHaving(having)
@@ -302,7 +312,7 @@ class AnalysisSerializer[C,T](serializeColumn: C => String, serializeType: T => 
     out.flush()
 
     val codedOutputStream = CodedOutputStream.newInstance(outputStream)
-    codedOutputStream.writeInt32NoTag(2) // version number
+    codedOutputStream.writeInt32NoTag(3) // version number
     dictionary.save(codedOutputStream)
     codedOutputStream.flush()
     postDictionaryData.writeTo(outputStream)

--- a/soql-analyzer/src/main/scala/com/socrata/soql/aliases/AliasAnalysis.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/aliases/AliasAnalysis.scala
@@ -70,7 +70,8 @@ object AliasAnalysis extends AliasAnalysis {
    * @throws com.socrata.soql.exceptions.NoSuchColumn if a column not on the dataset is excepted.
    */
   def processStar(starSelection: StarSelection, columns: OrderedSet[ColumnName])(implicit ctx: UntypedDatasetContext): Seq[SelectedExpression] = {
-    val StarSelection(exceptions) = starSelection
+    // TODO: Actually handle qualifier
+    val StarSelection(qual, exceptions) = starSelection
     val exceptedColumnNames = new mutable.HashSet[ColumnName]
     for((column, position) <- exceptions) {
       if(exceptedColumnNames.contains(column)) throw RepeatedException(column, position)
@@ -151,13 +152,13 @@ object AliasAnalysis extends AliasAnalysis {
     def inUse(name: ColumnName) = existingAliases.contains(name) || ctx.columns.contains(name)
 
     val base = selection.toSyntheticIdentifierBase
-    val firstTry = ColumnName(base)
+    val firstTry = ColumnName(None, base) // TODO: columnname qualifier
 
     if(inUse(firstTry)) {
       val prefix = if(base.endsWith("_") || base.endsWith("-")) base
                    else base + "_"
       Iterator.from(1).
-        map { i => ColumnName(prefix + i) }.
+        map { i => ColumnName(None, prefix + i) }. // TODO: columnname qualifier
         dropWhile(inUse).
         next()
     } else {

--- a/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
@@ -1,15 +1,13 @@
 package com.socrata.soql
 
-import com.socrata.soql.exceptions.{NonGroupableGroupBy, NonBooleanHaving, NonBooleanWhere, UnorderableOrderBy}
-import org.scalacheck.{Gen, Arbitrary}
+import com.socrata.soql.exceptions.{NonBooleanHaving, NonBooleanWhere, NonGroupableGroupBy, UnorderableOrderBy}
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.PropertyChecks
 
 import scala.util.parsing.input.NoPosition
-
 import org.scalatest.FunSuite
 import org.scalatest.MustMatchers
-
-import com.socrata.soql.environment.{ColumnName, DatasetContext}
+import com.socrata.soql.environment.{ColumnName, DatasetContext, TableName}
 import com.socrata.soql.parsing.Parser
 import com.socrata.soql.typechecker.Typechecker
 import com.socrata.soql.types._
@@ -28,7 +26,9 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with PropertyChecks {
       ColumnName("address") -> TestLocation,
       ColumnName("balance") -> TestMoney,
       ColumnName("object") -> TestObject,
-      ColumnName("array") -> TestArray
+      ColumnName("array") -> TestArray,
+      ColumnName(Some("_aaaa-aaaa"), "last_name") -> TestText,
+      ColumnName(Some("_a1"), "first_name") -> TestText
     )
   }
 
@@ -264,4 +264,43 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with PropertyChecks {
     analysis.distinct must be (true)
   }
 
+  test("qualified column name") {
+    val analysis = analyzer.analyzeUnchainedQuery("select object.a, object.b as ob, visits, @aaaa-aaaa.last_name, @a1.first_name")
+    analysis.selection.toSeq must equal (Seq(
+      ColumnName("object_a") -> typedExpression("object.a"),
+      ColumnName("ob") -> typedExpression("object.b"),
+      ColumnName("visits") -> typedExpression("visits"),
+      ColumnName(Some("_aaaa-aaaa"), "last_name") -> typedExpression("@aaaa-aaaa.last_name"),
+      ColumnName(Some("_a1"), "first_name") -> typedExpression("@a1.first_name")
+    ))
+  }
+
+  test("join") {
+    val analysis = analyzer.analyzeUnchainedQuery("select visits, @aaaa-aaaa.last_name join @aaaa-aaaa on name_last = @aaaa-aaaa.last_name")
+    analysis.selection.toSeq must equal (Seq(
+      ColumnName("visits") -> typedExpression("visits"),
+      ColumnName(Some("_aaaa-aaaa"), "last_name") -> typedExpression("@aaaa-aaaa.last_name")
+    ))
+    analysis.join must equal (Some(List((TableName("_aaaa-aaaa", None), typedExpression("name_last = @aaaa-aaaa.last_name")))))
+  }
+
+  test("join with table alias") {
+    val analysis = analyzer.analyzeUnchainedQuery("select visits, @a1.first_name join @aaaa-aaaa as a1 on visits > 10")
+    analysis.selection.toSeq must equal (Seq(
+      ColumnName("visits") -> typedExpression("visits"),
+      ColumnName(Some("_a1"), "first_name") -> typedExpression("@a1.first_name")
+    ))
+    analysis.join must equal (Some(List((TableName("_aaaa-aaaa", Some("_a1")), typedExpression("visits > 10")))))
+  }
+
+  test("join to string") {
+    val soql = "select visits, @a1.first_name join @aaaa-aaaa as a1 on name_last = @a1.last_name"
+    val parsed = new Parser().unchainedSelectStatement(soql)
+
+    val expected = "SELECT `visits`, @a1.`first_name` JOIN @aaaa-aaaa AS a1 ON `name_last` = @a1.`last_name`"
+    parsed.toString must equal(expected)
+
+    val parsedAgain = new Parser().unchainedSelectStatement(expected)
+    parsedAgain.toString must equal(expected)
+  }
 }

--- a/soql-analyzer/src/test/scala/com/socrata/soql/types/TestFunctions.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/types/TestFunctions.scala
@@ -16,6 +16,7 @@ object TestFunctions {
   private val NumLike = Set[TestType](TestNumber, TestDouble, TestMoney)
   private val RealNumLike = Set[TestType](TestNumber, TestDouble)
   private val GeospatialLike = Set[TestType](TestPoint, TestMultiPoint, TestLine, TestMultiLine, TestPolygon, TestMultiPolygon)
+  private val Equatable = Ordered ++ GeospatialLike ++ Set[TestType](TestText, TestNumber)
   private val AllTypes = TestType.typesByName.values.toSet
 
   // helpers to guide type inference (specifically forces TestType to be inferred)
@@ -27,6 +28,7 @@ object TestFunctions {
   val TextToLocation = mf("text to location", SpecialFunctions.Cast(TestLocation.name), Seq(TestText), Seq.empty, TestLocation)
 
   val Concat = f("||", SpecialFunctions.Operator("||"), Map.empty, Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(TestText))
+  val Eq = f("=", SpecialFunctions.Operator("="), Map("a" -> Equatable), Seq(VariableType("a"), VariableType("a")), Seq.empty, FixedType(TestBoolean))
   val Gt = f(">", SpecialFunctions.Operator(">"), Map("a" -> Ordered), Seq(VariableType("a"), VariableType("a")), Seq.empty, FixedType(TestBoolean))
   val Lt = f("<", SpecialFunctions.Operator("<"), Map("a" -> Ordered), Seq(VariableType("a"), VariableType("a")), Seq.empty, FixedType(TestBoolean))
 

--- a/soql-environment/src/main/scala/com/socrata/soql/environment/AbstractName.scala
+++ b/soql-environment/src/main/scala/com/socrata/soql/environment/AbstractName.scala
@@ -2,8 +2,8 @@ package com.socrata.soql.environment
 
 import com.ibm.icu.text.{Normalizer2, Normalizer}
 
-abstract class AbstractName[Self <: AbstractName[Self]](val name: String) extends Ordered[Self] {
-  final lazy val caseFolded = AbstractName.caseFold(name)
+abstract class AbstractName[Self <: AbstractName[Self]](val qualifier: Option[String], val name: String) extends Ordered[Self] {
+  final lazy val caseFolded = AbstractName.caseFold(toString)
 
   protected def hashCodeSeed: Int
   override lazy val hashCode = caseFolded.hashCode ^ hashCodeSeed
@@ -16,7 +16,7 @@ abstract class AbstractName[Self <: AbstractName[Self]](val name: String) extend
   final def compare(that: Self) =
     this.caseFolded.compareTo(that.caseFolded)
 
-  override final def toString = name
+  override final def toString = qualifier.map(x => x + ".").getOrElse("") + name
 }
 
 object AbstractName {

--- a/soql-environment/src/main/scala/com/socrata/soql/environment/ColumnName.scala
+++ b/soql-environment/src/main/scala/com/socrata/soql/environment/ColumnName.scala
@@ -1,9 +1,14 @@
 package com.socrata.soql.environment
 
-final class ColumnName(name: String) extends AbstractName[ColumnName](name) {
+final class ColumnName(qualifier: Option[String], name: String) extends AbstractName[ColumnName](qualifier, name) {
   protected def hashCodeSeed = 0x342a3466
 }
 
-object ColumnName extends (String => ColumnName) {
-  def apply(columnName: String) = new ColumnName(columnName)
+object ColumnName
+  extends ((Option[String], String) => ColumnName)
+     with (String => ColumnName) {
+
+  def apply(qualifier: Option[String], columnName: String) = new ColumnName(qualifier, columnName)
+
+  def apply(columnName: String) = new ColumnName(None, columnName)
 }

--- a/soql-environment/src/main/scala/com/socrata/soql/environment/FunctionName.scala
+++ b/soql-environment/src/main/scala/com/socrata/soql/environment/FunctionName.scala
@@ -1,6 +1,6 @@
 package com.socrata.soql.environment
 
-final class FunctionName(name: String) extends AbstractName[FunctionName](name) {
+final class FunctionName(name: String) extends AbstractName[FunctionName](None, name) {
   protected def hashCodeSeed = 0xfb392dda
 }
 

--- a/soql-environment/src/main/scala/com/socrata/soql/environment/TableName.scala
+++ b/soql-environment/src/main/scala/com/socrata/soql/environment/TableName.scala
@@ -1,0 +1,26 @@
+package com.socrata.soql.environment
+
+case class TableName(name: String, alias: Option[String] = None) {
+
+  import TableName._
+
+  override def toString(): String = {
+    val unPrefixedName = name.substring(SodaFountainTableNamePrefixSubStringIndex)
+    "@" + unPrefixedName + alias.map(" AS " + _.substring(SodaFountainTableNamePrefixSubStringIndex)).getOrElse("")
+  }
+}
+
+object TableName {
+  val PrimaryTable = TableName("")
+
+  val Prefix = "@"
+
+  val Field = "."
+
+  // All resource name in soda fountain have an underscore prefix.
+  // that is not exposed to end users making SoQLs.
+  // To handle this mis-match, we automatically prepend the prefix when the parse tree is built.
+  // To remove this "feature", re-define this with an empty string "" or completely remove this variable.
+  val SodaFountainTableNamePrefix = "_"
+  val SodaFountainTableNamePrefixSubStringIndex = 1
+}

--- a/soql-environment/src/main/scala/com/socrata/soql/environment/TypeName.scala
+++ b/soql-environment/src/main/scala/com/socrata/soql/environment/TypeName.scala
@@ -1,6 +1,6 @@
 package com.socrata.soql.environment
 
-final class TypeName(name: String) extends AbstractName[TypeName](name) {
+final class TypeName(name: String) extends AbstractName[TypeName](None, name) {
   protected def hashCodeSeed = 0x32fa2313
 }
 

--- a/soql-standalone-parser/src/main/jflex/SoQLLexer.flex
+++ b/soql-standalone-parser/src/main/jflex/SoQLLexer.flex
@@ -65,6 +65,8 @@ SystemIdentifier = ":" "@"? [:jletterdigit:]+
 QuotedIdentifier = ("-" | [:jletter:]) ("-" | [:jletterdigit:])*
 QuotedSystemIdentifier = ":" "@"? ("-" | [:jletterdigit:])+
 
+TableIdentifier = "@" ("-" | [:jletterdigit:])+
+
 %state QUOTEDIDENTIFIER
 %state QUOTEDSYSTEMIDENTIFIER
 %state BADQUOTEDIDENTIFIER
@@ -81,9 +83,12 @@ QuotedSystemIdentifier = ":" "@"? ("-" | [:jletterdigit:])+
   "|>"  { return token(new QUERYPIPE()); }
 
   // Subscripting
-  "."   { return token(new DOT()); }
+  // "." share with qualifying
   "["   { return token(new LBRACKET()); }
   "]"   { return token(new RBRACKET()); }
+
+  // Qualifying
+  "."   { return token(new DOT()); }
 
   // Math
   "+"   { return token(new PLUS()); }
@@ -125,6 +130,9 @@ QuotedSystemIdentifier = ":" "@"? ("-" | [:jletterdigit:])+
   // Identifiers
   {SystemIdentifier} { return token(new SystemIdentifier(yytext(), false)); }
   "`" / ":" { stringStart = pos(); yybegin(QUOTEDSYSTEMIDENTIFIER); }
+
+  {TableIdentifier} { return token(new TableIdentifier(yytext())); }
+  "" { stringStart = pos(); yybegin(QUOTEDIDENTIFIER); }
 
   // Punctuation
   ","  { return token(new COMMA()); }

--- a/soql-standalone-parser/src/main/jflex/SoQLLexer.flex
+++ b/soql-standalone-parser/src/main/jflex/SoQLLexer.flex
@@ -132,7 +132,6 @@ TableIdentifier = "@" ("-" | [:jletterdigit:])+
   "`" / ":" { stringStart = pos(); yybegin(QUOTEDSYSTEMIDENTIFIER); }
 
   {TableIdentifier} { return token(new TableIdentifier(yytext())); }
-  "" { stringStart = pos(); yybegin(QUOTEDIDENTIFIER); }
 
   // Punctuation
   ","  { return token(new COMMA()); }

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Expression.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Expression.scala
@@ -2,8 +2,7 @@ package com.socrata.soql.ast
 
 import scala.util.parsing.input.Position
 import scala.runtime.ScalaRunTime
-
-import com.socrata.soql.environment.{TypeName, FunctionName, ColumnName}
+import com.socrata.soql.environment.{ColumnName, FunctionName, TableName, TypeName}
 
 sealed abstract class Expression extends Product {
   val position: Position
@@ -90,7 +89,15 @@ object SpecialFunctions {
 }
 
 case class ColumnOrAliasRef(column: ColumnName)(val position: Position) extends Expression {
-  protected def asString = "`" + column.toString + "`"
+
+  protected def asString = {
+    column.qualifier.map { q =>
+      TableName.Prefix +
+        q.substring(TableName.SodaFountainTableNamePrefixSubStringIndex) +
+        TableName.Field
+    }.getOrElse("") + "`" + column.name + "`"
+  }
+
   def allColumnRefs = Set(this)
 }
 

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/mapping/ColumnNameMapper.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/mapping/ColumnNameMapper.scala
@@ -22,6 +22,7 @@ class ColumnNameMapper(columnNameMap: Map[ColumnName, ColumnName]) {
       ss.updated(0, Select(
         distinct = s.distinct,
         selection = mapSelection(s.selection),
+        join = None,
         where = s.where map mapExpression,
         groupBy = s.groupBy.map(_ map mapExpression),
         having = s.having map mapExpression,
@@ -55,7 +56,7 @@ class ColumnNameMapper(columnNameMap: Map[ColumnName, ColumnName]) {
     (columnNameMap(s._1), NoPosition)
 
   def mapStarSelection(s: StarSelection): StarSelection =
-    StarSelection(s.exceptions map mapColumnNameAndPosition)
+    StarSelection(s.qualifier, s.exceptions map mapColumnNameAndPosition)
 
   def mapSelectedExpression(s: SelectedExpression): SelectedExpression = {
       // name isn't a column name, but a column alias so no mapping

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/tokens/Tokens.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/tokens/Tokens.scala
@@ -53,9 +53,12 @@ case class RIGHT() extends Token
 case class QUERYPIPE() extends Token
 
 // Subscripting
-case class DOT() extends FormattedToken(".")
+// DOT() share with qualifying
 case class LBRACKET() extends FormattedToken("[")
 case class RBRACKET() extends FormattedToken("]")
+
+// Qualifying
+case class DOT() extends FormattedToken(".")
 
 // Math
 case class PLUS() extends FormattedToken("+")


### PR DESCRIPTION
Qualified star selection.
Use @aaaa-aaaa.field_name syntax.
support join table alias

Automatically add prefix ‘_’ in the parse tree so that end user can address resource name with just the 4x4 and no prefixes despite that the real resource name is always prefixed with ‘_’.