### PR TITLE
EN-23592 system column names in column aliases

### DIFF
--- a/soql-analyzer/src/test/scala/com/socrata/soql/aliases/AliasAnalysisTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/aliases/AliasAnalysisTest.scala
@@ -351,7 +351,7 @@ class AliasAnalysisTest extends WordSpec with MustMatchers {
     }
 
     "allow standard system columns in aliases" in {
-      val parser = new Parser(new Parameters(true, Set(":id", ":created_at", ":updated_at")))
+      val parser = new Parser(new Parameters(true, Set(":id", ":created_at", ":updated_at").map(ColumnName(_))))
       AliasAnalysis(parser.selection("max(:id) as :id, max(:created_at) as :created_at, max(:updated_at) as :updated_at")) must equal(AliasAnalysis.Analysis(
         OrderedMap(
           ColumnName(":id") -> expr("max(:id)"),

--- a/soql-analyzer/src/test/scala/com/socrata/soql/aliases/AliasAnalysisTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/aliases/AliasAnalysisTest.scala
@@ -8,6 +8,7 @@ import com.socrata.soql.ast._
 import com.socrata.soql.exceptions._
 import com.socrata.soql.environment.{ColumnName, TableName, UntypedDatasetContext}
 import com.socrata.soql.collection.{OrderedMap, OrderedSet}
+import com.socrata.soql.parsing.AbstractParser.Parameters
 
 class AliasAnalysisTest extends WordSpec with MustMatchers {
   def columnNames(names: String*) =
@@ -350,7 +351,8 @@ class AliasAnalysisTest extends WordSpec with MustMatchers {
     }
 
     "allow standard system columns in aliases" in {
-      AliasAnalysis(selections("max(:id) as :id, max(:created_at) as :created_at, max(:updated_at) as :updated_at")) must equal(AliasAnalysis.Analysis(
+      val parser = new Parser(new Parameters(true, Set(":id", ":created_at", ":updated_at")))
+      AliasAnalysis(parser.selection("max(:id) as :id, max(:created_at) as :created_at, max(:updated_at) as :updated_at")) must equal(AliasAnalysis.Analysis(
         OrderedMap(
           ColumnName(":id") -> expr("max(:id)"),
           ColumnName(":created_at") -> expr("max(:created_at)"),

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
@@ -9,7 +9,7 @@ import com.socrata.soql.ast._
 import com.socrata.soql.environment.{ColumnName, FunctionName, TableName, TypeName}
 
 object AbstractParser {
-  class Parameters(val allowJoins: Boolean = true, val systemColumnAliasesAllowed: Set[String] = Set.empty)
+  class Parameters(val allowJoins: Boolean = true, val systemColumnAliasesAllowed: Set[ColumnName] = Set.empty)
   val defaultParameters = new Parameters()
 }
 
@@ -203,8 +203,9 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
   def namedSelection = expr ~ opt(AS() ~> simpleIdentifier) ^^ {
     case e ~ None => SelectedExpression(e, None)
     case e ~ Some((name, pos)) =>
-      if (!name.startsWith(":") || parameters.systemColumnAliasesAllowed.contains(name)) {
-        SelectedExpression(e, Some((ColumnName(name), pos)))
+      val columnName = ColumnName(name)
+      if (!name.startsWith(":") || parameters.systemColumnAliasesAllowed.contains(columnName)) {
+        SelectedExpression(e, Some(columnName, pos))
       } else {
         badParse(s"column alias cannot start with colon - $name", pos)
       }


### PR DESCRIPTION
So that we can do max(:id) as :id.  This help interoperability with obe