### PR TITLE
Fix stackoverflow

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/typechecker/Typechecker.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/typechecker/Typechecker.scala
@@ -75,7 +75,7 @@ class Typechecker[Type](typeInfo: TypeInfo[Type], functionInfo: FunctionInfo[Typ
             choices
           }
 
-          selectedParameters.foldRight(Seq(List.empty[Expr])) { (choices, remainingParams) =>
+          selectedParameters.toVector.foldRight(Seq(List.empty[Expr])) { (choices, remainingParams) =>
             choices.flatMap { choice => remainingParams.map(choice :: _) }
           }.map(typed.FunctionCall(f, _)(fc.position, fc.functionNamePosition))
         }


### PR DESCRIPTION
* On super large expressions, the foldright in the typechecker
  would overflow the stack. This makes it fold right in constant
  stack space