### PR TITLE
union

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisDeserializer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisDeserializer.scala
@@ -332,9 +332,9 @@ class AnalysisDeserializer[C, T](columnDeserializer: String => C, typeDeserializ
   def toBinaryTree(seq: Seq[SoQLAnalysis[C, T]]): BinaryTree[SoQLAnalysis[C, T]] = {
     def buildBinaryTree(seq: Seq[SoQLAnalysis[C, T]]): BinaryTree[SoQLAnalysis[C, T]] = {
       seq match {
-        case Seq(x) => x
+        case Seq(x) => Leaf(x)
         case ss =>
-          PipeQuery(buildBinaryTree(ss.dropRight(1)), ss.last)
+          PipeQuery(buildBinaryTree(ss.dropRight(1)), Leaf(ss.last))
       }
     }
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisDeserializer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisDeserializer.scala
@@ -27,7 +27,8 @@ private trait DeserializationDictionary[C, T] {
 }
 
 object AnalysisDeserializer {
-  val CurrentVersion = 6
+  val CurrentVersion = 7
+  val LastVersion = CurrentVersion - 1
 
   // This is odd and for smooth deploy transition.
   val TestVersionV5 = -1
@@ -162,6 +163,18 @@ class AnalysisDeserializer[C, T](columnDeserializer: String => C, typeDeserializ
 
     def readNonEmptySeq[A](f: => A): NonEmptySeq[A] = NonEmptySeq.fromSeqUnsafe(readSeq(f))
 
+    def readBinaryTree[A](f: => A): BinaryTree[A] = {
+      in.readUInt32() match {
+        case 1 =>
+          f.asInstanceOf[BinaryTree[A]]
+        case 2 =>
+          val op = in.readString()
+          val l = readBinaryTree(f)
+          val r = readBinaryTree(f)
+          Compound(op, l, r)
+      }
+    }
+
     def readSelection(): OrderedMap[ColumnName, Expr] = {
       val elems = readSeq {
         val name =  dictionary.labels(in.readUInt32())
@@ -215,11 +228,31 @@ class AnalysisDeserializer[C, T](columnDeserializer: String => C, typeDeserializ
     }
 
     def readSubAnalysis(): SubAnalysis[C, T] = {
-      SubAnalysis(read(), in.readString())
+      if (this.version >= CurrentVersion || this.version == TestVersionV5) {
+        SubAnalysis(readBinaryTree(readAnalysis), in.readString())
+      } else {
+        val neseq = readNonEmptySeq(readAnalysis)
+        val bt = toBinaryTree(neseq.seq)
+        SubAnalysis(bt, in.readString())
+      }
     }
 
     def readJoinAnalysis(): JoinAnalysis[C, T] = {
-      JoinAnalysis(readTableName(), maybeRead(readSubAnalysis()))
+      if (this.version >= CurrentVersion || this.version == TestVersionV5) {
+        in.readUInt32() match {
+          case 0 =>
+            JoinAnalysis(Left(readTableName()))
+          case 1 =>
+            JoinAnalysis(Right(readSubAnalysis()))
+        }
+      } else {
+        val tableName = readTableName()
+        val subAnalysisOpt = maybeRead(readSubAnalysis())
+        subAnalysisOpt match {
+          case Some(subAnalysis) => JoinAnalysis(Right(subAnalysis))
+          case None => JoinAnalysis(Left(tableName))
+        }
+      }
     }
 
     def readSearch(): Option[String] =
@@ -227,10 +260,16 @@ class AnalysisDeserializer[C, T](columnDeserializer: String => C, typeDeserializ
         dictionary.strings(in.readUInt32())
       }
 
+    def readFrom(): Option[TableName] =
+      maybeRead {
+        readTableName()
+      }
+
     def readAnalysis(): SoQLAnalysis[C, T] = {
       val ig = readIsGrouped()
       val d = readDistinct()
       val s = readSelection()
+      val f = if (this.version >= CurrentVersion || this.version == TestVersionV5) readFrom() else None
       val j = readJoins()
       val w = readWhere()
       val gb = readGroupBy()
@@ -240,7 +279,7 @@ class AnalysisDeserializer[C, T](columnDeserializer: String => C, typeDeserializ
       val o = readOffset()
       val search = readSearch()
 
-      SoQLAnalysis(ig, d, s, j, w, gb, h, ob, l, o, search)
+      SoQLAnalysis(ig, d, s, f, j, w, gb, h, ob, l, o, search)
     }
 
     def read(): NonEmptySeq[SoQLAnalysis[C, T]] = {
@@ -251,7 +290,7 @@ class AnalysisDeserializer[C, T](columnDeserializer: String => C, typeDeserializ
   def apply(in: InputStream): NonEmptySeq[SoQLAnalysis[C, T]] = {
     val cis = CodedInputStream.newInstance(in)
     cis.readInt32() match {
-      case v if v >= 5 && v <= 6 =>
+      case v if v >= 5 && v <= CurrentVersion =>
         val dictionary = DeserializationDictionaryImpl.fromInput(cis)
         val deserializer = new Deserializer(cis, dictionary, v)
         deserializer.read()
@@ -262,5 +301,43 @@ class AnalysisDeserializer[C, T](columnDeserializer: String => C, typeDeserializ
       case other =>
         throw new UnknownAnalysisSerializationVersion(other)
     }
+  }
+
+  def applyBinaryTree(in: InputStream): BinaryTree[SoQLAnalysis[C, T]] = {
+    val cis = CodedInputStream.newInstance(in)
+    cis.readInt32() match {
+      case v if v >= 5 && v <= LastVersion =>
+        val dictionary = DeserializationDictionaryImpl.fromInput(cis)
+        val deserializer = new Deserializer(cis, dictionary, v)
+        val seq: NonEmptySeq[SoQLAnalysis[C, T]] = deserializer.read()
+        val bt: BinaryTree[SoQLAnalysis[C, T]] = toBinaryTree(seq.seq)
+        bt
+      case v if v >= CurrentVersion =>
+        val dictionary = DeserializationDictionaryImpl.fromInput(cis)
+        val deserializer = new Deserializer(cis, dictionary, v)
+        val bt: BinaryTree[SoQLAnalysis[C, T]] = deserializer.readBinaryTree(deserializer.readAnalysis)
+        bt
+      case v if v == TestVersionV5 => // single select
+        val dictionary = DeserializationDictionaryImpl.fromInput(cis)
+        val deserializer = new Deserializer(cis, dictionary, v)
+        val seq = NonEmptySeq(deserializer.readAnalysis(), Seq.empty)
+        val bt: BinaryTree[SoQLAnalysis[C, T]] = toBinaryTree(seq.seq)
+        bt
+      case other =>
+        throw new UnknownAnalysisSerializationVersion(other)
+    }
+  }
+
+  // Not designed for empty seq
+  def toBinaryTree(seq: Seq[SoQLAnalysis[C, T]]): BinaryTree[SoQLAnalysis[C, T]] = {
+    def buildBinaryTree(seq: Seq[SoQLAnalysis[C, T]]): BinaryTree[SoQLAnalysis[C, T]] = {
+      seq match {
+        case Seq(x) => x
+        case ss =>
+          PipeQuery(buildBinaryTree(ss.dropRight(1)), ss.last)
+      }
+    }
+
+    buildBinaryTree(seq)
   }
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisDeserializer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisDeserializer.scala
@@ -166,7 +166,7 @@ class AnalysisDeserializer[C, T](columnDeserializer: String => C, typeDeserializ
     def readBinaryTree[A](f: => A): BinaryTree[A] = {
       in.readUInt32() match {
         case 1 =>
-          f.asInstanceOf[BinaryTree[A]]
+          Leaf(f)
         case 2 =>
           val op = in.readString()
           val l = readBinaryTree(f)

--- a/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisSerializer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisSerializer.scala
@@ -260,7 +260,7 @@ class AnalysisSerializer[C,T](serializeColumn: C => String, serializeType: T => 
           out.writeStringNoTag(op)
           writeBinaryTree(l)(f)
           writeBinaryTree(r)(f)
-        case a: A =>
+        case Leaf(a) =>
           out.writeUInt32NoTag(1)
           f(a)
       }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisSerializer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisSerializer.scala
@@ -232,10 +232,14 @@ class AnalysisSerializer[C,T](serializeColumn: C => String, serializeType: T => 
     }
 
     private def writeJoinAnalysis(ja: JoinAnalysis[C, T]): Unit = {
-      writeTableName(ja.fromTable)
-      maybeWrite(ja.subAnalysis) { case SubAnalysis(analyses, alias) =>
-        write(analyses)
-        out.writeStringNoTag(alias)
+      ja.subAnalysis match {
+        case Left(tableName) =>
+          out.writeUInt32NoTag(0)
+          writeTableName(tableName)
+        case Right(SubAnalysis(analyses, alias)) =>
+          out.writeUInt32NoTag(1)
+          writeBinaryTree(analyses)(writeAnalysis)
+          out.writeStringNoTag(alias)
       }
     }
 
@@ -247,6 +251,19 @@ class AnalysisSerializer[C,T](serializeColumn: C => String, serializeType: T => 
     def writeSeq[A](list: Iterable[A])(f: A => Unit): Unit = {
       out.writeUInt32NoTag(list.size)
       list.foreach(f)
+    }
+
+    def writeBinaryTree[A](bt: BinaryTree[A])(f: A => Unit): Unit = {
+      bt match {
+        case Compound(op: String, l, r) =>
+          out.writeUInt32NoTag(2)
+          out.writeStringNoTag(op)
+          writeBinaryTree(l)(f)
+          writeBinaryTree(r)(f)
+        case a: A =>
+          out.writeUInt32NoTag(1)
+          f(a)
+      }
     }
 
     private def maybeWrite[A](x: Option[A])(f: A => Unit): Unit = x match {
@@ -289,10 +306,16 @@ class AnalysisSerializer[C,T](serializeColumn: C => String, serializeType: T => 
         out.writeUInt32NoTag(registerString(s))
       }
 
+    private def writeFrom(from: Option[TableName]) =
+      maybeWrite(from) { tableName =>
+        writeTableName(tableName)
+      }
+
     def writeAnalysis(analysis: SoQLAnalysis[C, T]) {
       val SoQLAnalysis(isGrouped,
                        distinct,
                        selection,
+                       from,
                        join,
                        where,
                        groupBy,
@@ -304,6 +327,7 @@ class AnalysisSerializer[C,T](serializeColumn: C => String, serializeType: T => 
       writeGrouped(isGrouped)
       writeDistinct(analysis.distinct)
       writeSelection(selection)
+      writeFrom(from)
       writeJoins(join)
       writeWhere(where)
       writeGroupBy(groupBy)
@@ -325,6 +349,21 @@ class AnalysisSerializer[C,T](serializeColumn: C => String, serializeType: T => 
     val out = CodedOutputStream.newInstance(postDictionaryData)
     val serializer = new Serializer(out, dictionary)
     serializer.write(analyses)
+    out.flush()
+
+    val codedOutputStream = CodedOutputStream.newInstance(outputStream)
+    codedOutputStream.writeInt32NoTag(AnalysisDeserializer.CurrentVersion) // version number
+    dictionary.save(codedOutputStream)
+    codedOutputStream.flush()
+    postDictionaryData.writeTo(outputStream)
+  }
+
+  def applyBinaryTree(outputStream: OutputStream, analyses: BinaryTree[SoQLAnalysis[C, T]]) {
+    val dictionary = new SerializationDictionaryImpl
+    val postDictionaryData = new ByteArrayOutputStream
+    val out = CodedOutputStream.newInstance(postDictionaryData)
+    val serializer = new Serializer(out, dictionary)
+    serializer.writeBinaryTree(analyses)(serializer.writeAnalysis)
     out.flush()
 
     val codedOutputStream = CodedOutputStream.newInstance(outputStream)

--- a/soql-analyzer/src/main/scala/com/socrata/soql/exceptions/Exceptions.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/exceptions/Exceptions.scala
@@ -141,3 +141,6 @@ case class NonBooleanWhere(typ: TypeName, position: Position) extends SoQLExcept
 case class NonGroupableGroupBy(typ: TypeName, position: Position) extends SoQLException("Cannot group by an expression of type `" + typ + "'", position) with TypecheckException
 case class NonBooleanHaving(typ: TypeName, position: Position) extends SoQLException("Cannot filter by an expression of type `" + typ + "'", position) with TypecheckException
 case class UnorderableOrderBy(typ: TypeName, position: Position) extends SoQLException("Cannot order by an expression of type `" + typ + "'", position) with TypecheckException
+
+sealed trait QueryOperationException extends SoQLException
+case class RightSideOfChainQueryMustBeLeaf(position: Position) extends SoQLException("Right side of a chain query must be a leaf query.", position) with QueryOperationException

--- a/soql-analyzer/src/main/scala/com/socrata/soql/mapping/ColumnIdMapper.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/mapping/ColumnIdMapper.scala
@@ -1,0 +1,35 @@
+package com.socrata.soql.mapping
+
+import com.socrata.soql.environment.ColumnName
+import com.socrata.soql.typed.Qualifier
+import com.socrata.soql.{BinaryTree, Compound, PipeQuery, SoQLAnalysis}
+
+object ColumnIdMapper {
+  def mapColumnIds[ColumnId, Type, NewColumnId](bt: BinaryTree[SoQLAnalysis[ColumnId, Type]])
+                                               (qColumnIdNewColumnIdMap: Map[(ColumnId, Qualifier), NewColumnId],
+                                                qColumnNameToQColumnId: (Qualifier, ColumnName) => (ColumnId, Qualifier),
+                                                columnNameToNewColumnId: ColumnName => NewColumnId,
+                                                columnIdToNewColumnId: ColumnId => NewColumnId):
+  BinaryTree[SoQLAnalysis[NewColumnId, Type]] = {
+    bt match {
+      case PipeQuery(l, r) =>
+        val nl = mapColumnIds(l)(qColumnIdNewColumnIdMap, qColumnNameToQColumnId, columnNameToNewColumnId, columnIdToNewColumnId)
+        val prev = nl.previous
+        val prevQColumnIdToQColumnIdMap = prev.selection.foldLeft(qColumnIdNewColumnIdMap) { (acc, selCol) =>
+          val (colName, expr) = selCol
+          acc + (qColumnNameToQColumnId(None, colName) -> columnNameToNewColumnId(colName))
+        }
+        val newQColumnIdToQColumnIdMap = qColumnIdNewColumnIdMap ++ prevQColumnIdToQColumnIdMap
+        val nr = r.asLeaf.mapColumnIds(newQColumnIdToQColumnIdMap, qColumnNameToQColumnId, columnNameToNewColumnId, columnIdToNewColumnId)
+        PipeQuery(nl, nr)
+      case Compound(op, l, r) =>
+        val nl = mapColumnIds(l)(qColumnIdNewColumnIdMap, qColumnNameToQColumnId, columnNameToNewColumnId, columnIdToNewColumnId)
+        val nr = mapColumnIds(r)(qColumnIdNewColumnIdMap, qColumnNameToQColumnId, columnNameToNewColumnId, columnIdToNewColumnId)
+        Compound(op, nl, nr)
+      case s =>
+        val ana = s.asLeaf
+        val nana = ana.mapColumnIds(qColumnIdNewColumnIdMap, qColumnNameToQColumnId, columnNameToNewColumnId, columnIdToNewColumnId)
+        nana
+    }
+  }
+}

--- a/soql-analyzer/src/main/scala/com/socrata/soql/mapping/ColumnIdMapper.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/mapping/ColumnIdMapper.scala
@@ -3,7 +3,7 @@ package com.socrata.soql.mapping
 import com.socrata.soql.environment.ColumnName
 import com.socrata.soql.exceptions.RightSideOfChainQueryMustBeLeaf
 import com.socrata.soql.typed.Qualifier
-import com.socrata.soql.{BinaryTree, Compound, PipeQuery, SoQLAnalysis}
+import com.socrata.soql.{BinaryTree, Compound, Leaf, PipeQuery, SoQLAnalysis}
 
 import scala.util.parsing.input.NoPosition
 
@@ -25,15 +25,14 @@ object ColumnIdMapper {
         val newQColumnIdToQColumnIdMap = qColumnIdNewColumnIdMap ++ prevQColumnIdToQColumnIdMap
         val rightLeaf = r.asLeaf.getOrElse(throw RightSideOfChainQueryMustBeLeaf(NoPosition))
         val nr = rightLeaf.mapColumnIds(newQColumnIdToQColumnIdMap, qColumnNameToQColumnId, columnNameToNewColumnId, columnIdToNewColumnId)
-        PipeQuery(nl, nr)
+        PipeQuery(nl, Leaf(nr))
       case Compound(op, l, r) =>
         val nl = mapColumnIds(l)(qColumnIdNewColumnIdMap, qColumnNameToQColumnId, columnNameToNewColumnId, columnIdToNewColumnId)
         val nr = mapColumnIds(r)(qColumnIdNewColumnIdMap, qColumnNameToQColumnId, columnNameToNewColumnId, columnIdToNewColumnId)
         Compound(op, nl, nr)
-      case s =>
-        val ana = s.asLeaf.getOrElse(throw RightSideOfChainQueryMustBeLeaf(NoPosition))
+      case Leaf(ana) =>
         val nana = ana.mapColumnIds(qColumnIdNewColumnIdMap, qColumnNameToQColumnId, columnNameToNewColumnId, columnIdToNewColumnId)
-        nana
+        Leaf(nana)
     }
   }
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/typed/CoreExpr.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/typed/CoreExpr.scala
@@ -24,7 +24,7 @@ object CoreExpr {
 }
 
 case class ColumnRef[ColumnId, Type](qualifier: Qualifier, column: ColumnId, typ: Type)(val position: Position) extends CoreExpr[ColumnId, Type] {
-  protected def asString = column.toString
+  protected def asString = qualifier.map(_ + ".").getOrElse("") + column.toString
   def mapColumnIds[NewColumnId](f: (ColumnId, Qualifier) => NewColumnId) = copy(column = f(column, qualifier))
   val size = 0
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/typed/Join.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/typed/Join.scala
@@ -14,7 +14,7 @@ sealed trait Join[ColumnId, Type] {
   def mapColumnIds[NewColumnId](f: (ColumnId, Qualifier) => NewColumnId): Join[NewColumnId, Type] = {
     val mappedSub: Either[TableName, SubAnalysis[NewColumnId, Type]] = from.subAnalysis match {
       case Right(SubAnalysis(analyses, alias)) =>
-        val newAnas = analyses.flatMap(_.mapColumnIds(f))
+        val newAnas = analyses.flatMap { analysis => Leaf(analysis.mapColumnIds(f)) }
         Right(SubAnalysis(newAnas, alias))
       case Left(tableName) =>
         Left(tableName)

--- a/soql-analyzer/src/test/scala/com/socrata/soql/AnalysisSerializationTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/AnalysisSerializationTest.scala
@@ -78,6 +78,12 @@ class AnalysisSerializationTest extends FunSpec with MustMatchers {
     deserializer(new ByteArrayInputStream(baos.toByteArray)) must equal(analysis)
   }
 
+  def testFull(analysis: BinaryTree[Analysis]) = {
+    val baos = new ByteArrayOutputStream
+    serializer.applyBinaryTree(baos, analysis)
+    deserializer.applyBinaryTree(new ByteArrayInputStream(baos.toByteArray)) must equal(analysis)
+  }
+
   def testCompatibilityFull(query: String, v4Serializedb64: String) = {
     val analysis = analyzeFull(query)
     val baos = b64Decoder.decode(v4Serializedb64)

--- a/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerQueryOperatorTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerQueryOperatorTest.scala
@@ -1,0 +1,133 @@
+package com.socrata.soql
+
+import com.socrata.soql.collection.OrderedMap
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.FunSuite
+import org.scalatest.MustMatchers
+import com.socrata.soql.environment.{ColumnName, DatasetContext, TableName}
+import com.socrata.soql.mapping.ColumnIdMapper
+import com.socrata.soql.parsing.{Parser, StandaloneParser}
+import com.socrata.soql.typechecker.Typechecker
+import com.socrata.soql.typed.Qualifier
+import com.socrata.soql.types._
+
+class SoQLAnalyzerQueryOperatorTest extends FunSuite with MustMatchers with PropertyChecks {
+
+  val commonColumns = OrderedMap(
+    ColumnName(":id") -> TestNumber,
+    ColumnName(":updated_at") -> TestFixedTimestamp,
+    ColumnName(":created_at") -> TestFixedTimestamp,
+    ColumnName("name") -> TestText,
+    ColumnName("breed") -> TestText,
+    ColumnName("age") -> TestNumber
+  )
+
+  val catCtx = new DatasetContext[TestType] {
+    val schema = commonColumns + (ColumnName("cat") -> TestText)
+  }
+
+  val dogCtx = new DatasetContext[TestType] {
+    val schema = commonColumns + (ColumnName("dog") -> TestText)
+  }
+
+  val birdCtx = new DatasetContext[TestType] {
+    val schema = commonColumns + (ColumnName("bird") -> TestText)
+  }
+
+  val fishCtx = new DatasetContext[TestType] {
+    val schema = commonColumns + (ColumnName("fish") -> TestText)
+  }
+
+  implicit val datasetCtxMap =
+    Map(TableName.PrimaryTable.qualifier -> catCtx,
+      TableName("_cat", None).qualifier -> catCtx,
+      TableName("_dog", None).qualifier -> dogCtx,
+      TableName("_bird", None).qualifier -> birdCtx,
+      TableName("_fish", None).qualifier -> fishCtx)
+
+  val analyzer = new SoQLAnalyzer(TestTypeInfo, TestFunctionInfo)
+
+  def expression(s: String) = new Parser().expression(s)
+
+  def typedExpression(s: String) = {
+    val tc = new Typechecker(TestTypeInfo, TestFunctionInfo)
+    tc(expression(s), Map.empty)
+  }
+
+  test("Analyze compound queries") {
+    val parser = new StandaloneParser()
+    val soqls = Seq( /* tuple3 of soql, analysis::string, mapped analysis::string */
+      ("SELECT name, @dog.breed join @dog on true",
+       "SELECT Map(name -> name :: text, breed -> _dog.breed :: text) JOIN _dog ON TRUE :: boolean",
+       "SELECT Map(name -> str_cat_name :: text, breed -> _dog.str_dog_breed :: text) JOIN _dog ON TRUE :: boolean"),
+      ("SELECT name, @d1.breed join @dog as d1 on true",
+       "SELECT Map(name -> name :: text, breed -> _d1.breed :: text) JOIN _dog AS d1 ON TRUE :: boolean",
+       "SELECT Map(name -> str_cat_name :: text, breed -> _d1.str_dog_breed :: text) JOIN _dog AS d1 ON TRUE :: boolean"),
+      ("SELECT name, @j1.breed join (select name, breed from @dog) as j1 on true",
+       "SELECT Map(name -> name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> name :: text, breed -> breed :: text) FROM @dog) AS j1 ON TRUE :: boolean",
+       "SELECT Map(name -> str_cat_name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> str_dog_name :: text, breed -> str_dog_breed :: text) FROM @dog) AS j1 ON TRUE :: boolean"),
+      ("SELECT name, @j1.breed join (select @dog.name, @dog.breed from @dog) as j1 on true",
+       "SELECT Map(name -> name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> _dog.name :: text, breed -> _dog.breed :: text) FROM @dog) AS j1 ON TRUE :: boolean",
+       "SELECT Map(name -> str_cat_name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> _dog.str_dog_name :: text, breed -> _dog.str_dog_breed :: text) FROM @dog) AS j1 ON TRUE :: boolean"),
+      ("SELECT name, @j1.breed join (select @d1.name, @d1.breed from @dog as d1) as j1 on true",
+       "SELECT Map(name -> name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> _d1.name :: text, breed -> _d1.breed :: text) FROM @dog AS d1) AS j1 ON TRUE :: boolean",
+       "SELECT Map(name -> str_cat_name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> _d1.str_dog_name :: text, breed -> _d1.str_dog_breed :: text) FROM @dog AS d1) AS j1 ON TRUE :: boolean"),
+      ("SELECT name UNION SELECT name from @dog",
+       "SELECT Map(name -> name :: text) UNION SELECT Map(name -> name :: text) FROM @dog",
+       "SELECT Map(name -> str_cat_name :: text) UNION SELECT Map(name -> str_dog_name :: text) FROM @dog"),
+      ("""
+       SELECT name, @dog.name as dogname, @j2.name as j2catname, @j4.name as j4name,
+              @dog.dog, @j2.cat as j2cat, @j3.cat as j3cat, @j4.bird as j4bird
+         JOIN @dog ON TRUE
+         JOIN @cat as j2 ON TRUE
+         JOIN @cat as j3 ON TRUE
+         JOIN (SELECT @b1.name, @b1.bird FROM @bird as b1
+                UNION
+              (SELECT name, fish, @c2.cat as cat2 FROM @fish JOIN @cat as c2 ON TRUE |> SELECT name, cat2)
+                UNION ALL
+               SELECT @cat.name, @cat.cat FROM @cat) as j4 ON TRUE
+      """,
+       "SELECT Map(name -> name :: text, dogname -> _dog.name :: text, j2catname -> _j2.name :: text, j4name -> _j4.name :: text, dog -> _dog.dog :: text, j2cat -> _j2.cat :: text, j3cat -> _j3.cat :: text, j4bird -> _j4.bird :: text) JOIN _dog ON TRUE :: boolean JOIN _cat AS j2 ON TRUE :: boolean JOIN _cat AS j3 ON TRUE :: boolean JOIN (SELECT Map(name -> _b1.name :: text, bird -> _b1.bird :: text) FROM @bird AS b1 UNION (SELECT Map(name -> name :: text, fish -> fish :: text, cat2 -> _c2.cat :: text) FROM @fish JOIN _cat AS c2 ON TRUE :: boolean |> SELECT Map(name -> name :: text, cat2 -> cat2 :: text)) UNION ALL SELECT Map(name -> _cat.name :: text, cat -> _cat.cat :: text) FROM @cat) AS j4 ON TRUE :: boolean",
+       "SELECT Map(name -> str_cat_name :: text, dogname -> _dog.str_dog_name :: text, j2catname -> _j2.str_cat_name :: text, j4name -> _j4.name :: text, dog -> _dog.str_dog_dog :: text, j2cat -> _j2.str_cat_cat :: text, j3cat -> _j3.str_cat_cat :: text, j4bird -> _j4.bird :: text) JOIN _dog ON TRUE :: boolean JOIN _cat AS j2 ON TRUE :: boolean JOIN _cat AS j3 ON TRUE :: boolean JOIN (SELECT Map(name -> _b1.str_bird_name :: text, bird -> _b1.str_bird_bird :: text) FROM @bird AS b1 UNION (SELECT Map(name -> str_fish_name :: text, fish -> str_fish_fish :: text, cat2 -> _c2.str_cat_cat :: text) FROM @fish JOIN _cat AS c2 ON TRUE :: boolean |> SELECT Map(name -> name :: text, cat2 -> cat2 :: text)) UNION ALL SELECT Map(name -> _cat.str_cat_name :: text, cat -> _cat.str_cat_cat :: text) FROM @cat) AS j4 ON TRUE :: boolean")
+    )
+
+    val qColumnIdNewColumnIdMap = Map(
+      (ColumnName("name"), None) -> "str_cat_name",
+      (ColumnName("cat"), None) -> "str_cat_cat",
+      (ColumnName("breed"), None) -> "str_cat_breed",
+
+      (ColumnName("name"), Some("_cat")) -> "str_cat_name",
+      (ColumnName("cat"), Some("_cat")) -> "str_cat_cat",
+      (ColumnName("breed"), Some("_cat")) -> "str_cat_breed",
+
+      (ColumnName("name"), Some("_dog")) -> "str_dog_name",
+      (ColumnName("dog"), Some("_dog")) -> "str_dog_dog",
+      (ColumnName("breed"), Some("_dog")) -> "str_dog_breed",
+
+      (ColumnName("name"), Some("_bird")) -> "str_bird_name",
+      (ColumnName("bird"), Some("_bird")) -> "str_bird_bird",
+      (ColumnName("breed"), Some("_bird")) -> "str_bird_breed",
+
+      (ColumnName("name"), Some("_fish")) -> "str_fish_name",
+      (ColumnName("fish"), Some("_fish")) -> "str_fish_fish",
+      (ColumnName("breed"), Some("_fish")) -> "str_fish_breed"
+    )
+    val qColumnNameToQColumnId = (q: Qualifier, cn: ColumnName) => (cn, q)
+    val columnNameToNewColumnId = (cn: ColumnName) => cn.name
+    val columnIdToNewColumnId = (cn: ColumnName) => cn.name
+
+    val serializerTest = new AnalysisSerializationTest()
+
+    soqls.foreach {
+      case (soql, expectedAnalysis, expectedMappedAnalysis) =>
+      val ast = parser.binaryTreeSelect(soql)
+      val analysis = analyzer.analyzeBinary(ast)(datasetCtxMap)
+      analysis.toString must equal(expectedAnalysis)
+      // test mapColumnIds
+      val mappedAnalysis = ColumnIdMapper.mapColumnIds(analysis)(qColumnIdNewColumnIdMap, qColumnNameToQColumnId, columnNameToNewColumnId, columnIdToNewColumnId)
+      mappedAnalysis.toString must equal(expectedMappedAnalysis)
+      // test analysis serialization
+      serializerTest.testFull(analysis)
+    }
+  }
+}

--- a/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerQueryOperatorTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerQueryOperatorTest.scala
@@ -40,10 +40,10 @@ class SoQLAnalyzerQueryOperatorTest extends FunSuite with MustMatchers with Prop
 
   implicit val datasetCtxMap =
     Map(TableName.PrimaryTable.qualifier -> catCtx,
-      TableName("_cat", None).qualifier -> catCtx,
-      TableName("_dog", None).qualifier -> dogCtx,
-      TableName("_bird", None).qualifier -> birdCtx,
-      TableName("_fish", None).qualifier -> fishCtx)
+        TableName("_cat", None).qualifier -> catCtx,
+        TableName("_dog", None).qualifier -> dogCtx,
+        TableName("_bird", None).qualifier -> birdCtx,
+        TableName("_fish", None).qualifier -> fishCtx)
 
   val analyzer = new SoQLAnalyzer(TestTypeInfo, TestFunctionInfo)
 

--- a/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
@@ -207,8 +207,8 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with PropertyChecks {
 
   test("a subselect makes the output of the inner select available to the outer") {
     val PipeQuery(inner, outer) = analyzer.analyzeFullQueryBinary("select 5 :: money as x |> select max(x)")
-    outer.asLeaf.selection(ColumnName("max_x")) must equal (typed.FunctionCall(MonomorphicFunction(TestFunctions.Max, Map("a" -> TestMoney)), Seq(typed.ColumnRef(None, ColumnName("x"), TestMoney : TestType)(NoPosition)), None)(NoPosition, NoPosition))
-    inner.asLeaf.selection(ColumnName("x")) must equal (typed.FunctionCall(TestFunctions.castIdentities.find(_.result == functions.FixedType(TestMoney)).get.monomorphic.get,
+    outer.asLeaf.get.selection(ColumnName("max_x")) must equal (typed.FunctionCall(MonomorphicFunction(TestFunctions.Max, Map("a" -> TestMoney)), Seq(typed.ColumnRef(None, ColumnName("x"), TestMoney : TestType)(NoPosition)), None)(NoPosition, NoPosition))
+    inner.asLeaf.get.selection(ColumnName("x")) must equal (typed.FunctionCall(TestFunctions.castIdentities.find(_.result == functions.FixedType(TestMoney)).get.monomorphic.get,
       Seq(typed.FunctionCall(TestFunctions.NumberToMoney.monomorphic.get, Seq(typed.NumberLiteral(java.math.BigDecimal.valueOf(5), TestNumber.t)(NoPosition)), None)(NoPosition, NoPosition)), None)(NoPosition, NoPosition))
   }
 
@@ -471,14 +471,14 @@ SELECT visits, @x3.x
        ) as x3 on @x3.x = name_first
       """)
 
-    val innermostJoins = analysis.joins.head.from.subAnalysis.right.get.analyses.asLeaf.joins
-    val innermostAnalysis = innermostJoins.head.from.subAnalysis.right.get.analyses.asLeaf
+    val innermostJoins = analysis.joins.head.from.subAnalysis.right.get.analyses.asLeaf.get.joins
+    val innermostAnalysis = innermostJoins.head.from.subAnalysis.right.get.analyses.asLeaf.get
     innermostAnalysis.selection.toSeq must equal (Seq(
       ColumnName("x") -> ColumnRef(Some("_x1"), ColumnName("x"), TestText)(NoPosition)
     ))
 
     val joins = analysis.joins
-    val joinAnalysis = joins.head.from.subAnalysis.right.get.analyses.asLeaf
+    val joinAnalysis = joins.head.from.subAnalysis.right.get.analyses.asLeaf.get
     joinAnalysis.selection.toSeq must equal (Seq(
       ColumnName("x") -> ColumnRef(Some("_x2"), ColumnName("x"), TestText)(NoPosition),
       ColumnName("name_first") -> ColumnRef(Some("_a1"), ColumnName("name_first"), TestText)(NoPosition)
@@ -498,13 +498,13 @@ SELECT visits, @x2.zx
        ) as x2 on @x2.zx = name_first
       """)
 
-    val innermostLeftOuterJoin = analysis.joins.head.from.analyses.get.asLeaf.joins
-    val innermostAnalysis = innermostLeftOuterJoin.head.from.analyses.get.asLeaf
+    val innermostLeftOuterJoin = analysis.joins.head.from.analyses.get.asLeaf.get.joins
+    val innermostAnalysis = innermostLeftOuterJoin.head.from.analyses.get.asLeaf.get
     innermostAnalysis.selection.toSeq must equal (Seq(
       ColumnName("x") -> ColumnRef(Some("_x1"), ColumnName("x"), TestText)(NoPosition)
     ))
 
-    val rightOuterJoinAnalysis = analysis.joins.head.from.analyses.get.asLeaf
+    val rightOuterJoinAnalysis = analysis.joins.head.from.analyses.get.asLeaf.get
     rightOuterJoinAnalysis.selection.toSeq must equal (Seq(
       ColumnName("zx") -> ColumnRef(Some("_x2"), ColumnName("x"), TestText)(NoPosition)
     ))

--- a/soql-standalone-parser/src/main/jflex/SoQLLexer.flex
+++ b/soql-standalone-parser/src/main/jflex/SoQLLexer.flex
@@ -82,6 +82,14 @@ TableIdentifier = "@" ("-" | [:jletterdigit:])+
   // Query chaining
   "|>"  { return token(new QUERYPIPE()); }
 
+  "UNION" { return token(new QUERYUNION()); }
+  "INTERSECT"  { return token(new QUERYINTERSECT()); }
+  "MINUS"  { return token(new QUERYMINUS()); }
+
+  "UNION" {WhiteSpace}+ "ALL" { return token(new QUERYUNIONALL()); }
+  "INTERSECT" {WhiteSpace}+ "ALL" { return token(new QUERYINTERSECTALL()); }
+  "MINUS" {WhiteSpace}+ "ALL" { return token(new QUERYMINUSALL()); }
+
   // Subscripting
   // "." share with qualifying
   "["   { return token(new LBRACKET()); }

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/BinaryTree.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/BinaryTree.scala
@@ -113,4 +113,6 @@ case class MinusQuery[T](left: BinaryTree[T], right: BinaryTree[T]) extends Comp
   val op = Compound.Minus
 }
 
-case class Leaf[T](leaf: T) extends BinaryTree[T]
+case class Leaf[T](leaf: T) extends BinaryTree[T] {
+  override def toString: String = leaf.toString
+}

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/BinaryTree.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/BinaryTree.scala
@@ -31,13 +31,19 @@ trait BinaryTree[T] {
 }
 
 object Compound {
+  val QueryPipe = "QUERYPIPE"
+  val Union = "UNION"
+  val UnionAll = "UNION ALL"
+  val Intersect = "INTERSECT"
+  val Minus = "MINUS"
+
   def apply[T](op: String, left: BinaryTree[T], right: BinaryTree[T]): Compound[T] = {
     op match {
-      case "QUERYPIPE" => PipeQuery(left, right)
-      case "UNION" => UnionQuery(left, right)
-      case "UNION ALL" => UnionAllQuery(left, right)
-      case "INTERSECT" => IntersectQuery(left, right)
-      case "MINUS" => MinusQuery(left, right)
+      case QueryPipe => PipeQuery(left, right)
+      case Union => UnionQuery(left, right)
+      case UnionAll => UnionAllQuery(left, right)
+      case Intersect => IntersectQuery(left, right)
+      case Minus => MinusQuery(left, right)
     }
   }
 
@@ -46,7 +52,9 @@ object Compound {
   }
 }
 
-abstract class Compound[T](val op: String) extends BinaryTree[T] {
+sealed trait Compound[T] extends BinaryTree[T] {
+
+  val op: String
 
   val left: BinaryTree[T]
 
@@ -83,11 +91,26 @@ abstract class Compound[T](val op: String) extends BinaryTree[T] {
   }
 }
 
-case class PipeQuery[T](left: BinaryTree[T], right: BinaryTree[T]) extends Compound[T]("QUERYPIPE") {
+case class PipeQuery[T](left: BinaryTree[T], right: BinaryTree[T]) extends Compound[T]() {
   override def opString: String = "|>"
+
+  val op = Compound.QueryPipe
 }
 
-case class UnionQuery[T](left: BinaryTree[T], right: BinaryTree[T]) extends Compound[T]("UNION")
-case class UnionAllQuery[T](left: BinaryTree[T], right: BinaryTree[T]) extends Compound[T]("UNION ALL")
-case class IntersectQuery[T](left: BinaryTree[T], right: BinaryTree[T]) extends Compound[T]("INTERSECT")
-case class MinusQuery[T](left: BinaryTree[T], right: BinaryTree[T]) extends Compound[T]("MINUS")
+case class UnionQuery[T](left: BinaryTree[T], right: BinaryTree[T]) extends Compound[T]() {
+  val op = Compound.Union
+}
+
+case class UnionAllQuery[T](left: BinaryTree[T], right: BinaryTree[T]) extends Compound[T]() {
+  val op = Compound.UnionAll
+}
+
+case class IntersectQuery[T](left: BinaryTree[T], right: BinaryTree[T]) extends Compound[T]() {
+  val op = Compound.Intersect
+}
+
+case class MinusQuery[T](left: BinaryTree[T], right: BinaryTree[T]) extends Compound[T]() {
+  val op = Compound.Minus
+}
+
+case class Leaf[T](leaf: T) extends BinaryTree[T]

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/BinaryTree.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/BinaryTree.scala
@@ -1,6 +1,6 @@
 package com.socrata.soql
 
-trait BinaryTree[T] {
+sealed trait BinaryTree[T] {
 
   def seq: Seq[T] = {
     asLeaf.toSeq
@@ -18,7 +18,7 @@ trait BinaryTree[T] {
   def asLeaf: Option[T] = {
     this match {
       case _: Compound[T] => None
-      case t: T @unchecked => Some(t)
+      case Leaf(t) => Some(t)
     }
   }
 

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/BinaryTree.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/BinaryTree.scala
@@ -22,12 +22,7 @@ sealed trait BinaryTree[T] {
     }
   }
 
-  def flatMap[B](transform: T => BinaryTree[B]): BinaryTree[B] = {
-    asLeaf match {
-      case Some(t) => transform(t)
-      case None => ???
-    }
-  }
+  def flatMap[B](transform: T => BinaryTree[B]): BinaryTree[B]
 }
 
 object Compound {
@@ -64,7 +59,7 @@ sealed trait Compound[T] extends BinaryTree[T] {
     left.seq ++ right.seq
   }
 
-  override def flatMap[B](transform: T => BinaryTree[B]): BinaryTree[B] = {
+  def flatMap[B](transform: T => BinaryTree[B]): BinaryTree[B] = {
     val nl = left.flatMap(transform)
     val nr = right.flatMap(transform)
     Compound(this.op, left = nl, right = nr)
@@ -115,4 +110,8 @@ case class MinusQuery[T](left: BinaryTree[T], right: BinaryTree[T]) extends Comp
 
 case class Leaf[T](leaf: T) extends BinaryTree[T] {
   override def toString: String = leaf.toString
+
+  def flatMap[B](transform: T => BinaryTree[B]): BinaryTree[B] = {
+    transform(leaf)
+  }
 }

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/BinaryTree.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/BinaryTree.scala
@@ -1,0 +1,90 @@
+package com.socrata.soql
+
+trait BinaryTree[+T] {
+
+  def seq: Seq[T] = {
+    Seq(asLeaf)
+  }
+
+  /**
+   * output schema
+   */
+  def previous: T = {
+    asLeaf
+  }
+
+  def last: T = asLeaf
+
+  def asLeaf: T = {
+    this match {
+      case _: Compound[T] => ???
+      case t: T @unchecked => t
+    }
+  }
+
+  def flatMap[B](transform: T => BinaryTree[B]): BinaryTree[B] = {
+    transform(asLeaf)
+  }
+}
+
+object Compound {
+  def apply[T](op: String, left: BinaryTree[T], right: BinaryTree[T]): Compound[T] = {
+    op match {
+      case "QUERYPIPE" => PipeQuery(left, right)
+      case "UNION" => UnionQuery(left, right)
+      case "UNION ALL" => UnionAllQuery(left, right)
+      case "INTERSECT" => IntersectQuery(left, right)
+      case "MINUS" => MinusQuery(left, right)
+    }
+  }
+
+  def unapply[T](arg: Compound[T]): Option[(String, BinaryTree[T], BinaryTree[T])] = {
+    Some(arg.op, arg.left, arg.right)
+  }
+}
+
+abstract class Compound[T](val op: String) extends BinaryTree[T] {
+
+  val left: BinaryTree[T]
+
+  val right: BinaryTree[T]
+
+  override def seq: Seq[T] = {
+    left.seq ++ right.seq
+  }
+
+  override def flatMap[B](transform: T => BinaryTree[B]): BinaryTree[B] = {
+    val nl = left.flatMap(transform)
+    val nr = right.flatMap(transform)
+    Compound(this.op, left = nl, right = nr)
+  }
+
+  override def previous: T = {
+    this match {
+      case PipeQuery(_, r) =>
+        r.previous
+      case Compound(_, l, _) =>
+        l.previous
+    }
+  }
+
+  override def last: T = {
+    right.last
+  }
+
+  def opString: String = op
+
+  override def toString: String = {
+    if (right.isInstanceOf[Compound[T]]) s"${left.toString} $opString (${right.toString})"
+    else s"${left.toString} $opString ${right.toString}"
+  }
+}
+
+case class PipeQuery[T](left: BinaryTree[T], right: BinaryTree[T]) extends Compound[T]("QUERYPIPE") {
+  override def opString: String = "|>"
+}
+
+case class UnionQuery[T](left: BinaryTree[T], right: BinaryTree[T]) extends Compound[T]("UNION")
+case class UnionAllQuery[T](left: BinaryTree[T], right: BinaryTree[T]) extends Compound[T]("UNION ALL")
+case class IntersectQuery[T](left: BinaryTree[T], right: BinaryTree[T]) extends Compound[T]("INTERSECT")
+case class MinusQuery[T](left: BinaryTree[T], right: BinaryTree[T]) extends Compound[T]("MINUS")

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/BinaryTree.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/BinaryTree.scala
@@ -1,29 +1,32 @@
 package com.socrata.soql
 
-trait BinaryTree[+T] {
+trait BinaryTree[T] {
 
   def seq: Seq[T] = {
-    Seq(asLeaf)
+    asLeaf.toSeq
   }
 
   /**
-   * output schema
+   * return: the leaf node of the ultimate schema that this subtree will produce
    */
-  def previous: T = {
-    asLeaf
+  def outputSchemaLeaf: T = {
+    asLeaf.get
   }
 
-  def last: T = asLeaf
+  def last: T = asLeaf.get
 
-  def asLeaf: T = {
+  def asLeaf: Option[T] = {
     this match {
-      case _: Compound[T] => ???
-      case t: T @unchecked => t
+      case _: Compound[T] => None
+      case t: T @unchecked => Some(t)
     }
   }
 
   def flatMap[B](transform: T => BinaryTree[B]): BinaryTree[B] = {
-    transform(asLeaf)
+    asLeaf match {
+      case Some(t) => transform(t)
+      case None => ???
+    }
   }
 }
 
@@ -59,12 +62,12 @@ abstract class Compound[T](val op: String) extends BinaryTree[T] {
     Compound(this.op, left = nl, right = nr)
   }
 
-  override def previous: T = {
+  override def outputSchemaLeaf: T = {
     this match {
       case PipeQuery(_, r) =>
-        r.previous
+        r.outputSchemaLeaf
       case Compound(_, l, _) =>
-        l.previous
+        l.outputSchemaLeaf
     }
   }
 

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
@@ -3,7 +3,7 @@ package com.socrata.soql.ast
 import scala.util.parsing.input.{NoPosition, Position}
 import com.socrata.soql.environment._
 import Select._
-import com.socrata.soql.{BinaryTree, Compound, PipeQuery}
+import com.socrata.soql.{BinaryTree, Compound, Leaf, PipeQuery}
 
 /**
   * A SubSelect represents (potentially chained) soql that is required to have an alias
@@ -75,7 +75,7 @@ object Select {
         val ls = Select.toString(l)
         val rs = Select.toString(r)
         s"$ls $op $rs"
-      case select: Select =>
+      case Leaf(select) =>
         select.toString
     }
   }

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
@@ -109,7 +109,7 @@ case class Select(
   orderBys: Seq[OrderBy],
   limit: Option[BigInt],
   offset: Option[BigInt],
-  search: Option[String]) extends BinaryTree[Select] {
+  search: Option[String]) {
 
   private def toString(from: Option[TableName]): String = {
     if(AST.pretty) {

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/mapping/ColumnNameMapper.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/mapping/ColumnNameMapper.scala
@@ -2,7 +2,7 @@ package com.socrata.soql.mapping
 
 import com.socrata.soql.ast._
 import com.socrata.soql.environment.ColumnName
-import com.socrata.soql.{BinaryTree, Compound, PipeQuery}
+import com.socrata.soql.{BinaryTree, Compound, PipeQuery, Leaf}
 
 import scala.util.parsing.input.{NoPosition, Position}
 
@@ -27,8 +27,8 @@ class ColumnNameMapper(columnNameMap: Map[ColumnName, ColumnName]) {
         val nl = mapSelect(l)
         val nr = mapSelect(r)
         Compound(op, nl, nr)
-      case h: Select =>
-        Select(
+      case Leaf(h) =>
+        Leaf(Select(
           distinct = h.distinct,
           selection = mapSelection(h.selection),
           from = h.from,
@@ -40,7 +40,7 @@ class ColumnNameMapper(columnNameMap: Map[ColumnName, ColumnName]) {
           limit = h.limit,
           offset = h.offset,
           search = h.search
-        )
+        ))
     }
   }
 

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
@@ -5,7 +5,7 @@ import com.socrata.NonEmptySeq
 import scala.reflect.ClassTag
 import scala.util.parsing.combinator.{PackratParsers, Parsers}
 import util.parsing.input.Position
-import com.socrata.soql.{ast, tokens}
+import com.socrata.soql.{BinaryTree, Compound, ast, tokens}
 import com.socrata.soql.tokens._
 import com.socrata.soql.ast._
 import com.socrata.soql.environment.{ColumnName, FunctionName, TableName, TypeName}
@@ -19,6 +19,8 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
   import parameters._
 
   type Elem = Token
+
+  def binaryTreeSelect(soql: String) = parseFull(compoundSelect, soql)
 
   /*
    *               *************
@@ -107,10 +109,14 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
   def ifCanJoinList[T](p: Parser[List[T]]) = ifCanJoin(p).map(_.getOrElse(Nil))
 
   val select: Parser[Select] = {
-    SELECT() ~> distinct ~ selectList ~ ifCanJoinList(joinList) ~ opt(whereClause) ~
+    SELECT() ~> distinct ~ selectList ~ opt((FROM() ~> tableIdentifier) ~ opt(AS() ~> simpleIdToAlias)) ~ ifCanJoinList(joinList) ~ opt(whereClause) ~
       opt(groupByClause) ~ opt(havingClause) ~ orderByAndSearch ~ limitOffset ^^ {
-      case d ~ s ~ j ~ w ~ gb ~ h ~ ((ord, sr)) ~ ((lim, off)) =>
-        Select(d, s, j, w, gb.getOrElse(Nil), h, ord, lim, off, sr)
+      case d ~ s ~ optFrom ~ j ~ w ~ gb ~ h ~ ((ord, sr)) ~ ((lim, off)) =>
+        val optTableName = optFrom.map {
+          case ((t: String, _) ~ a) =>
+            TableName(t, a)
+        }
+        Select(d, s, optTableName, j, w, gb.getOrElse(Nil), h, ord, lim, off, sr)
     }
   }
 
@@ -133,6 +139,27 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
       case other =>
         sys.error("Cannot happen, we only accept unquoted identifiers in this rule")
     }
+
+  val query_op = QUERYPIPE() |
+    QUERYUNION() | QUERYINTERSECT() | QUERYMINUS() |
+    QUERYUNIONALL() | QUERYINTERSECTALL() | QUERYMINUSALL()
+
+  def parenSelect: Parser[BinaryTree[Select]] =
+    LPAREN() ~> compoundSelect <~ RPAREN() ^^ { s => s }
+
+  lazy val compoundSelect: PackratParser[BinaryTree[Select]] =
+    opt(compoundSelect ~ query_op) ~ atomSelect ^^ {
+      case None ~ a =>
+        a
+      case Some(a ~ op) ~ b =>
+        Compound(op.printable, a, b)
+    }
+
+
+  def atomSelect =
+    select |
+      parenSelect |
+      failure(errors.missingExpr)
 
   val tableIdentifier: Parser[(String, Position)] =
     accept[tokens.TableIdentifier] ^^ { t =>
@@ -167,22 +194,14 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
     case (alias, _) => TableName.withSodaFountainPrefix(alias)
   }
 
-  val selectFrom: Parser[(TableName, Select)] = {
-    SELECT() ~> distinct ~ selectList ~ (FROM() ~> tableIdentifier) ~ opt(AS() ~> simpleIdToAlias) ~ ifCanJoinList(joinList) ~ opt(whereClause) ~
-      opt(groupByClause) ~ opt(havingClause) ~ orderByAndSearch ~ limitOffset ^^ {
-      case d ~ s ~ ((t: String, _)) ~ a ~ j ~ w ~ gb ~ h ~ ((ord, sr)) ~ ((lim, off)) =>
-        (TableName(t, a), Select(d, s, j, w, gb.getOrElse(Nil), h, ord, lim, off, sr))
-    }
-  }
-
   val joinSelect: Parser[JoinSelect] = {
     tableIdentifier ~ opt(AS() ~> simpleIdToAlias) ^^ {
       case ((tid: String, _)) ~ alias =>
-        JoinSelect(TableName(tid, alias), None)
+        JoinSelect(Left(TableName(tid, alias)))
     } |
-    LPAREN() ~> selectFrom ~ opt(QUERYPIPE() ~> pipedSelect) ~ (RPAREN() ~> AS() ~> simpleIdToAlias) ^^ {
-      case ((tn, s)) ~ chainedQueries ~ alias =>
-        JoinSelect(tn, Some(SubSelect(NonEmptySeq(s, chainedQueries.map(_.seq).getOrElse(Seq.empty)), alias)))
+    atomSelect ~ ( AS() ~> simpleIdToAlias) ^^ {
+      case queries ~ alias =>
+        JoinSelect(Right(SubSelect(queries, alias)))
     }
   }
 

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
@@ -5,7 +5,7 @@ import com.socrata.NonEmptySeq
 import scala.reflect.ClassTag
 import scala.util.parsing.combinator.{PackratParsers, Parsers}
 import util.parsing.input.Position
-import com.socrata.soql.{BinaryTree, Compound, PipeQuery, ast, tokens}
+import com.socrata.soql.{BinaryTree, Compound, Leaf, PipeQuery, ast, tokens}
 import com.socrata.soql.tokens._
 import com.socrata.soql.ast._
 import com.socrata.soql.environment.{ColumnName, FunctionName, TableName, TypeName}
@@ -156,7 +156,7 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
       case Some(a ~ op) ~ b if op == QUERYPIPE() =>
         b.asLeaf match {
           case Some(leaf) =>
-            PipeQuery(a, leaf)
+            PipeQuery(a, Leaf(leaf))
           case None =>
             badParse(errors.leafQueryOnTheRightExpected, op.position)
         }
@@ -164,8 +164,8 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
         Compound(op.printable, a, b)
     }
 
-  def atomSelect =
-    select |
+  def atomSelect: Parser[BinaryTree[Select]] =
+    (select ^^ { s => Leaf(s) }) |
       parenSelect |
       failure(errors.missingQuery)
 

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/tokens/Tokens.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/tokens/Tokens.scala
@@ -47,6 +47,13 @@ case class DESC() extends Token with OrderDirection
 // Query chaining
 case class QUERYPIPE() extends Token
 
+case class QUERYUNION() extends FormattedToken("UNION")
+case class QUERYINTERSECT() extends FormattedToken("INTERSECT")
+case class QUERYMINUS() extends FormattedToken("MINUS")
+case class QUERYUNIONALL() extends FormattedToken("UNION ALL")
+case class QUERYINTERSECTALL() extends FormattedToken("INTERSECT ALL")
+case class QUERYMINUSALL() extends FormattedToken("MINUS ALL")
+
 // Subscripting
 // DOT() share with qualifying
 case class LBRACKET() extends FormattedToken("[")

--- a/soql-standalone-parser/src/test/scala/com/socrata/soql/BinaryTreeSelectTest.scala
+++ b/soql-standalone-parser/src/test/scala/com/socrata/soql/BinaryTreeSelectTest.scala
@@ -9,14 +9,14 @@ class BinaryTreeSelectTest extends FunSpec with MustMatchers {
     it("of pipe is the right query") {
       val soql = "SELECT 1 as a |> SELECT 2 as b"
       val selects = parser.binaryTreeSelect(soql)
-      val columnName = selects.previous.asLeaf.selection.expressions.head.name.get._1.name
+      val columnName = selects.outputSchemaLeaf.asLeaf.get.selection.expressions.head.name.get._1.name
       columnName must be("b")
     }
 
     it("of union is the left query") {
       val soql = "SELECT 1 as a UNION SELECT 2 as b"
       val selects = parser.binaryTreeSelect(soql)
-      val columnName = selects.previous.asLeaf.selection.expressions.head.name.get._1.name
+      val columnName = selects.outputSchemaLeaf.asLeaf.get.selection.expressions.head.name.get._1.name
       columnName must be("a")
     }
   }

--- a/soql-standalone-parser/src/test/scala/com/socrata/soql/BinaryTreeSelectTest.scala
+++ b/soql-standalone-parser/src/test/scala/com/socrata/soql/BinaryTreeSelectTest.scala
@@ -1,0 +1,31 @@
+package com.socrata.soql.parsing
+
+import org.scalatest.{FunSpec, MustMatchers}
+
+class BinaryTreeSelectTest extends FunSpec with MustMatchers {
+  val parser = new StandaloneParser()
+
+  describe("Previous") {
+    it("of pipe is the right query") {
+      val soql = "SELECT 1 as a |> SELECT 2 as b"
+      val selects = parser.binaryTreeSelect(soql)
+      val columnName = selects.previous.asLeaf.selection.expressions.head.name.get._1.name
+      columnName must be("b")
+    }
+
+    it("of union is the left query") {
+      val soql = "SELECT 1 as a UNION SELECT 2 as b"
+      val selects = parser.binaryTreeSelect(soql)
+      val columnName = selects.previous.asLeaf.selection.expressions.head.name.get._1.name
+      columnName must be("a")
+    }
+  }
+
+  describe("Seq") {
+    it("of pipe is the right query") {
+      val soql = "SELECT 1 as a |> SELECT 2 as b |> SELECT 3 as c"
+      val selects = parser.binaryTreeSelect(soql)
+      selects.seq.map(_.toString) must be (Seq("SELECT 1 AS a", "SELECT 2 AS b", "SELECT 3 AS c"))
+    }
+  }
+}

--- a/soql-standalone-parser/src/test/scala/com/socrata/soql/BinaryTreeSelectTest.scala
+++ b/soql-standalone-parser/src/test/scala/com/socrata/soql/BinaryTreeSelectTest.scala
@@ -9,14 +9,14 @@ class BinaryTreeSelectTest extends FunSpec with MustMatchers {
     it("of pipe is the right query") {
       val soql = "SELECT 1 as a |> SELECT 2 as b"
       val selects = parser.binaryTreeSelect(soql)
-      val columnName = selects.outputSchemaLeaf.asLeaf.get.selection.expressions.head.name.get._1.name
+      val columnName = selects.outputSchemaLeaf.selection.expressions.head.name.get._1.name
       columnName must be("b")
     }
 
     it("of union is the left query") {
       val soql = "SELECT 1 as a UNION SELECT 2 as b"
       val selects = parser.binaryTreeSelect(soql)
-      val columnName = selects.outputSchemaLeaf.asLeaf.get.selection.expressions.head.name.get._1.name
+      val columnName = selects.outputSchemaLeaf.selection.expressions.head.name.get._1.name
       columnName must be("a")
     }
   }

--- a/soql-standalone-parser/src/test/scala/com/socrata/soql/parsing/ParserTest.scala
+++ b/soql-standalone-parser/src/test/scala/com/socrata/soql/parsing/ParserTest.scala
@@ -277,6 +277,17 @@ class ParserTest extends WordSpec with MustMatchers {
       expectFailure("Expression expected", "select avg(x) over(order by m nulls last)")
     }
 
+    "reject pipe query where right side is not a leaf." in {
+      val parser = new StandaloneParser()
+      try {
+        parser.binaryTreeSelect("SELECT 1 |> (SELECT 2 UNION SELECT 3 FROM @t2 )")
+        fail("Unexpected success")
+      } catch {
+        case e: BadParse =>
+          e.message must equal (parser.errors.leafQueryOnTheRightExpected)
+      }
+    }
+
     // def show[T](x: => T) {
     //   try {
     //     println(x)

--- a/soql-standalone-parser/src/test/scala/com/socrata/soql/parsing/ToStringTest.scala
+++ b/soql-standalone-parser/src/test/scala/com/socrata/soql/parsing/ToStringTest.scala
@@ -149,7 +149,7 @@ class ToStringTest extends FunSpec with MustMatchers {
     it("chains, unions, joins round trip") {
       val soqls = Seq(
         "SELECT 1 |> SELECT 2 |> SELECT 3",
-        "SELECT 1 |> SELECT 2 |> (SELECT 3 |> SELECT 4 |> SELECT 5 |> SELECT 6)",
+        "SELECT 1 |> SELECT 2 UNION (SELECT 3 |> SELECT 4 |> SELECT 5 |> SELECT 6)",
         "SELECT 1 UNION (SELECT 2 UNION ALL (SELECT 3 UNION SELECT 4) UNION SELECT 5) UNION SELECT 6",
         "SELECT `x`, @a.`a1`, @jb.`b1`, @jcd.`c1` JOIN @a ON TRUE JOIN (SELECT @b.`b1` FROM @b) AS jb ON TRUE JOIN (SELECT @cc.`c1` FROM @c AS cc UNION SELECT `d1` FROM @d) AS jcd ON TRUE |> SELECT `x`, `c1`, 1 + 2 ORDER BY `x` ASC NULL LAST, `c1` ASC NULL LAST"
       )

--- a/soql-toy/src/main/scala/com/socrata/soql/AliasToy.scala
+++ b/soql-toy/src/main/scala/com/socrata/soql/AliasToy.scala
@@ -29,7 +29,7 @@ object AliasToy extends (Array[String] => Unit) {
       val selection = readLine("> ")
       if(selection == null) return;
       try {
-        val analysis = AliasAnalysis(p.selection(selection))
+        val analysis = AliasAnalysis(p.selection(selection), None)
         println("Resulting aliases:")
         Util.printList(analysis.expressions, "  ")
         println(analysis.evaluationOrder.mkString("Typecheck in this order:\n  ", ", ", ""))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.0.0-SNAPSHOT"
+version in ThisBuild := "3.0.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.16.6"
+version in ThisBuild := "3.0.0-SNAPSHOT"


### PR DESCRIPTION
Anlaysis

Third approach - binary tree

upgrade analysis from from string to table name

Serializer version

Update serializer

Rightmost

more for rollup

It is previous instead of rightmost

Fix Seq to binary

Must be depth first

Previous

Soqlmerge

Rename function

Fixed tree previous

Further subclass compound

Fix serialization test

Soql merge

Typo PIPEQUERY

Unions in joins

Change join analysis

join+union remapAnalysis

Join - convert from to default _

Handle select *

Fix AliasAnalysis - join (select d1.field from @dog as d1)

Serializer missing something

Scala 2.10 compatibility - Either does not have map until 2.12

Join toString

Column name mapper