### PR TITLE
Support carriage returns as whitespace

### DIFF
--- a/soql-standalone-parser/src/main/jflex/SoQLLexer.flex
+++ b/soql-standalone-parser/src/main/jflex/SoQLLexer.flex
@@ -58,7 +58,7 @@ import com.socrata.soql.tokens.*;
   protected abstract RuntimeException unexpectedCharacter(char c, Position pos);
 %}
 
-WhiteSpace = [ \t\n]
+WhiteSpace = [ \t\r\n]
 
 Identifier = [:jletter:] [:jletterdigit:]*
 SystemIdentifier = ":" "@"? [:jletterdigit:]+


### PR DESCRIPTION
If someone on Windows pastes soql into the soql editor, it can end up
with CRLF-style newlines.  We should tolerate that.