### PR TITLE
EN-16454 Support multiple “SELECT *”’s

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
@@ -206,7 +206,7 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type],
       val beforeAliasAnalysis = System.nanoTime()
       val count_* = FunctionCall(SpecialFunctions.StarFunc("count"), Nil)(NoPosition, NoPosition)
       val untypedSelectedExpressions = groupBy.getOrElse(Nil) :+ count_*
-      val names = AliasAnalysis(Selection(None, None, untypedSelectedExpressions.map(SelectedExpression(_, None)))).expressions.keys.toSeq
+      val names = AliasAnalysis(Selection(None, Seq.empty, untypedSelectedExpressions.map(SelectedExpression(_, None)))).expressions.keys.toSeq
       val afterAliasAnalysis = System.nanoTime()
 
       log.trace("alias analysis took {}ms", ns2ms(afterAliasAnalysis - beforeAliasAnalysis))
@@ -218,7 +218,7 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type],
       log.debug("It is not grouped; selecting *")
 
       val beforeAliasAnalysis = System.nanoTime()
-      val names = AliasAnalysis(Selection(None, Some(StarSelection(None, Nil)), Nil)).expressions.keys.toSeq
+      val names = AliasAnalysis(Selection(None, Seq(StarSelection(None, Nil)), Nil)).expressions.keys.toSeq
       val afterAliasAnalyis = System.nanoTime()
 
       log.trace("alias analysis took {}ms", ns2ms(afterAliasAnalyis - beforeAliasAnalysis))

--- a/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
@@ -412,4 +412,15 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with PropertyChecks {
       ColumnName("z") -> typedExpression("@x1.z")
     ))
   }
+
+  test("`SELECT *` toString") {
+    val soql = "SELECT @a1.:*, @a1.*, * JOIN @aaaa-aaax AS x1 ON visits > 10"
+    val parsed = new Parser().unchainedSelectStatement(soql)
+
+    val expected = "SELECT @a1.:*, @a1.*, * JOIN @aaaa-aaax AS x1 ON `visits` > 10"
+    parsed.toString must equal(expected)
+
+    val parsedAgain = new Parser().unchainedSelectStatement(expected)
+    parsedAgain.toString must equal(expected)
+  }
 }

