### PR TITLE
Ensure that variadic application is correct when varargs length > 1

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/functions/Function.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/functions/Function.scala
@@ -28,6 +28,15 @@ case class Function[Type](identity: String,
 
   val minArity = parameters.length
   def isVariadic = repeated.nonEmpty
+  val varargsMultiplicity = repeated.length
+
+  final def willAccept(n: Int): Boolean = {
+    if(isVariadic && n > minArity) {
+      (n - minArity) % varargsMultiplicity == 0
+    } else {
+      n == minArity
+    }
+  }
 
   lazy val typeParameters: Set[String] =
     (parameters ++ List(result) ++ repeated).collect {

--- a/soql-analyzer/src/test/scala/com/socrata/soql/types/TestFunctionInfo.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/types/TestFunctionInfo.scala
@@ -25,7 +25,7 @@ object TestFunctionInfo extends FunctionInfo[TestType] {
         var i = n
         while(i >= 0) {
           funcsByArity.get(i) match {
-            case Some(fs) => result ++= fs
+            case Some(fs) => result ++= fs.filter(_.willAccept(n))
             case None => // nothing
           }
           i -= 1

--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctionInfo.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctionInfo.scala
@@ -12,7 +12,7 @@ object SoQLFunctionInfo extends FunctionInfo[SoQLType] {
           case Some(fs) =>
             fs
           case None =>
-            variadicFunctionsWithArity(name ,n)
+            variadicFunctionsWithArity(name, n)
         }
       case None =>
         variadicFunctionsWithArity(name, n)
@@ -25,7 +25,7 @@ object SoQLFunctionInfo extends FunctionInfo[SoQLType] {
         var i = n
         while(i >= 0) {
           funcsByArity.get(i) match {
-            case Some(fs) => result ++= fs
+            case Some(fs) => result ++= fs.filter(_.willAccept(n))
             case None => // nothing
           }
           i -= 1


### PR DESCRIPTION
This is for functions like `case`, which takes varargs in pairs
instead of one-by-one