### PR TITLE
Syntactic sugar for CASE

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/typechecker/Typechecker.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/typechecker/Typechecker.scala
@@ -44,6 +44,14 @@ class Typechecker[Type](typeInfo: TypeInfo[Type], functionInfo: FunctionInfo[Typ
       assert(params.length == 1, "Parens with more than one parameter?!")
       assert(window.isEmpty, "Window clause exists?!")
       typecheck(params(0), aliases)
+    case fc@FunctionCall(SpecialFunctions.Case, params, None) =>
+      val actualParams =
+        if(params.takeRight(2).headOption == Some(BooleanLiteral(true)(fc.position))) {
+          params
+        } else {
+          params.dropRight(2)
+        }
+      typecheck(fc.copy(functionName = SpecialFunctions.CasePostTypecheck, parameters=actualParams)(position = fc.position, functionNamePosition = fc.functionNamePosition), aliases)
     case fc@FunctionCall(SpecialFunctions.Subscript, Seq(base, StringLiteral(prop)), window) =>
       assert(window.isEmpty, "Window clause exists?!")
       // Subscripting special case.  Some types have "subfields" that

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
@@ -428,8 +428,21 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
   def paren: Parser[Expression] =
     LPAREN() ~> expr <~ RPAREN() ^^ { e => FunctionCall(SpecialFunctions.Parens, Seq(e), None)(e.position, e.position) }
 
+
+  lazy val conditional: PackratParser[Expression] =
+    keyword("CASE") ~ rep1((keyword("WHEN") ~> expr <~ keyword("THEN")) ~ expr) ~ opt(keyword("ELSE") ~ expr) <~ keyword("END") ^^ {
+      case caseword ~ exprs ~ None  =>
+        FunctionCall(SpecialFunctions.Case,
+                     exprs.flatMap { case a ~ b => Seq(a, b) } ++ Seq(ast.BooleanLiteral(false)(caseword.position), ast.NullLiteral()(caseword.position)),
+                     None)(caseword.position, caseword.position)
+      case caseword ~ exprs ~ Some(sinon ~ sinonExpr)  =>
+        FunctionCall(SpecialFunctions.Case,
+                     exprs.flatMap { case a ~ b => Seq(a, b) } ++ Seq(ast.BooleanLiteral(true)(caseword.position), sinonExpr),
+                     None)(caseword.position, caseword.position)
+    }
+
   def atom =
-    literal | identifier_or_funcall | paren | failure(errors.missingExpr)
+    conditional | literal | identifier_or_funcall | paren | failure(errors.missingExpr)
 
   lazy val dereference: PackratParser[Expression] =
     dereference ~ DOT() ~ simpleIdentifier ^^ {
@@ -495,18 +508,6 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
       case Some(a ~ op) ~ b => FunctionCall(SpecialFunctions.Operator(op.printable), Seq(a, b), None)(a.position, op.position)
     }
 
-  lazy val conditional: PackratParser[Expression] =
-    keyword("CASE") ~ rep1((keyword("WHEN") ~> expr <~ keyword("THEN")) ~ expr) ~ opt(keyword("ELSE") ~ expr) <~ keyword("END") ^^ {
-      case caseword ~ exprs ~ None  =>
-        FunctionCall(SpecialFunctions.Case,
-                     exprs.flatMap { case a ~ b => Seq(a, b) } ++ Seq(ast.BooleanLiteral(false)(caseword.position), ast.NullLiteral()(caseword.position)),
-                     None)(caseword.position, caseword.position)
-      case caseword ~ exprs ~ Some(sinon ~ sinonExpr)  =>
-        FunctionCall(SpecialFunctions.Case,
-                     exprs.flatMap { case a ~ b => Seq(a, b) } ++ Seq(ast.BooleanLiteral(true)(caseword.position), sinonExpr),
-                     None)(caseword.position, caseword.position)
-    } | order
-
   lazy val isLikeBetweenIn: PackratParser[Expression] =
     isLikeBetweenIn ~ IS() ~ NULL() ^^ {
       case a ~ is ~ _ => FunctionCall(SpecialFunctions.IsNull, Seq(a), None)(a.position, is.position)
@@ -537,7 +538,7 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
     isLikeBetweenIn ~ (IN() | failure(errors.missingKeywords(NOT(), BETWEEN(), IN(), LIKE()))) ~ LPAREN() ~ rep1sep(expr, COMMA()) ~ RPAREN() ^^  {
       case a ~ in ~ _ ~ es ~ _ => FunctionCall(SpecialFunctions.In, a +: es, None)(a.position, in.position)
     } |
-    conditional
+    order
 
   lazy val negation: PackratParser[Expression] =
     NOT() ~ negation ^^ { case op ~ b => FunctionCall(SpecialFunctions.Operator(op.printable), Seq(b), None)(op.position, op.position) } |


### PR DESCRIPTION
With this change, both the legacy functional form
```
    case(if1, then1, if2, then2, ...)
````
and
````
    case
      when if1 then then1
      when if2 then then2
      ...
      [else otherwise]
    end
````
are accepted.  They both eventually end up being the function-call style
post-analysis.

I don't think the pretty printer for the new form is ideal yet; it will
work but might not actually produce particularly pretty output.