--- a/soql-analyzer/src/test/scala/com/socrata/soql/aliases/AliasAnalysisTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/aliases/AliasAnalysisTest.scala
@@ -84,32 +84,32 @@ class AliasAnalysisTest extends WordSpec with MustMatchers {
     val someSelections = selections("2+2,hello,avg(gnu) as average").expressions
 
     "return the input if there were no stars" in {
-      AliasAnalysis.expandSelection(Selection(None, None, someSelections)) must equal (someSelections)
+      AliasAnalysis.expandSelection(Selection(None, Seq.empty, someSelections)) must equal (someSelections)
     }
 
     "return the system columns if there was a :*" in {
       // TODO: check the positions
-      AliasAnalysis.expandSelection(Selection(Some(StarSelection(None, Seq.empty).positionedAt(pos)), None, someSelections)) must equal (unaliased(":a",":b")(pos) ++ someSelections)
+      AliasAnalysis.expandSelection(Selection(Some(StarSelection(None, Seq.empty).positionedAt(pos)), Seq.empty, someSelections)) must equal (unaliased(":a",":b")(pos) ++ someSelections)
     }
 
     "return the un-excepted columns if there was a :*" in {
       // TODO: check the positions
-      AliasAnalysis.expandSelection(Selection(Some(StarSelection(None, Seq((ident(":a"), NoPosition))).positionedAt(pos)), None, someSelections)) must equal (unaliased(":b")(pos) ++ someSelections)
+      AliasAnalysis.expandSelection(Selection(Some(StarSelection(None, Seq((ident(":a"), NoPosition))).positionedAt(pos)), Seq.empty, someSelections)) must equal (unaliased(":b")(pos) ++ someSelections)
     }
 
     "return the user columns if there was a *" in {
       // TODO: check the positions
-      AliasAnalysis.expandSelection(Selection(None, Some(StarSelection(None, Seq.empty).positionedAt(pos)), someSelections)) must equal (unaliased("c","d","e")(pos) ++ someSelections)
+      AliasAnalysis.expandSelection(Selection(None, Seq(StarSelection(None, Seq.empty).positionedAt(pos)), someSelections)) must equal (unaliased("c","d","e")(pos) ++ someSelections)
     }
 
     "return the un-excepted user columns if there was a *" in {
       // TODO: check the positions
-      AliasAnalysis.expandSelection(Selection(None, Some(StarSelection(None, Seq((ident("d"), NoPosition),(ident("e"), NoPosition))).positionedAt(pos)), someSelections)) must equal (unaliased("c")(pos) ++ someSelections)
+      AliasAnalysis.expandSelection(Selection(None, Seq(StarSelection(None, Seq((ident("d"), NoPosition),(ident("e"), NoPosition))).positionedAt(pos)), someSelections)) must equal (unaliased("c")(pos) ++ someSelections)
     }
 
     "return the all user columns if there was a :* and a *" in {
       // TODO: check the positions
-      AliasAnalysis.expandSelection(Selection(Some(StarSelection(None, Seq.empty).positionedAt(pos)), Some(StarSelection(None, Seq.empty).positionedAt(pos2)), someSelections)) must equal (unaliased(":a",":b")(pos) ++ unaliased("c","d","e")(pos2) ++ someSelections)
+      AliasAnalysis.expandSelection(Selection(Some(StarSelection(None, Seq.empty).positionedAt(pos)), Seq(StarSelection(None, Seq.empty).positionedAt(pos2)), someSelections)) must equal (unaliased(":a",":b")(pos) ++ unaliased("c","d","e")(pos2) ++ someSelections)
     }
   }
 

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
@@ -27,7 +27,7 @@ case class Select(distinct: Boolean, selection: Selection, join: Option[List[Joi
   }
 }
 
-case class Selection(allSystemExcept: Option[StarSelection], allUserExcept: Option[StarSelection], expressions: Seq[SelectedExpression]) {
+case class Selection(allSystemExcept: Option[StarSelection], allUserExcept: Seq[StarSelection], expressions: Seq[SelectedExpression]) {
   override def toString = {
     if(AST.pretty) {
       def star(s: StarSelection, token: String) = {

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
@@ -31,7 +31,12 @@ case class Selection(allSystemExcept: Option[StarSelection], allUserExcept: Seq[
   override def toString = {
     if(AST.pretty) {
       def star(s: StarSelection, token: String) = {
-        val sb = new StringBuilder(token)
+        val sb = new StringBuilder()
+        s.qualifier.foreach { x =>
+          sb.append(x.replaceFirst(TableName.SodaFountainTableNamePrefix, TableName.Prefix))
+          sb.append(TableName.Field)
+        }
+        sb.append(token)
         if(s.exceptions.nonEmpty) {
           sb.append(s.exceptions.map(e => e._1).mkString(" (EXCEPT ", ", ", ")"))
         }

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
@@ -153,27 +153,33 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
    *               ********************
    */
 
+  /**
+    * There can be only one [table.]:* but multiple [table.]* because
+    * all system column names are always identical and it does not support the same column twice w/o rename.
+    */
   def selectList =
     allSystemSelection ~ opt(COMMA() ~> onlyUserStarSelectList) ^^ {
       case star ~ Some(rest) => rest.copy(allSystemExcept = Some(star))
-      case star ~ None => Selection(Some(star), None, Seq.empty)
+      case star ~ None => Selection(Some(star), Seq.empty, Seq.empty)
     } |
     onlyUserStarSelectList
 
   def onlyUserStarSelectList =
-    allUserSelection ~ opt(COMMA() ~> expressionSelectList) ^^ {
-      case star ~ Some(rest) => rest.copy(allUserExcept = Some(star))
-      case star ~ None => Selection(None, Some(star), Seq.empty)
+    allUserSelectionList ~ opt(COMMA() ~> expressionSelectList) ^^ {
+      case star ~ Some(rest) => rest.copy(allUserExcept = star)
+      case star ~ None => Selection(None, star, Seq.empty)
     } |
     expressionSelectList
 
-  def expressionSelectList = rep1sep(namedSelection, COMMA()) ^^ (Selection(None, None, _))
+  def expressionSelectList = rep1sep(namedSelection, COMMA()) ^^ (Selection(None, Seq.empty, _))
 
   def allSystemSelection =
     opt(tableIdentifier ~ DOT()) ~ COLONSTAR() ~ opt(selectExceptions(systemIdentifier)) ^^ {
       case None ~ star ~ exceptions => StarSelection(None, exceptions.getOrElse(Seq.empty)).positionedAt(star.position)
       case Some(qual ~ _) ~ star ~ exceptions => StarSelection(Some(qual._1), exceptions.getOrElse(Seq.empty)).positionedAt(qual._2)
     }
+
+  def allUserSelectionList = rep1sep(allUserSelection, COMMA()) ^^ ( _.map { star =>  star } )
 
   def allUserSelection =
     opt(tableIdentifier ~ DOT()) ~ STAR() ~ opt(selectExceptions(userIdentifier)) ^^ {

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
@@ -179,7 +179,7 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
       case Some(qual ~ _) ~ star ~ exceptions => StarSelection(Some(qual._1), exceptions.getOrElse(Seq.empty)).positionedAt(qual._2)
     }
 
-  def allUserSelectionList = rep1sep(allUserSelection, COMMA()) ^^ ( _.map { star =>  star } )
+  def allUserSelectionList = rep1sep(allUserSelection, COMMA()) ^^ ( _.map { star => star } )
 
   def allUserSelection =
     opt(tableIdentifier ~ DOT()) ~ STAR() ~ opt(selectExceptions(userIdentifier)) ^^ {

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
@@ -158,16 +158,16 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
     * all system column names are always identical and it does not support the same column twice w/o rename.
     */
   def selectList =
-    allSystemSelection ~ opt(COMMA() ~> onlyUserStarSelectList) ^^ {
+    allSystemSelection ~ opt(COMMA() ~> onlyUserStarsSelectList) ^^ {
       case star ~ Some(rest) => rest.copy(allSystemExcept = Some(star))
       case star ~ None => Selection(Some(star), Seq.empty, Seq.empty)
     } |
-    onlyUserStarSelectList
+    onlyUserStarsSelectList
 
-  def onlyUserStarSelectList =
+  def onlyUserStarsSelectList =
     allUserSelectionList ~ opt(COMMA() ~> expressionSelectList) ^^ {
-      case star ~ Some(rest) => rest.copy(allUserExcept = star)
-      case star ~ None => Selection(None, star, Seq.empty)
+      case stars ~ Some(rest) => rest.copy(allUserExcept = stars)
+      case stars ~ None => Selection(None, stars, Seq.empty)
     } |
     expressionSelectList
 


### PR DESCRIPTION
There can be * from more than one table.  But :* is still limited to one table because system columns always contain name collisions.