### PR TITLE
Make joins optional at the parse level

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/parsing/Parser.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/parsing/Parser.scala
@@ -3,7 +3,7 @@ package com.socrata.soql.parsing
 import scala.util.parsing.input.Position
 import com.socrata.soql.exceptions.BadParse
 
-class Parser extends StandaloneParser {
+class Parser(parameters: AbstractParser.Parameters = AbstractParser.defaultParameters) extends StandaloneParser(parameters) {
   override protected def badParse(msg: String, position: Position): Nothing =
     throw BadParse(msg, position)
 }

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/StandaloneParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/StandaloneParser.scala
@@ -4,7 +4,7 @@ import com.socrata.soql.parsing.standalone_exceptions.BadParse
 import scala.util.parsing.input.Position
 import java.io.StringReader
 
-class StandaloneParser extends AbstractParser {
+class StandaloneParser(parameters: AbstractParser.Parameters = AbstractParser.defaultParameters) extends AbstractParser(parameters) {
   protected def badParse(msg: String, nextPos: Position): Nothing =
     throw BadParse(msg, nextPos)
 


### PR DESCRIPTION
DSMAPI doesn't need these and we can get a better error message if
trying to use them is a parse error.