### PR TITLE
EN-24347 Add date_trunc functions for fixed_timestamp.

### DIFF
--- a/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
@@ -538,4 +538,20 @@ SELECT visits, @x2.zx
     }
     partitionExpected.message must startWith("`PARTITION' expected")
   }
+
+  test("date_trunc fixed_timestamp with and without time zone") {
+    val analysisWordStyle = analyzer.analyzeUnchainedQuery("SELECT date_trunc_ymd(:created_at) as dt, date_trunc_ymd(:created_at, 'PDT') as dt_pdt")
+    analysisWordStyle.isGrouped must equal(false)
+    val select = analysisWordStyle.selection.toSeq
+    select must equal(Seq(
+      ColumnName("dt") -> typed.FunctionCall(TestFunctions.FixedTimeStampTruncYmd.monomorphic.get,
+        Seq(typed.ColumnRef(None, ColumnName(":created_at"), TestFixedTimestamp.t)(NoPosition)))(NoPosition, NoPosition),
+      ColumnName("dt_pdt") -> typed.FunctionCall(TestFunctions.FixedTimeStampTruncYmdAtTimeZone.monomorphic.get,
+        Seq(typed.ColumnRef(None, ColumnName(":created_at"), TestFixedTimestamp.t)(NoPosition),
+            typed.StringLiteral("PDT", TestText.t)(NoPosition)
+           )
+        )
+        (NoPosition, NoPosition)
+    ))
+  }
 }

--- a/soql-analyzer/src/test/scala/com/socrata/soql/types/TestFunctions.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/types/TestFunctions.scala
@@ -91,6 +91,18 @@ object TestFunctions {
   val CuratedRegionTest = f("curated_region_test", FunctionName("curated_region_test"), Map("a" -> GeospatialLike, "b" -> NumLike),
     Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(TestText))
 
+  val FloatingTimeStampTruncYmd = mf("floating timestamp trunc day", FunctionName("date_trunc_ymd"), Seq(TestFloatingTimestamp), Seq.empty, TestFloatingTimestamp)
+  val FloatingTimeStampTruncYm = mf("floating timestamp trunc month", FunctionName("date_trunc_ym"), Seq(TestFloatingTimestamp), Seq.empty, TestFloatingTimestamp)
+  val FloatingTimeStampTruncY = mf("floating timestamp trunc year", FunctionName("date_trunc_y"), Seq(TestFloatingTimestamp), Seq.empty, TestFloatingTimestamp)
+
+  val FixedTimeStampTruncYmd = mf("fixed timestamp trunc day", FunctionName("date_trunc_ymd"), Seq(TestFixedTimestamp), Seq.empty, TestFixedTimestamp)
+  val FixedTimeStampTruncYm = mf("fixed timestamp trunc month", FunctionName("date_trunc_ym"), Seq(TestFixedTimestamp), Seq.empty, TestFixedTimestamp)
+  val FixedTimeStampTruncY = mf("fixed timestamp trunc year", FunctionName("date_trunc_y"), Seq(TestFixedTimestamp), Seq.empty, TestFixedTimestamp)
+
+  val FixedTimeStampTruncYmdAtTimeZone = mf("fixed timestamp trunc day at time zone", FunctionName("date_trunc_ymd"), Seq(TestFixedTimestamp, TestText), Seq.empty, TestFloatingTimestamp)
+  val FixedTimeStampTruncYmAtTimeZone = mf("fixed timestamp trunc month at time zone", FunctionName("date_trunc_ym"), Seq(TestFixedTimestamp, TestText), Seq.empty, TestFloatingTimestamp)
+  val FixedTimeStampTruncYAtTimeZone = mf("fixed timestamp trunc year at time zone", FunctionName("date_trunc_y"), Seq(TestFixedTimestamp, TestText), Seq.empty, TestFloatingTimestamp)
+
   val Case = f("case", FunctionName("case"),
     Map("a" -> AllTypes),
     Seq(FixedType(TestBoolean), VariableType("a")),

--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -194,6 +194,19 @@ object SoQLFunctions {
   val FloatingTimeStampExtractDow = mf("floating timestamp extract day of week", FunctionName("date_extract_dow"), Seq(SoQLFloatingTimestamp), Seq.empty, SoQLNumber)
   val FloatingTimeStampExtractWoy = mf("floating timestamp extract week of year", FunctionName("date_extract_woy"), Seq(SoQLFloatingTimestamp), Seq.empty, SoQLNumber)
 
+
+  // This set of date_trunc functions for fixed_timestamp are for obe compatibility purpose.
+  // The truncated boundary does not aligned with the client time zone unless it happens to have the same time zone as the server.
+  // The FixedTimeStampTrunc*AtTimeZone set give the client more control to align at particular time zone.
+  val FixedTimeStampTruncYmd = mf("fixed timestamp trunc day", FunctionName("date_trunc_ymd"), Seq(SoQLFixedTimestamp), Seq.empty, SoQLFixedTimestamp)
+  val FixedTimeStampTruncYm = mf("fixed timestamp trunc month", FunctionName("date_trunc_ym"), Seq(SoQLFixedTimestamp), Seq.empty, SoQLFixedTimestamp)
+  val FixedTimeStampTruncY = mf("fixed timestamp trunc year", FunctionName("date_trunc_y"), Seq(SoQLFixedTimestamp), Seq.empty, SoQLFixedTimestamp)
+
+
+  val FixedTimeStampTruncYmdAtTimeZone = mf("fixed timestamp trunc day at time zone", FunctionName("date_trunc_ymd"), Seq(SoQLFixedTimestamp, SoQLText), Seq.empty, SoQLFloatingTimestamp)
+  val FixedTimeStampTruncYmAtTimeZone = mf("fixed timestamp trunc month at time zone", FunctionName("date_trunc_ym"), Seq(SoQLFixedTimestamp, SoQLText), Seq.empty, SoQLFloatingTimestamp)
+  val FixedTimeStampTruncYAtTimeZone = mf("fixed timestamp trunc year at time zone", FunctionName("date_trunc_y"), Seq(SoQLFixedTimestamp, SoQLText), Seq.empty, SoQLFloatingTimestamp)
+
   val castIdentities = for ((n, t) <- SoQLType.typesByName.toSeq) yield {
     f(n.caseFolded + "::" + n.caseFolded, SpecialFunctions.Cast(n), Map.empty, Seq(FixedType(t)), Seq.empty, FixedType(t))
   }


### PR DESCRIPTION
There are two versions:

1. for obe compatibility
2. for new application where you can pass in a time zone.  The returned value is floating_timestamp.