### PR TITLE
“Partition by” should not be optional if the list is not empty.

### DIFF
--- a/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
@@ -526,5 +526,16 @@ SELECT visits, @x2.zx
     intercept[TypeMismatch] {
       analyzer.analyzeUnchainedQuery("SELECT avg(name_last)")
     }
+
+    val expressionExpected = intercept[BadParse] {
+      analyzer.analyzeUnchainedQuery("SELECT name_last, avg(visits) OVER (PARTITION BY)")
+    }
+    expressionExpected.message must startWith("Expression expected")
+
+
+    val partitionExpected = intercept[BadParse] {
+      analyzer.analyzeUnchainedQuery("SELECT name_last, avg(visits) OVER (name_last, 2, 3)")
+    }
+    partitionExpected.message must startWith("`PARTITION' expected")
   }
 }

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
@@ -312,10 +312,13 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
 
 
   def windowFunctionParamList: Parser[Either[Position, Seq[Expression]]] =
-    repsep(expr, COMMA()) ^^ (Right(_))
+    rep1sep(expr, COMMA()) ^^ (Right(_))
 
   def windowFunctionParams: Parser[Either[Position, Seq[Expression]]] =
-    LPAREN() ~> opt(PARTITION() ~> BY()) ~> windowFunctionParamList <~ (RPAREN() | failure(errors.missingArg))
+    LPAREN() ~> RPAREN() ^^ { _ => Right(Seq.empty) } |
+      LPAREN() ~> PARTITION() ~> BY() ~> windowFunctionParamList <~ RPAREN() |
+      failure(errors.missingArg)
+
 
   def identifier_or_funcall: Parser[Expression] =
     identifier ~ opt(params) ~ opt(OVER() ~ windowFunctionParams) ^^ {


### PR DESCRIPTION
aggregate_fn(field) over (partition by x, y…)