### PR TITLE
EN-44901: Make from (via this alias) context available to lateral join

### DIFF
--- a/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
@@ -671,10 +671,10 @@ SELECT visits, @x2.zx
       ColumnName("x") -> ColumnRef(Some("_j"), ColumnName("x"), TestText)(NoPosition)
     ))
 
+    // Analyze again with "lateral" removed and t1 is no longer in the join scope.
     val noSuchTable = intercept[NoSuchTable] {
       analyzer.analyzeFullQueryBinary(soql.replace("LATERAL", ""))
     }
-
     noSuchTable.getMessage must startWith("No such table `_t1'")
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.2.2"
+version in ThisBuild := "3.3.0"


### PR DESCRIPTION
Make from context available to lateral join (previously only contexts from preceding joins are available)