### PR TITLE
Qualification is not needed in column alias

### DIFF
--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
@@ -200,9 +200,9 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
       }
     }
 
-  def namedSelection = expr ~ opt(AS() ~> userIdentifier) ^^ {
+  def namedSelection = expr ~ opt(AS() ~> simpleUserIdentifier) ^^ {
     case e ~ None => SelectedExpression(e, None)
-    case e ~ Some((qual, name, pos)) => SelectedExpression(e, Some((ColumnName(name), pos)))
+    case e ~ Some((name, pos)) => SelectedExpression(e, Some((ColumnName(name), pos)))
   }
 
   /*


### PR DESCRIPTION
column_x as @table.x2 // invalid
column_x as x2 // valid