### PR TITLE
SoQL Join (Qualifier is moved from ColumnName to ColumnRef)

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisDeserializer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisDeserializer.scala
@@ -110,7 +110,9 @@ class AnalysisDeserializer[C, T](columnDeserializer: String => C, typeDeserializ
       val pos = readPosition()
       in.readRawByte() match {
         case 1 =>
-          val qual = maybeRead(in.readString())
+          val qual =
+            if (version >= 3 || version == TestVersion) maybeRead(in.readString())
+            else None
           val name = dictionary.columns(in.readUInt32())
           val typ = dictionary.types(in.readUInt32())
           ColumnRef(qual, name, typ)(pos)

--- a/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisDeserializer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisDeserializer.scala
@@ -1,18 +1,18 @@
 package com.socrata.soql
 
-import scala.util.parsing.input.{NoPosition, Position}
-import scala.collection.immutable.VectorBuilder
-
 import java.io.InputStream
 
-import com.google.protobuf.CodedInputStream
-import gnu.trove.map.hash.TIntObjectHashMap
+import scala.collection.immutable.VectorBuilder
+import scala.collection.mutable.ListBuffer
+import scala.util.parsing.input.{NoPosition, Position}
 
-import com.socrata.soql.environment.ColumnName
-import com.socrata.soql.functions.{MonomorphicFunction, Function}
+import com.google.protobuf.CodedInputStream
+import com.socrata.soql.collection.OrderedMap
+import com.socrata.soql.environment.{ColumnName, TableName}
+import com.socrata.soql.functions.{Function, MonomorphicFunction}
 import com.socrata.soql.parsing.SoQLPosition
 import com.socrata.soql.typed._
-import com.socrata.soql.collection.OrderedMap
+import gnu.trove.map.hash.TIntObjectHashMap
 
 private case class SimplePosition(line: Int, column: Int, lineContents: String) extends Position
 
@@ -29,6 +29,8 @@ private trait DeserializationDictionary[C, T] {
 class AnalysisDeserializer[C, T](columnDeserializer: String => C, typeDeserializer: String => T, functionMap: String => Function[T]) extends (InputStream => Seq[SoQLAnalysis[C, T]]) {
   type Expr = CoreExpr[C, T]
   type Order = OrderBy[C, T]
+
+  private val TestVersion = 0 // This is odd and for smooth deploy transition.  0 is used by test.
 
   private class DeserializationDictionaryImpl(typesRegistry: TIntObjectHashMap[T],
                                       stringsRegistry: TIntObjectHashMap[String],
@@ -108,9 +110,10 @@ class AnalysisDeserializer[C, T](columnDeserializer: String => C, typeDeserializ
       val pos = readPosition()
       in.readRawByte() match {
         case 1 =>
+          val qual = maybeRead(in.readString())
           val name = dictionary.columns(in.readUInt32())
           val typ = dictionary.types(in.readUInt32())
-          ColumnRef(name, typ)(pos)
+          ColumnRef(qual, name, typ)(pos)
         case 2 =>
           val value = dictionary.strings(in.readUInt32())
           val typ = dictionary.types(in.readUInt32())
@@ -142,7 +145,7 @@ class AnalysisDeserializer[C, T](columnDeserializer: String => C, typeDeserializ
     def readDistinct(): Boolean = {
       version match {
         case 1 => false
-        case 0 | 2 => in.readBool() // This is odd and for smooth deploy transition.  0 is used by test.
+        case TestVersion | 2 => in.readBool()
         case _ => in.readBool()
       }
     }
@@ -160,6 +163,25 @@ class AnalysisDeserializer[C, T](columnDeserializer: String => C, typeDeserializ
         elems += name -> expr
       }
       OrderedMap(elems.result() : _*)
+    }
+
+    def readJoins(): Option[List[Tuple2[TableName, Expr]]] = {
+      if (version < 3 && version != TestVersion) {
+        None
+      } else {
+        val count = in.readUInt32()
+        if (count == 0) {
+          None
+        } else {
+          val elems = new ListBuffer[(TableName, Expr)]
+          for (_ <- 1 to count) {
+            val tableName = TableName(in.readString(), maybeRead(in.readString()))
+            val expr = readExpr()
+            elems += (tableName -> expr)
+          }
+          Some(elems.result())
+        }
+      }
     }
 
     def readWhere(): Option[Expr] =
@@ -205,6 +227,7 @@ class AnalysisDeserializer[C, T](columnDeserializer: String => C, typeDeserializ
       val isGrouped = readIsGrouped()
       val distinct = readDistinct()
       val selection = readSelection()
+      val join = readJoins()
       val where = readWhere()
       val groupBy = readGroupBy()
       val having = readHaving()
@@ -216,6 +239,7 @@ class AnalysisDeserializer[C, T](columnDeserializer: String => C, typeDeserializ
         isGrouped,
         distinct,
         selection,
+        join,
         where,
         groupBy,
         having,
@@ -238,7 +262,7 @@ class AnalysisDeserializer[C, T](columnDeserializer: String => C, typeDeserializ
         val dictionary = DeserializationDictionaryImpl.fromInput(cis)
         val deserializer = new Deserializer(cis, dictionary, 0)
         Seq(deserializer.readAnalysis())
-      case v if v == 1 || v == 2 =>
+      case v if v >= 1 && v <= 3 =>
         val dictionary = DeserializationDictionaryImpl.fromInput(cis)
         val deserializer = new Deserializer(cis, dictionary, v)
         deserializer.read()

--- a/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
@@ -11,6 +11,7 @@ import com.socrata.soql.parsing.Parser
 import com.socrata.soql.typechecker._
 import com.socrata.soql.environment.{ColumnName, DatasetContext, TableName, TypeName}
 import com.socrata.soql.collection.OrderedMap
+import com.socrata.soql.typed.Qualifier
 
 class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type], functionInfo: FunctionInfo[Type]) {
   type Analysis = SoQLAnalysis[ColumnName, Type]
@@ -356,7 +357,7 @@ case class SoQLAnalysis[ColumnId, Type](isGrouped: Boolean,
                                         limit: Option[BigInt],
                                         offset: Option[BigInt],
                                         search: Option[String]) {
-  def mapColumnIds[NewColumnId](f: ColumnId => NewColumnId): SoQLAnalysis[NewColumnId, Type] =
+  def mapColumnIds[NewColumnId](f: (ColumnId, Qualifier) => NewColumnId): SoQLAnalysis[NewColumnId, Type] =
     copy(
       selection = selection.mapValues(_.mapColumnIds(f)),
       join = join.map { joins => joins.map { case((table, expr)) =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
@@ -1,31 +1,34 @@
 package com.socrata.soql
 
-import com.socrata.soql.exceptions.{NonGroupableGroupBy, NonBooleanWhere, NonBooleanHaving, UnorderableOrderBy}
+import com.socrata.soql.exceptions.{NonBooleanHaving, NonBooleanWhere, NonGroupableGroupBy, UnorderableOrderBy}
 import com.socrata.soql.functions.MonomorphicFunction
 
-import scala.util.parsing.input.{Position, NoPosition}
-
+import scala.util.parsing.input.{NoPosition, Position}
 import com.socrata.soql.aliases.AliasAnalysis
 import com.socrata.soql.aggregates.AggregateChecker
 import com.socrata.soql.ast._
 import com.socrata.soql.parsing.Parser
 import com.socrata.soql.typechecker._
-import com.socrata.soql.environment.{TypeName, ColumnName, DatasetContext}
+import com.socrata.soql.environment.{ColumnName, DatasetContext, TableName, TypeName}
 import com.socrata.soql.collection.OrderedMap
 
 class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type], functionInfo: FunctionInfo[Type]) {
   type Analysis = SoQLAnalysis[ColumnName, Type]
   type Expr = typed.CoreExpr[ColumnName, Type]
+  type Qualifier = String
+  type AnalysisContext = Map[Qualifier, DatasetContext[Type]]
 
   val log = org.slf4j.LoggerFactory.getLogger(classOf[SoQLAnalyzer[_]])
+
   def ns2ms(ns: Long) = ns / 1000000
+
   val aggregateChecker = new AggregateChecker[Type]
 
   /** Turn a SoQL SELECT statement into a sequence of typed `Analysis` objects.
     * @param query The SELECT to parse and analyze
     * @throws com.socrata.soql.exceptions.SoQLException if the query is syntactically or semantically erroneous
     * @return The analysis of the query */
-  def analyzeFullQuery(query: String)(implicit ctx: DatasetContext[Type]): Seq[Analysis] = {
+  def analyzeFullQuery(query: String)(implicit ctx: AnalysisContext): Seq[Analysis] = {
     log.debug("Analyzing full query {}", query)
     val start = System.nanoTime()
     val parsed = new Parser().selectStatement(query)
@@ -34,28 +37,42 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type], functionInfo: FunctionInfo[Ty
     analyze(parsed)
   }
 
-  def analyze(selects: Seq[Select])(implicit ctx: DatasetContext[Type]): Seq[Analysis] = {
-    selects.scanLeft(baseAnalysis)(analyzeInOuterSelectionContext).drop(1)
+  def analyze(selects: Seq[Select])(implicit ctx: AnalysisContext): Seq[Analysis] = {
+    selects.headOption match {
+      case Some(firstSelect) =>
+        val firstAnalysis = analyzeWithSelection(firstSelect)(ctx)
+        selects.tail.scanLeft(firstAnalysis)(analyzeInOuterSelectionContext)
+      case None =>
+        Seq.empty
+    }
   }
 
   /** Turn a simple SoQL SELECT statement into an `Analysis` object.
     * @param query The SELECT to parse and analyze
     * @throws com.socrata.soql.exceptions.SoQLException if the query is syntactically or semantically erroneous
     * @return The analysis of the query */
-  def analyzeUnchainedQuery(query: String)(implicit ctx: DatasetContext[Type]): Analysis = {
+  def analyzeUnchainedQuery(query: String)(implicit ctx: AnalysisContext): Analysis = {
     log.debug("Analyzing full unchained query {}", query)
     val start = System.nanoTime()
     val parsed = new Parser().unchainedSelectStatement(query)
     val end = System.nanoTime()
     log.trace("Parsing took {}ms", ns2ms(end - start))
 
-    analyzeInOuterSelectionContext(baseAnalysis, parsed)
+    analyzeWithSelection(parsed)(ctx)
   }
 
-  private def baseAnalysis(implicit ctx: DatasetContext[Type]) =
+  private def baseAnalysis(implicit ctx: AnalysisContext) = {
+
+    val selections = ctx.map { case (qual, dsCtx) =>
+      val q = if (qual == TableName.PrimaryTable.qualifier) None else Some(qual)
+      dsCtx.schema.transform(typed.ColumnRef(q, _, _)(NoPosition))
+    }
+    // TODO: Enhance resolution of column name conflict from different tables in chained SoQLs
+    val mergedSelection = selections.reduce(_ ++ _)
     SoQLAnalysis(isGrouped = false,
                  distinct = false,
-                 selection = ctx.schema.transform(typed.ColumnRef(_, _)(NoPosition)),
+                 selection = mergedSelection,
+                 join = None,
                  where = None,
                  groupBy = None,
                  having = None,
@@ -63,6 +80,7 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type], functionInfo: FunctionInfo[Ty
                  limit = None,
                  offset = None,
                  search = None)
+  }
 
   /** Turn framents of a SoQL SELECT statement into a typed `Analysis` object.  If no `selection` is provided,
     * one is generated based on whether the rest of the parameters indicate an aggregate query or not.  If it
@@ -70,19 +88,21 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type], functionInfo: FunctionInfo[Ty
     * If it is an aggregate query, a selection list made up of the expressions from `groupBy` (if provided) together
     * with "`count(*)`" is generated.
     *
-    * @param distinct Reduce identical tuples into one.
-    * @param selection A selection list.
-    * @param where An expression to be used as the query's WHERE clause.
-    * @param groupBy A comma-separated list of expressions to be used as the query's GROUP BY cluase.
-    * @param having An expression to be used as the query's HAVING clause.
-    * @param orderBy A comma-separated list of expressions and sort-order specifiers to be uesd as the query's ORDER BY clause.
-    * @param limit A non-negative integer to be used as the query's LIMIT parameter
-    * @param offset A non-negative integer to be used as the query's OFFSET parameter
+    * @param distinct   Reduce identical tuples into one.
+    * @param selection  A selection list.
+    * @param join       A join list.
+    * @param where      An expression to be used as the query's WHERE clause.
+    * @param groupBy    A comma-separated list of expressions to be used as the query's GROUP BY cluase.
+    * @param having     An expression to be used as the query's HAVING clause.
+    * @param orderBy    A comma-separated list of expressions and sort-order specifiers to be uesd as the query's ORDER BY clause.
+    * @param limit      A non-negative integer to be used as the query's LIMIT parameter
+    * @param offset     A non-negative integer to be used as the query's OFFSET parameter
     * @param sourceFrom The analysis-chain of the query this query is based upon, if applicable.
     * @throws com.socrata.soql.exceptions.SoQLException if the query is syntactically or semantically erroneous.
     * @return The analysis of the query.  Note this should be appended to `sourceFrom` to form a full query-chain. */
   def analyzeSplitQuery(distinct: Boolean,
                         selection: Option[String],
+                        join: Option[String],
                         where: Option[String],
                         groupBy: Option[String],
                         having: Option[String],
@@ -90,8 +110,7 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type], functionInfo: FunctionInfo[Ty
                         limit: Option[String],
                         offset: Option[String],
                         search: Option[String],
-                        sourceFrom: Seq[Analysis] = Nil)(implicit ctx: DatasetContext[Type]): Analysis =
-  {
+                        sourceFrom: Seq[Analysis] = Nil)(implicit ctx: AnalysisContext): Analysis = {
     log.debug("analyzing split query")
 
     val p = new Parser
@@ -100,15 +119,18 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type], functionInfo: FunctionInfo[Ty
       if(sourceFrom.isEmpty) baseAnalysis
       else sourceFrom.last
 
-    def dispatch(distinct: Boolean, selection: Option[Selection], where: Option[Expression], groupBy: Option[Seq[Expression]], having: Option[Expression], orderBy: Option[Seq[OrderBy]], limit: Option[BigInt], offset: Option[BigInt], search: Option[String]) =
+    def dispatch(distinct: Boolean, selection: Option[Selection],
+                 joins: Option[List[Tuple2[TableName, Expression]]],
+                 where: Option[Expression], groupBy: Option[Seq[Expression]], having: Option[Expression], orderBy: Option[Seq[OrderBy]], limit: Option[BigInt], offset: Option[BigInt], search: Option[String]) =
       selection match {
-        case None => analyzeNoSelectionInOuterSelectionContext(lastQuery, distinct, where, groupBy, having, orderBy, limit, offset, search)
-        case Some(s) => analyzeInOuterSelectionContext(lastQuery, Select(distinct, s, where, groupBy, having, orderBy, limit, offset, search))
+        case None => analyzeNoSelectionInOuterSelectionContext(lastQuery, distinct, None, where, groupBy, having, orderBy, limit, offset, search)
+        case Some(s) => analyzeInOuterSelectionContext(lastQuery, Select(distinct, s, joins, where, groupBy, having, orderBy, limit, offset, search))
       }
 
     dispatch(
       distinct,
       selection.map(p.selection),
+      join.map(p.joins),
       where.map(p.expression),
       groupBy.map(p.groupBys),
       having.map(p.expression),
@@ -121,27 +143,27 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type], functionInfo: FunctionInfo[Ty
 
   def analyzeNoSelectionInOuterSelectionContext(lastQuery: Analysis,
                                                 distinct: Boolean,
+                                                joins: Option[List[Tuple2[TableName, Expression]]],
                                                 where: Option[Expression],
                                                 groupBy: Option[Seq[Expression]],
                                                 having: Option[Expression],
                                                 orderBy: Option[Seq[OrderBy]],
                                                 limit: Option[BigInt],
                                                 offset: Option[BigInt],
-                                                search: Option[String]): Analysis =
-  {
+                                                search: Option[String]): Analysis = {
     implicit val fakeCtx = contextFromAnalysis(lastQuery)
-    analyzeNoSelection(distinct, where, groupBy, having, orderBy, limit, offset, search)
+    analyzeNoSelection(distinct, joins, where, groupBy, having, orderBy, limit, offset, search)
   }
 
   def analyzeNoSelection(distinct: Boolean,
+                         join: Option[List[Tuple2[TableName, Expression]]],
                          where: Option[Expression],
                          groupBy: Option[Seq[Expression]],
                          having: Option[Expression],
                          orderBy: Option[Seq[OrderBy]],
                          limit: Option[BigInt],
                          offset: Option[BigInt],
-                         search: Option[String])(implicit ctx: DatasetContext[Type]): Analysis =
-  {
+                         search: Option[String])(implicit ctx: AnalysisContext): Analysis = {
     log.debug("No selection; doing typechecking of the other parts then deciding what to make the selection")
 
     // ok, so the only tricky thing here is the selection itself.  Since it isn't provided, there are two cases:
@@ -192,22 +214,27 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type], functionInfo: FunctionInfo[Ty
       log.debug("It is not grouped; selecting *")
 
       val beforeAliasAnalysis = System.nanoTime()
-      val names = AliasAnalysis(Selection(None, Some(StarSelection(Nil)), Nil)).expressions.keys.toSeq
+      val names = AliasAnalysis(Selection(None, Some(StarSelection(None, Nil)), Nil)).expressions.keys.toSeq
       val afterAliasAnalyis = System.nanoTime()
 
       log.trace("alias analysis took {}ms", ns2ms(afterAliasAnalyis - beforeAliasAnalysis))
 
       val typedSelectedExpressions = names.map { column =>
-        typed.ColumnRef(column, ctx.schema(column))(NoPosition)
+        typed.ColumnRef(None, column, ctx(TableName.PrimaryTable.qualifier).schema(column))(NoPosition)
       }
 
       (names, typedSelectedExpressions)
     }
 
+    val checkedJoin = join.map {
+      _.map { j => (j._1, typecheck(j._2)) }
+    }
+
     finishAnalysis(
       isGrouped,
       distinct,
-      OrderedMap(names.zip(typedSelectedExpressions) : _*),
+      OrderedMap(names.zip(typedSelectedExpressions): _*),
+      checkedJoin,
       checkedWhere,
       checkedGroupBy,
       checkedHaving,
@@ -222,12 +249,14 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type], functionInfo: FunctionInfo[Ty
     analyzeWithSelection(query)
   }
 
-  def contextFromAnalysis(a: Analysis): DatasetContext[Type] =
-    new DatasetContext[Type] {
+  def contextFromAnalysis(a: Analysis): AnalysisContext = {
+    val ctx = new DatasetContext[Type] {
       override val schema: OrderedMap[ColumnName, Type] = a.selection.mapValues(_.typ)
     }
+    Map(TableName.PrimaryTable.qualifier -> ctx)
+  }
 
-  def analyzeWithSelection(query: Select)(implicit ctx: DatasetContext[Type]): Analysis = {
+  def analyzeWithSelection(query: Select)(implicit ctx: AnalysisContext): Analysis = {
     log.debug("There is a selection; typechecking all parts")
 
     val typechecker = new Typechecker(typeInfo, functionInfo)
@@ -271,14 +300,19 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type], functionInfo: FunctionInfo[Ty
       log.trace("checking for aggregation took {}ms", ns2ms(t7 - t6))
     }
 
+    val checkedJoin = query.join.map { js => js.map { j: Tuple2[TableName, Expression] =>
+      (j._1, typecheck(j._2))
+    }}
+
     finishAnalysis(isGrouped, query.distinct,
-                   outputs, checkedWhere, checkedGroupBy, checkedHaving, checkedOrderBy,
+                   outputs, checkedJoin, checkedWhere, checkedGroupBy, checkedHaving, checkedOrderBy,
                    query.limit, query.offset, query.search)
   }
 
   def finishAnalysis(isGrouped: Boolean,
                      distinct: Boolean,
                      output: OrderedMap[ColumnName, Expr],
+                     join: Option[List[Tuple2[TableName, Expr]]],
                      where: Option[Expr],
                      groupBy: Option[Seq[Expr]],
                      having: Option[Expr],
@@ -300,6 +334,7 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type], functionInfo: FunctionInfo[Ty
       isGrouped,
       distinct,
       output,
+      join,
       where,
       groupBy,
       having,
@@ -313,6 +348,7 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type], functionInfo: FunctionInfo[Ty
 case class SoQLAnalysis[ColumnId, Type](isGrouped: Boolean,
                                         distinct: Boolean,
                                         selection: OrderedMap[ColumnName, typed.CoreExpr[ColumnId, Type]],
+                                        join: Option[List[Tuple2[TableName, typed.CoreExpr[ColumnId, Type]]]],
                                         where: Option[typed.CoreExpr[ColumnId, Type]],
                                         groupBy: Option[Seq[typed.CoreExpr[ColumnId, Type]]],
                                         having: Option[typed.CoreExpr[ColumnId, Type]],
@@ -323,6 +359,9 @@ case class SoQLAnalysis[ColumnId, Type](isGrouped: Boolean,
   def mapColumnIds[NewColumnId](f: ColumnId => NewColumnId): SoQLAnalysis[NewColumnId, Type] =
     copy(
       selection = selection.mapValues(_.mapColumnIds(f)),
+      join = join.map { joins => joins.map { case((table, expr)) =>
+        (table, expr.mapColumnIds(f))
+      }},
       where = where.map(_.mapColumnIds(f)),
       groupBy = groupBy.map(_.map(_.mapColumnIds(f))),
       having = having.map(_.mapColumnIds(f)),
@@ -352,13 +391,14 @@ private class Merger[T](andFunction: MonomorphicFunction[T]) {
   // dataset".  Unfortunately this means "select :*,*" isn't a left-identity of merge
   // for a query that contains a search.
   private def tryMerge(a: Analysis, b: Analysis): Option[Analysis] = (a, b) match {
-    case (SoQLAnalysis(aIsGroup, false, aSelect, aWhere, aGroup, aHaving, aOrder, aLim, aOff, aSearch),
-          SoQLAnalysis(false,    false, bSelect, None,   None,   None,    None,   bLim, bOff, None)) =>
+    case (SoQLAnalysis(aIsGroup, false, aSelect, None, aWhere, aGroup, aHaving, aOrder, aLim, aOff, aSearch),
+          SoQLAnalysis(false,    false, bSelect, None, None,   None,   None,    None,   bLim, bOff, None)) =>
       // we can merge a change of only selection and limit + offset onto anything
       val (newLim, newOff) = Merger.combineLimits(aLim, aOff, bLim, bOff)
       Some(SoQLAnalysis(isGrouped = aIsGroup,
                         distinct = false,
                         selection = mergeSelection(aSelect, bSelect),
+                        join = None,
                         where = aWhere,
                         groupBy = aGroup,
                         having = aHaving,
@@ -366,12 +406,13 @@ private class Merger[T](andFunction: MonomorphicFunction[T]) {
                         limit = newLim,
                         offset = newOff,
                         search = aSearch))
-    case (SoQLAnalysis(false, false, aSelect, aWhere, None, None, aOrder, None, None, aSearch),
-          SoQLAnalysis(false, false, bSelect, bWhere, None, None, bOrder, bLim, bOff, None)) =>
+    case (SoQLAnalysis(false, false, aSelect, None, aWhere, None, None, aOrder, None, None, aSearch),
+          SoQLAnalysis(false, false, bSelect, None, bWhere, None, None, bOrder, bLim, bOff, None)) =>
       // Can merge a change of filter or order only if no window was specified on the left
       Some(SoQLAnalysis(isGrouped = false,
                         distinct = false,
                         selection = mergeSelection(aSelect, bSelect),
+                        join = None,
                         where = mergeWhereLike(aSelect, aWhere, bWhere),
                         groupBy = None,
                         having = None,
@@ -379,12 +420,13 @@ private class Merger[T](andFunction: MonomorphicFunction[T]) {
                         limit = bLim,
                         offset = bOff,
                         search = aSearch))
-    case (SoQLAnalysis(false, false, aSelect, aWhere, None,     None,    _,      None, None, aSearch),
-          SoQLAnalysis(true, false, bSelect, bWhere, bGroupBy, bHaving, bOrder, bLim, bOff, None)) =>
+    case (SoQLAnalysis(false, false, aSelect, None, aWhere, None,     None,    _,      None, None, aSearch),
+          SoQLAnalysis(true, false, bSelect, None, bWhere, bGroupBy, bHaving, bOrder, bLim, bOff, None)) =>
       // an aggregate on a non-aggregate
       Some(SoQLAnalysis(isGrouped = true,
                         distinct = false,
                         selection = mergeSelection(aSelect, bSelect),
+                        join = None,
                         where = mergeWhereLike(aSelect, aWhere, bWhere),
                         groupBy = mergeGroupBy(aSelect, bGroupBy),
                         having = mergeWhereLike(aSelect, None, bHaving),
@@ -392,12 +434,13 @@ private class Merger[T](andFunction: MonomorphicFunction[T]) {
                         limit = bLim,
                         offset = bOff,
                         search = aSearch))
-    case (SoQLAnalysis(true,  false, aSelect, aWhere, aGroupBy, aHaving, aOrder, None, None, aSearch),
-          SoQLAnalysis(false, false, bSelect, bWhere, None,     None,    bOrder, bLim, bOff, None)) =>
+    case (SoQLAnalysis(true,  false, aSelect, None, aWhere, aGroupBy, aHaving, aOrder, None, None, aSearch),
+          SoQLAnalysis(false, false, bSelect, None, bWhere, None,     None,    bOrder, bLim, bOff, None)) =>
       // a non-aggregate on an aggregate -- merge the WHERE of the second with the HAVING of the first
       Some(SoQLAnalysis(isGrouped = true,
                         distinct = false,
                         selection = mergeSelection(aSelect, bSelect),
+                        join = None,
                         where = aWhere,
                         groupBy = aGroupBy,
                         having = mergeWhereLike(aSelect, aHaving, bWhere),
@@ -410,13 +453,13 @@ private class Merger[T](andFunction: MonomorphicFunction[T]) {
   }
 
   private def mergeSelection(a: OrderedMap[ColumnName, Expr],
-                                b: OrderedMap[ColumnName, Expr]): OrderedMap[ColumnName, Expr] =
+                             b: OrderedMap[ColumnName, Expr]): OrderedMap[ColumnName, Expr] =
     // ok.  We don't need anything from A, but columnRefs in b's expr that refer to a's values need to get substituted
     b.mapValues(replaceRefs(a, _))
 
   private def mergeOrderBy(aliases: OrderedMap[ColumnName, Expr],
-                              obA: Option[Seq[typed.OrderBy[ColumnName, T]]],
-                              obB: Option[Seq[typed.OrderBy[ColumnName, T]]]): Option[Seq[typed.OrderBy[ColumnName, T]]] =
+                           obA: Option[Seq[typed.OrderBy[ColumnName, T]]],
+                           obB: Option[Seq[typed.OrderBy[ColumnName, T]]]): Option[Seq[typed.OrderBy[ColumnName, T]]] =
     (obA, obB) match {
       case (None, None) => None
       case (Some(a), None) => Some(a)
@@ -435,13 +478,13 @@ private class Merger[T](andFunction: MonomorphicFunction[T]) {
     }
 
   private def mergeGroupBy(aliases: OrderedMap[ColumnName, Expr],
-                              gb: Option[Seq[Expr]]): Option[Seq[Expr]] =
+                           gb: Option[Seq[Expr]]): Option[Seq[Expr]] =
     gb.map(_.map(replaceRefs(aliases, _)))
 
   private def replaceRefs(a: OrderedMap[ColumnName, Expr],
                              b: Expr): Expr =
     b match {
-      case cr@typed.ColumnRef(c, t) =>
+      case cr@typed.ColumnRef(qual, c, t) =>
         a.getOrElse(c, cr)
       case tl: typed.TypedLiteral[T] =>
         tl

--- a/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
@@ -123,7 +123,7 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type], functionInfo: FunctionInfo[Ty
                  joins: Option[List[Tuple2[TableName, Expression]]],
                  where: Option[Expression], groupBy: Option[Seq[Expression]], having: Option[Expression], orderBy: Option[Seq[OrderBy]], limit: Option[BigInt], offset: Option[BigInt], search: Option[String]) =
       selection match {
-        case None => analyzeNoSelectionInOuterSelectionContext(lastQuery, distinct, None, where, groupBy, having, orderBy, limit, offset, search)
+        case None => analyzeNoSelectionInOuterSelectionContext(lastQuery, distinct, joins, where, groupBy, having, orderBy, limit, offset, search)
         case Some(s) => analyzeInOuterSelectionContext(lastQuery, Select(distinct, s, joins, where, groupBy, having, orderBy, limit, offset, search))
       }
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/typechecker/SubscriptConverter.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/typechecker/SubscriptConverter.scala
@@ -1,7 +1,7 @@
 package com.socrata.soql.typechecker
 
 import com.socrata.soql.ast._
-import com.socrata.soql.environment.{FunctionName, DatasetContext}
+import com.socrata.soql.environment.{DatasetContext, FunctionName, TableName}
 
 /**
  * This class rewrites subscript functions to functions that access subtype columns before type check
@@ -9,18 +9,17 @@ import com.socrata.soql.environment.{FunctionName, DatasetContext}
  * The names of these functions must be type_subColumnType by convention.
  */
 class SubscriptConverter[Type](typeInfo: TypeInfo[Type], functionInfo: FunctionInfo[Type])
-                              (implicit ctx: DatasetContext[Type])
+                              (implicit ctx: String => DatasetContext[Type])
   extends (Expression => Expression) { self =>
-
-  val columns = ctx.schema
 
   def apply(e: Expression) = convert(e)
 
   private def convert(e: Expression): Expression = e match {
-    case c@ColumnOrAliasRef(_) => c
+    case c@ColumnOrAliasRef(_, _) => c
     case l: Literal => l
     case fc@FunctionCall(SpecialFunctions.Subscript,
-                         params@Seq(ColumnOrAliasRef(columnName), StringLiteral(prop))) =>
+                         params@Seq(ColumnOrAliasRef(qual, columnName), StringLiteral(prop))) =>
+      val columns = ctx(qual.getOrElse(TableName.PrimaryTable.qualifier)).schema
       columns.get(columnName) match {
         case Some(t) =>
           val typeName = typeInfo.typeNameFor(t)

--- a/soql-analyzer/src/main/scala/com/socrata/soql/typed/CoreExpr.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/typed/CoreExpr.scala
@@ -24,7 +24,7 @@ object CoreExpr {
   val pretty = true
 }
 
-case class ColumnRef[ColumnId, Type](column: ColumnId, typ: Type)(val position: Position) extends CoreExpr[ColumnId, Type] {
+case class ColumnRef[ColumnId, Type](qualifier: Option[String], column: ColumnId, typ: Type)(val position: Position) extends CoreExpr[ColumnId, Type] {
   protected def asString = column.toString
   def mapColumnIds[NewColumnId](f: ColumnId => NewColumnId) = copy(column = f(column))(position)
   val size = 0

--- a/soql-analyzer/src/main/scala/com/socrata/soql/typed/OrderBy.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/typed/OrderBy.scala
@@ -1,5 +1,5 @@
 package com.socrata.soql.typed
 
 case class OrderBy[ColumnId, Type](expression: CoreExpr[ColumnId, Type], ascending: Boolean, nullLast: Boolean) {
-  def mapColumnIds[NewColumnId](f: ColumnId => NewColumnId) = copy(expression = expression.mapColumnIds(f))
+  def mapColumnIds[NewColumnId](f: (ColumnId, Qualifier) => NewColumnId) = copy(expression = expression.mapColumnIds(f))
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/typed/package.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/typed/package.scala
@@ -1,0 +1,5 @@
+package com.socrata.soql
+
+package object typed {
+  type Qualifier = Option[String]
+}

--- a/soql-analyzer/src/test/scala/com/socrata/soql/AnalysisSerializationTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/AnalysisSerializationTest.scala
@@ -1,9 +1,10 @@
 package com.socrata.soql
 
 import org.scalatest.FunSuite
-import com.socrata.soql.environment.{TypeName, ColumnName, DatasetContext}
+import com.socrata.soql.environment.{ColumnName, DatasetContext, TableName, TypeName}
 import com.socrata.soql.types._
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+
 import org.scalatest.MustMatchers
 
 class AnalysisSerializationTest extends FunSuite with MustMatchers {
@@ -22,6 +23,8 @@ class AnalysisSerializationTest extends FunSuite with MustMatchers {
       ColumnName("array") -> TestArray
     )
   }
+
+  implicit val datasetCtxMap = Map(TableName.PrimaryTable.qualifier -> datasetCtx)
 
   val analyzer = new SoQLAnalyzer(TestTypeInfo, TestFunctionInfo)
 

--- a/soql-analyzer/src/test/scala/com/socrata/soql/parsing/ParserTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/parsing/ParserTest.scala
@@ -22,7 +22,7 @@ class ParserTest extends WordSpec with MustMatchers {
       case e: BadParse => e.message must equal (expectedMsg)
     }
 
-  def ident(name: String) = ColumnOrAliasRef(ColumnName(name))(NoPosition)
+  def ident(name: String) = ColumnOrAliasRef(None, ColumnName(name))(NoPosition)
   def functionCall(name: FunctionName, args: Seq[Expression]) = FunctionCall(name, args)(NoPosition, NoPosition)
   def stringLiteral(s: String) = StringLiteral(s)(NoPosition)
   def numberLiteral(num: BigDecimal) = NumberLiteral(num)(NoPosition)

--- a/soql-analyzer/src/test/scala/com/socrata/soql/types/TestFunctions.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/types/TestFunctions.scala
@@ -16,6 +16,7 @@ object TestFunctions {
   private val NumLike = Set[TestType](TestNumber, TestDouble, TestMoney)
   private val RealNumLike = Set[TestType](TestNumber, TestDouble)
   private val GeospatialLike = Set[TestType](TestPoint, TestMultiPoint, TestLine, TestMultiLine, TestPolygon, TestMultiPolygon)
+  private val Equatable = Ordered ++ GeospatialLike ++ Set[TestType](TestText, TestNumber)
   private val AllTypes = TestType.typesByName.values.toSet
 
   // helpers to guide type inference (specifically forces TestType to be inferred)
@@ -27,6 +28,7 @@ object TestFunctions {
   val TextToLocation = mf("text to location", SpecialFunctions.Cast(TestLocation.name), Seq(TestText), Seq.empty, TestLocation)
 
   val Concat = f("||", SpecialFunctions.Operator("||"), Map.empty, Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(TestText))
+  val Eq = f("=", SpecialFunctions.Operator("="), Map("a" -> Equatable), Seq(VariableType("a"), VariableType("a")), Seq.empty, FixedType(TestBoolean))
   val Gt = f(">", SpecialFunctions.Operator(">"), Map("a" -> Ordered), Seq(VariableType("a"), VariableType("a")), Seq.empty, FixedType(TestBoolean))
   val Lt = f("<", SpecialFunctions.Operator("<"), Map("a" -> Ordered), Seq(VariableType("a"), VariableType("a")), Seq.empty, FixedType(TestBoolean))
 

--- a/soql-environment/src/main/scala/com/socrata/soql/environment/TableName.scala
+++ b/soql-environment/src/main/scala/com/socrata/soql/environment/TableName.scala
@@ -1,0 +1,28 @@
+package com.socrata.soql.environment
+
+case class TableName(name: String, alias: Option[String] = None) {
+
+  import TableName._
+
+  override def toString(): String = {
+    val unPrefixedName = name.substring(SodaFountainTableNamePrefixSubStringIndex)
+    "@" + unPrefixedName + alias.map(" AS " + _.substring(SodaFountainTableNamePrefixSubStringIndex)).getOrElse("")
+  }
+
+  def qualifier: String = alias.getOrElse(name)
+}
+
+object TableName {
+  val PrimaryTable = TableName("_")
+
+  val Prefix = "@"
+
+  val Field = "."
+
+  // All resource name in soda fountain have an underscore prefix.
+  // that is not exposed to end users making SoQLs.
+  // To handle this mis-match, we automatically prepend the prefix when the parse tree is built.
+  // To remove this "feature", re-define this with an empty string "" or completely remove this variable.
+  val SodaFountainTableNamePrefix = "_"
+  val SodaFountainTableNamePrefixSubStringIndex = 1
+}

--- a/soql-standalone-parser/src/main/jflex/SoQLLexer.flex
+++ b/soql-standalone-parser/src/main/jflex/SoQLLexer.flex
@@ -65,6 +65,8 @@ SystemIdentifier = ":" "@"? [:jletterdigit:]+
 QuotedIdentifier = ("-" | [:jletter:]) ("-" | [:jletterdigit:])*
 QuotedSystemIdentifier = ":" "@"? ("-" | [:jletterdigit:])+
 
+TableIdentifier = "@" ("-" | [:jletterdigit:])+
+
 %state QUOTEDIDENTIFIER
 %state QUOTEDSYSTEMIDENTIFIER
 %state BADQUOTEDIDENTIFIER
@@ -81,9 +83,12 @@ QuotedSystemIdentifier = ":" "@"? ("-" | [:jletterdigit:])+
   "|>"  { return token(new QUERYPIPE()); }
 
   // Subscripting
-  "."   { return token(new DOT()); }
+  // "." share with qualifying
   "["   { return token(new LBRACKET()); }
   "]"   { return token(new RBRACKET()); }
+
+  // Qualifying
+  "."   { return token(new DOT()); }
 
   // Math
   "+"   { return token(new PLUS()); }
@@ -125,6 +130,8 @@ QuotedSystemIdentifier = ":" "@"? ("-" | [:jletterdigit:])+
   // Identifiers
   {SystemIdentifier} { return token(new SystemIdentifier(yytext(), false)); }
   "`" / ":" { stringStart = pos(); yybegin(QUOTEDSYSTEMIDENTIFIER); }
+
+  {TableIdentifier} { return token(new TableIdentifier(yytext())); }
 
   // Punctuation
   ","  { return token(new COMMA()); }

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
@@ -1,14 +1,21 @@
 package com.socrata.soql.ast
 
-import scala.util.parsing.input.{Position, NoPosition}
-import com.socrata.soql.environment.ColumnName
+import scala.util.parsing.input.{NoPosition, Position}
+import com.socrata.soql.environment.{ColumnName, TableName}
 
-case class Select(distinct: Boolean, selection: Selection, where: Option[Expression], groupBy: Option[Seq[Expression]], having: Option[Expression], orderBy: Option[Seq[OrderBy]], limit: Option[BigInt], offset: Option[BigInt], search: Option[String]) {
+case class Select(distinct: Boolean, selection: Selection, join: Option[List[(TableName, Expression)]], where: Option[Expression], groupBy: Option[Seq[Expression]], having: Option[Expression], orderBy: Option[Seq[OrderBy]], limit: Option[BigInt], offset: Option[BigInt], search: Option[String]) {
   override def toString = {
     if(AST.pretty) {
       val sb = new StringBuilder("SELECT ")
       if (distinct) sb.append("DISTINCT ")
       sb.append(selection)
+      join.toList.flatten.foreach { j =>
+        val (tableName, joinExpr) = j
+        sb.append(" JOIN ")
+        sb.append(tableName)
+        sb.append(" ON ")
+        sb.append(joinExpr)
+      }
       where.foreach(sb.append(" WHERE ").append(_))
       groupBy.foreach { gb => sb.append(gb.mkString(" GROUP BY ", ", ", "")) }
       having.foreach(sb.append(" HAVING ").append(_))
@@ -40,7 +47,7 @@ case class Selection(allSystemExcept: Option[StarSelection], allUserExcept: Opti
   }
 }
 
-case class StarSelection(exceptions: Seq[(ColumnName, Position)]) {
+case class StarSelection(qualifier: Option[String], exceptions: Seq[(ColumnName, Position)]) {
   var starPosition: Position = NoPosition
   def positionedAt(p: Position): this.type = {
     starPosition = p

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/mapping/ColumnNameMapper.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/mapping/ColumnNameMapper.scala
@@ -22,6 +22,7 @@ class ColumnNameMapper(columnNameMap: Map[ColumnName, ColumnName]) {
       ss.updated(0, Select(
         distinct = s.distinct,
         selection = mapSelection(s.selection),
+        join = None,
         where = s.where map mapExpression,
         groupBy = s.groupBy.map(_ map mapExpression),
         having = s.having map mapExpression,
@@ -41,7 +42,7 @@ class ColumnNameMapper(columnNameMap: Map[ColumnName, ColumnName]) {
     case NullLiteral() => NullLiteral()(NoPosition)
 
     case e: ColumnOrAliasRef =>
-      ColumnOrAliasRef(columnNameMap(e.column))(NoPosition)
+      ColumnOrAliasRef(e.qualifier, columnNameMap(e.column))(NoPosition)
     case e: FunctionCall =>
       FunctionCall(e.functionName, e.parameters map mapExpression)(NoPosition, NoPosition)
   }
@@ -55,7 +56,7 @@ class ColumnNameMapper(columnNameMap: Map[ColumnName, ColumnName]) {
     (columnNameMap(s._1), NoPosition)
 
   def mapStarSelection(s: StarSelection): StarSelection =
-    StarSelection(s.exceptions map mapColumnNameAndPosition)
+    StarSelection(s.qualifier, s.exceptions map mapColumnNameAndPosition)
 
   def mapSelectedExpression(s: SelectedExpression): SelectedExpression = {
       // name isn't a column name, but a column alias so no mapping

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
@@ -1,14 +1,13 @@
 package com.socrata.soql.parsing
 
 import scala.reflect.ClassTag
-import scala.util.parsing.combinator.{Parsers, PackratParsers}
+import scala.util.parsing.combinator.{PackratParsers, Parsers}
 import util.parsing.input.Position
-
 import com.socrata.soql.tokens
 import com.socrata.soql.tokens._
 import com.socrata.soql.ast
 import com.socrata.soql.ast._
-import com.socrata.soql.environment.{TypeName, FunctionName, ColumnName}
+import com.socrata.soql.environment.{ColumnName, FunctionName, TableName, TypeName}
 
 // This can't be an "object" because parsers are not thread safe at least
 // through 2.9.2.  Might revisit when we drop 2.9 support, but it's hardly
@@ -22,6 +21,7 @@ abstract class AbstractParser extends Parsers with PackratParsers {
    *               *************
    */
   def selection(soql: String): Selection = parseFull(selectList, soql)
+  def joins(soql: String): List[Tuple2[TableName, Expression]] = parseFull(joinList, soql)
   def expression(soql: String): Expression = parseFull(expr, soql)
   def orderings(soql: String): Seq[OrderBy] = parseFull(orderingList, soql)
   def groupBys(soql: String): Seq[Expression] = parseFull(groupByList, soql)
@@ -95,8 +95,8 @@ abstract class AbstractParser extends Parsers with PackratParsers {
   def pipedSelect: Parser[Seq[Select]] = rep1sep(unchainedSelect, QUERYPIPE())
 
   def unchainedSelect: Parser[Select] =
-    SELECT() ~> distinct ~ selectList ~ opt(whereClause) ~ opt(groupByClause) ~ opt(havingClause) ~ orderByAndSearch ~ limitOffset ^^ {
-      case d ~ s ~ w ~ gb ~ h ~ ((ord, sr)) ~ ((lim, off)) => Select(d, s, w, gb, h, ord, lim, off, sr)
+    SELECT() ~> distinct ~ selectList ~ opt(joinList) ~ opt(whereClause) ~ opt(groupByClause) ~ opt(havingClause) ~ orderByAndSearch ~ limitOffset ^^ {
+      case d ~ s ~ j ~ w ~ gb ~ h ~ ((ord, sr)) ~ ((lim, off)) => Select(d, s, j, w, gb, h, ord, lim, off, sr)
     }
 
   def distinct: Parser[Boolean] = opt(DISTINCT()) ^^ (_.isDefined)
@@ -127,6 +127,15 @@ abstract class AbstractParser extends Parsers with PackratParsers {
   def offsetClause = OFFSET() ~> integer
   def searchClause = SEARCH() ~> stringLiteral
 
+  def joinClause: PackratParser[(TableName, Expression)] =
+    JOIN() ~ tableIdentifier ~ opt(AS() ~> simpleIdentifier) ~ ON() ~ expr ^^ {
+      case j ~ t ~ None ~ o ~ e => (TableName(t._1, None), e)
+      // TODO: finish table aliases
+      case j ~ t ~ Some((alias, pos)) ~ o ~ e => (TableName(t._1, Some(TableName.SodaFountainTableNamePrefix + alias)), e)
+    }
+
+  def joinList = rep1(joinClause)
+
   /*
    *               ********************
    *               * COLUMN-SELECTION *
@@ -150,21 +159,27 @@ abstract class AbstractParser extends Parsers with PackratParsers {
   def expressionSelectList = rep1sep(namedSelection, COMMA()) ^^ (Selection(None, None, _))
 
   def allSystemSelection =
-    COLONSTAR() ~ opt(selectExceptions(systemIdentifier)) ^^ { case star ~ exceptions => StarSelection(exceptions.getOrElse(Seq.empty)).positionedAt(star.position) }
+    opt(tableIdentifier ~ DOT()) ~ COLONSTAR() ~ opt(selectExceptions(systemIdentifier)) ^^ {
+      case None ~ star ~ exceptions => StarSelection(None, exceptions.getOrElse(Seq.empty)).positionedAt(star.position)
+      case Some(qual ~ _) ~ star ~ exceptions => StarSelection(Some(qual._1), exceptions.getOrElse(Seq.empty)).positionedAt(qual._2)
+    }
 
   def allUserSelection =
-    STAR() ~ opt(selectExceptions(userIdentifier)) ^^ { case star ~ exceptions => StarSelection(exceptions.getOrElse(Seq.empty)).positionedAt(star.position) }
+    opt(tableIdentifier ~ DOT()) ~ STAR() ~ opt(selectExceptions(userIdentifier)) ^^ {
+      case None ~ star ~ exceptions => StarSelection(None, exceptions.getOrElse(Seq.empty)).positionedAt(star.position)
+      case Some(qual ~ _) ~ star ~ exceptions => StarSelection(Some(qual._1), exceptions.getOrElse(Seq.empty)).positionedAt(qual._2)
+    }
 
-  def selectExceptions(identifierType: Parser[(String, Position)]): Parser[Seq[(ColumnName, Position)]] =
+  def selectExceptions(identifierType: Parser[(Option[String], String, Position)]): Parser[Seq[(ColumnName, Position)]] =
     LPAREN() ~ EXCEPT() ~> rep1sep(identifierType, COMMA()) <~ (RPAREN() | failure(errors.missingArg)) ^^ { namePoses =>
-      namePoses.map { case (name, pos) =>
+      namePoses.map { case (qual, name, pos) =>
         (ColumnName(name), pos)
       }
     }
 
   def namedSelection = expr ~ opt(AS() ~> userIdentifier) ^^ {
     case e ~ None => SelectedExpression(e, None)
-    case e ~ Some((name, pos)) => SelectedExpression(e, Some((ColumnName(name), pos)))
+    case e ~ Some((qual, name, pos)) => SelectedExpression(e, Some((ColumnName(name), pos)))
   }
 
   /*
@@ -220,18 +235,40 @@ abstract class AbstractParser extends Parsers with PackratParsers {
       case n: NULL => NullLiteral()(n.position)
     }
 
+  def userIdentifier: Parser[(Option[String], String, Position)] =
+     opt(tableIdentifier ~ DOT()) ~ simpleUserIdentifier ^^ {
+       case None ~ uid =>
+         (None, uid._1, uid._2)
+       case Some(qual ~ _) ~ uid =>
+         (Some(qual._1), uid._1, qual._2)
+    }
 
-  val userIdentifier: Parser[(String, Position)] =
+  val tableIdentifier: Parser[(String, Position)] =
+    accept[tokens.TableIdentifier] ^^ { t =>
+      (TableName.SodaFountainTableNamePrefix + t.value.substring(1) /* remove prefix @ */, t.position)
+    } | failure(errors.missingUserIdentifier)
+
+  val simpleUserIdentifier: Parser[(String, Position)] =
     accept[tokens.Identifier] ^^ { t =>
       (t.value, t.position)
     } | failure(errors.missingUserIdentifier)
 
-  val systemIdentifier: Parser[(String, Position)] =
+  val systemIdentifier: Parser[(Option[String], String, Position)] =
+    opt(tableIdentifier ~ DOT()) ~ simpleSystemIdentifier ^^ {
+      case None ~ sid =>
+        (None, sid._1, sid._2)
+      case Some(qual ~ _) ~ sid =>
+        (Some(qual._1), sid._1, qual._2)
+    }
+
+  val simpleSystemIdentifier: Parser[(String, Position)] =
     accept[tokens.SystemIdentifier] ^^ { t =>
       (t.value, t.position)
     } | failure(errors.missingSystemIdentifier)
 
-  val identifier: Parser[(String, Position)] = systemIdentifier | userIdentifier | failure(errors.missingIdentifier)
+  val identifier: Parser[(Option[String], String, Position)] = systemIdentifier | userIdentifier | failure(errors.missingIdentifier)
+
+  val simpleIdentifier: Parser[(String, Position)] = simpleSystemIdentifier | simpleUserIdentifier | failure(errors.missingIdentifier)
 
   def paramList: Parser[Either[Position, Seq[Expression]]] =
     // the clauses have to be in this order, or it can't backtrack enough to figure out it's allowed to take
@@ -244,11 +281,11 @@ abstract class AbstractParser extends Parsers with PackratParsers {
 
   def identifier_or_funcall: Parser[Expression] =
     identifier ~ opt(params) ^^ {
-      case ((ident, identPos)) ~ None =>
-        ColumnOrAliasRef(ColumnName(ident))(identPos)
-      case ((ident, identPos)) ~ Some(Right(params)) =>
+      case ((qual, ident, identPos)) ~ None =>
+        ColumnOrAliasRef(qual, ColumnName(ident))(identPos)
+      case ((_, ident, identPos)) ~ Some(Right(params)) =>
         FunctionCall(FunctionName(ident), params)(identPos, identPos)
-      case ((ident, identPos)) ~ Some(Left(position)) =>
+      case ((_, ident, identPos)) ~ Some(Left(position)) =>
         FunctionCall(SpecialFunctions.StarFunc(ident), Seq.empty)(identPos, identPos)
     }
 
@@ -259,7 +296,7 @@ abstract class AbstractParser extends Parsers with PackratParsers {
     literal | identifier_or_funcall | paren | failure(errors.missingExpr)
 
   lazy val dereference: PackratParser[Expression] =
-    dereference ~ DOT() ~ identifier ^^ {
+    dereference ~ DOT() ~ simpleIdentifier ^^ {
       case a ~ dot ~ ((b, bPos)) =>
         FunctionCall(SpecialFunctions.Subscript, Seq(a, ast.StringLiteral(b)(bPos)))(a.position, dot.position)
     } |
@@ -270,7 +307,7 @@ abstract class AbstractParser extends Parsers with PackratParsers {
     atom
 
   lazy val cast: PackratParser[Expression] =
-    cast ~ COLONCOLON() ~ identifier ^^ {
+    cast ~ COLONCOLON() ~ simpleIdentifier ^^ {
       case a ~ colcol ~ ((b, bPos)) =>
         FunctionCall(SpecialFunctions.Cast(TypeName(b)), Seq(a))(a.position, bPos)
     } |

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/tokens/Tokens.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/tokens/Tokens.scala
@@ -53,9 +53,12 @@ case class RIGHT() extends Token
 case class QUERYPIPE() extends Token
 
 // Subscripting
-case class DOT() extends FormattedToken(".")
+// DOT() share with qualifying
 case class LBRACKET() extends FormattedToken("[")
 case class RBRACKET() extends FormattedToken("]")
+
+// Qualifying
+case class DOT() extends FormattedToken(".")
 
 // Math
 case class PLUS() extends FormattedToken("+")

--- a/soql-standalone-parser/src/test/scala/com/socrata/soql/parsing/ParserTest.scala
+++ b/soql-standalone-parser/src/test/scala/com/socrata/soql/parsing/ParserTest.scala
@@ -22,7 +22,7 @@ class ParserTest extends WordSpec with MustMatchers {
       case e: BadParse => e.message must equal (expectedMsg)
     }
 
-  def ident(name: String) = ColumnOrAliasRef(ColumnName(name))(NoPosition)
+  def ident(name: String) = ColumnOrAliasRef(None, ColumnName(name))(NoPosition)
   def functionCall(name: FunctionName, args: Seq[Expression]) = FunctionCall(name, args)(NoPosition, NoPosition)
   def stringLiteral(s: String) = StringLiteral(s)(NoPosition)
   def numberLiteral(num: BigDecimal) = NumberLiteral(num)(NoPosition)

--- a/soql-toy/src/main/scala/com/socrata/soql/AliasToy.scala
+++ b/soql-toy/src/main/scala/com/socrata/soql/AliasToy.scala
@@ -2,10 +2,9 @@ package com.socrata.soql
 
 import collection.OrderedSet
 import com.socrata.soql.aliases._
-
 import com.socrata.soql.parsing.Parser
 import com.socrata.soql.exceptions.SoQLException
-import environment.{ColumnName, UntypedDatasetContext}
+import environment.{ColumnName, TableName, UntypedDatasetContext}
 
 object AliasToy extends (Array[String] => Unit) {
   def fail(msg: String) = {
@@ -13,14 +12,14 @@ object AliasToy extends (Array[String] => Unit) {
     sys.exit(1)
   }
 
-  implicit val datasetCtx = new UntypedDatasetContext {
+  implicit val datasetCtx = Map(TableName.PrimaryTable.qualifier -> new UntypedDatasetContext {
     val locale = com.ibm.icu.util.ULocale.ENGLISH
     val columns = com.socrata.soql.collection.OrderedSet(":id", ":created_at", "a", "b", "c", "d").map(ColumnName(_))
-  }
+  })
 
   def menu() {
     println("Columns:")
-    println(datasetCtx.columns.mkString("  ", ", ", ""))
+    println(datasetCtx(TableName.PrimaryTable.qualifier).columns.mkString("  ", ", ", ""))
   }
 
   def apply(args: Array[String]) {

--- a/soql-toy/src/main/scala/com/socrata/soql/SoqlToy.scala
+++ b/soql-toy/src/main/scala/com/socrata/soql/SoqlToy.scala
@@ -2,8 +2,8 @@ package com.socrata.soql
 
 import com.socrata.soql.exceptions.SoQLException
 import com.socrata.soql.types._
-import environment.{ColumnName, DatasetContext}
-import com.socrata.soql.functions.{SoQLTypeInfo, SoQLFunctionInfo}
+import environment.{ColumnName, DatasetContext, TableName}
+import com.socrata.soql.functions.{SoQLFunctionInfo, SoQLTypeInfo}
 
 object SoqlToy extends (Array[String] => Unit) {
   def fail(msg: String) = {
@@ -11,7 +11,7 @@ object SoqlToy extends (Array[String] => Unit) {
     sys.exit(1)
   }
 
-  implicit val datasetCtx = new DatasetContext[SoQLType] {
+  implicit val datasetCtx = Map(TableName.PrimaryTable.qualifier -> new DatasetContext[SoQLType] {
     private implicit def ctx = this
     val locale = com.ibm.icu.util.ULocale.ENGLISH
     val schema = com.socrata.soql.collection.OrderedMap(
@@ -30,11 +30,11 @@ object SoqlToy extends (Array[String] => Unit) {
       ColumnName("dbl") -> SoQLDouble,
       ColumnName(":@meta") -> SoQLObject
     )
-  }
+  })
 
   def menu() {
     println("Columns:")
-    Util.printList(datasetCtx.schema)
+    Util.printList(datasetCtx(TableName.PrimaryTable.qualifier).schema)
   }
 
   def apply(args: Array[String]) {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.1.2-SNAPSHOT"
+version in ThisBuild := "2.2.0-SNAPSHOT"


### PR DESCRIPTION
Basic join support
Qualified star selection
Use @aaaa-aaaa.field_name syntax
Join table alias

Automatically add prefix ‘_’ in the parse tree so that end user can address resource name with just the 4x4 and no prefixes despite that the real resource name is always prefixed with ‘_’.