### PR TITLE
EN-24347 date_trunc_*(fixed_timestamp) should be datez_trunc_* for co…

### DIFF
--- a/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
@@ -539,8 +539,8 @@ SELECT visits, @x2.zx
     partitionExpected.message must startWith("`PARTITION' expected")
   }
 
-  test("overloading and aliases work") {
-    val analysisWordStyle = analyzer.analyzeUnchainedQuery("SELECT date_trunc_ymd(:created_at) as dt, date_trunc_ymd(:created_at, 'PDT') as dt_pdt")
+  test("aliases work") {
+    val analysisWordStyle = analyzer.analyzeUnchainedQuery("SELECT datez_trunc_ymd(:created_at) as dt, date_trunc_ymd(:created_at, 'PDT') as dt_pdt")
     analysisWordStyle.isGrouped must equal(false)
     val select = analysisWordStyle.selection.toSeq
     select must equal(Seq(

--- a/soql-analyzer/src/test/scala/com/socrata/soql/types/TestFunctions.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/types/TestFunctions.scala
@@ -95,9 +95,9 @@ object TestFunctions {
   val FloatingTimeStampTruncYm = mf("floating timestamp trunc month", FunctionName("date_trunc_ym"), Seq(TestFloatingTimestamp), Seq.empty, TestFloatingTimestamp)
   val FloatingTimeStampTruncY = mf("floating timestamp trunc year", FunctionName("date_trunc_y"), Seq(TestFloatingTimestamp), Seq.empty, TestFloatingTimestamp)
 
-  val FixedTimeStampTruncYmd = mf("fixed timestamp trunc day", FunctionName("date_trunc_ymd"), Seq(TestFixedTimestamp), Seq.empty, TestFixedTimestamp)
-  val FixedTimeStampTruncYm = mf("fixed timestamp trunc month", FunctionName("date_trunc_ym"), Seq(TestFixedTimestamp), Seq.empty, TestFixedTimestamp)
-  val FixedTimeStampTruncY = mf("fixed timestamp trunc year", FunctionName("date_trunc_y"), Seq(TestFixedTimestamp), Seq.empty, TestFixedTimestamp)
+  val FixedTimeStampTruncYmd = mf("fixed timestamp trunc day", FunctionName("datez_trunc_ymd"), Seq(TestFixedTimestamp), Seq.empty, TestFixedTimestamp)
+  val FixedTimeStampTruncYm = mf("fixed timestamp trunc month", FunctionName("datez_trunc_ym"), Seq(TestFixedTimestamp), Seq.empty, TestFixedTimestamp)
+  val FixedTimeStampTruncY = mf("fixed timestamp trunc year", FunctionName("datez_trunc_y"), Seq(TestFixedTimestamp), Seq.empty, TestFixedTimestamp)
 
   val FixedTimeStampTruncYmdAtTimeZone = mf("fixed timestamp trunc day at time zone", FunctionName("date_trunc_ymd"), Seq(TestFixedTimestamp, TestText), Seq.empty, TestFloatingTimestamp)
   val FixedTimeStampTruncYmAtTimeZone = mf("fixed timestamp trunc month at time zone", FunctionName("date_trunc_ym"), Seq(TestFixedTimestamp, TestText), Seq.empty, TestFloatingTimestamp)

--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -198,9 +198,9 @@ object SoQLFunctions {
   // This set of date_trunc functions for fixed_timestamp are for obe compatibility purpose.
   // The truncated boundary does not aligned with the client time zone unless it happens to have the same time zone as the server.
   // The FixedTimeStampTrunc*AtTimeZone set give the client more control to align at particular time zone.
-  val FixedTimeStampTruncYmd = mf("fixed timestamp trunc day", FunctionName("date_trunc_ymd"), Seq(SoQLFixedTimestamp), Seq.empty, SoQLFixedTimestamp)
-  val FixedTimeStampTruncYm = mf("fixed timestamp trunc month", FunctionName("date_trunc_ym"), Seq(SoQLFixedTimestamp), Seq.empty, SoQLFixedTimestamp)
-  val FixedTimeStampTruncY = mf("fixed timestamp trunc year", FunctionName("date_trunc_y"), Seq(SoQLFixedTimestamp), Seq.empty, SoQLFixedTimestamp)
+  val FixedTimeStampTruncYmd = mf("fixed timestamp trunc day", FunctionName("datez_trunc_ymd"), Seq(SoQLFixedTimestamp), Seq.empty, SoQLFixedTimestamp)
+  val FixedTimeStampTruncYm = mf("fixed timestamp trunc month", FunctionName("datez_trunc_ym"), Seq(SoQLFixedTimestamp), Seq.empty, SoQLFixedTimestamp)
+  val FixedTimeStampTruncY = mf("fixed timestamp trunc year", FunctionName("datez_trunc_y"), Seq(SoQLFixedTimestamp), Seq.empty, SoQLFixedTimestamp)
 
 
   val FixedTimeStampTruncYmdAtTimeZone = mf("fixed timestamp trunc day at time zone", FunctionName("date_trunc_ymd"), Seq(SoQLFixedTimestamp, SoQLText), Seq.empty, SoQLFloatingTimestamp)


### PR DESCRIPTION
…mpatibility.