### PR TITLE
Add a `single_row` predefined alias

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
@@ -349,6 +349,8 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type],
 
   private def aliasContext(tableName: Option[TableName], ctx: AnalysisContext): AnalysisContext = {
     tableName match {
+      case Some(TableName(TableName.SingleRow, alias)) =>
+        Map(alias.getOrElse(TableName.SingleRow) -> DatasetContext.empty[Type])
       case Some(TableName(name, Some(alias))) =>
         val name1 = if (name == TableName.This) TableName.PrimaryTable.qualifier else name
         Map(alias -> ctx(name1))
@@ -602,7 +604,7 @@ case class SoQLAnalysis[ColumnId, Type](isGrouped: Boolean,
                                 columnNameToNewColumnId: ColumnName => NewColumnId,
                                 columnIdToNewColumnId: ColumnId => NewColumnId): SoQLAnalysis[NewColumnId, Type] = {
 
-    lazy val columnsByQualifier = qColumnIdNewColumnIdMap.groupBy(_._1._2)
+    lazy val columnsByQualifier = qColumnIdNewColumnIdMap.groupBy(_._1._2) + (Some(TableName.SingleRow) -> Map.empty)
 
     val qColumnIdNewColumnIdMapWithFrom = this.from.foldLeft(qColumnIdNewColumnIdMap) { (acc, tableName) =>
       val qual = tableName match {

--- a/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
@@ -209,14 +209,25 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type],
     analyzeNoSelection(distinct, joins, where, groupBys, having, orderBys, limit, offset, search)
   }
 
+  private def validateAlias(alias: String): Unit = {
+    if(TableName.reservedNames(alias)) {
+      // ugh, but the way joins are structured threading the position
+      // of the alias through is tricky without major surgery.  Maybe
+      // this can get better later.
+      throw ReservedTableAlias(alias, NoPosition)
+    }
+  }
+
   private def joinCtx(joins: Seq[Join], parentFromContext: Map[Qualifier, DatasetContext[Type]])(implicit ctx: AnalysisContext): AnalysisContext = {
     joins.foldLeft(parentFromContext) { (acc, join) =>
       val jCtx = if (join.lateral) ctx ++ acc else ctx
       join.from match {
         case JoinSelect(Right(SubSelect(selects, alias))) =>
+          validateAlias(alias)
           val analyses = analyzeBinary(selects)(jCtx)
           acc + contextFromAnalysis(alias, analyses.outputSchema.leaf)
         case JoinSelect(Left(tn@TableName(name, Some(alias)))) =>
+          validateAlias(alias)
           acc ++ aliasContext(tn, jCtx)
         case _ =>
           acc
@@ -350,8 +361,10 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type],
   private def aliasContext(tableName: Option[TableName], ctx: AnalysisContext): AnalysisContext = {
     tableName match {
       case Some(TableName(TableName.SingleRow, alias)) =>
+        alias.foreach(validateAlias(_))
         Map(alias.getOrElse(TableName.SingleRow) -> DatasetContext.empty[Type])
       case Some(TableName(name, Some(alias))) =>
+        validateAlias(alias)
         val name1 = if (name == TableName.This) TableName.PrimaryTable.qualifier else name
         Map(alias -> ctx(name1))
       case Some(tn@TableName(name, None)) =>
@@ -361,8 +374,8 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type],
     }
   }
 
-  private def aliasContext(tableName: TableName, ctx: AnalysisContext): AnalysisContext = {
-    aliasContext(Some(tableName), ctx)
+  private def aliasContext(from: TableName, ctx: AnalysisContext): AnalysisContext = {
+    aliasContext(Some(from), ctx)
   }
 
   def analyzeWithSelection(query: Select)(implicit ctx: AnalysisContext): Analysis = {

--- a/soql-analyzer/src/main/scala/com/socrata/soql/exceptions/Exceptions.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/exceptions/Exceptions.scala
@@ -101,6 +101,8 @@ object SoQLException {
       and("non-groupable-group-by", AutomaticJsonCodecBuilder[NonGroupableGroupBy]).
       and("non-boolean-having", AutomaticJsonCodecBuilder[NonBooleanHaving]).
       and("unorderable-order-by", AutomaticJsonCodecBuilder[UnorderableOrderBy]).
+      // other
+      and("reserved-table-alias", AutomaticJsonCodecBuilder[ReservedTableAlias]).
       build
 
     def encode(e: SoQLException) = {
@@ -131,6 +133,8 @@ case class UnexpectedEOF(position: Position) extends SoQLException("Unexpected e
 case class UnterminatedString(position: Position) extends SoQLException("Unterminated string", position) with LexerException
 
 case class BadParse(message: String, position: Position) extends SoQLException(message, position)
+
+case class ReservedTableAlias(alias: String, position: Position) extends SoQLException("Reserved table alias", position)
 
 sealed trait TypecheckException extends SoQLException
 case class NoSuchFunction(name: FunctionName, arity: Int, position: Position) extends SoQLException("No such function `" + name + "/" + arity + "'", position) with TypecheckException

--- a/soql-environment/src/main/scala/com/socrata/soql/environment/DatasetContext.scala
+++ b/soql-environment/src/main/scala/com/socrata/soql/environment/DatasetContext.scala
@@ -12,3 +12,9 @@ trait DatasetContext[Type] extends UntypedDatasetContext {
   val schema: OrderedMap[ColumnName, Type] // Note: contains ALL columns, system AND user!
   lazy val columns: OrderedSet[ColumnName] = schema.keySet
 }
+
+object DatasetContext {
+  def empty[Type]: DatasetContext[Type] = new DatasetContext[Type] {
+    val schema = OrderedMap.empty[ColumnName, Type]
+  }
+}

--- a/soql-environment/src/main/scala/com/socrata/soql/environment/TableName.scala
+++ b/soql-environment/src/main/scala/com/socrata/soql/environment/TableName.scala
@@ -29,6 +29,7 @@ object TableName {
   val SoqlPrefix = "@"
   val PrimaryTable = TableName(SodaFountainPrefix)
   val This = SodaFountainPrefix + "this"
+  val SingleRow = SodaFountainPrefix + "single_row"
   val Field = "."
   val PrefixIndex = 1
 

--- a/soql-environment/src/main/scala/com/socrata/soql/environment/TableName.scala
+++ b/soql-environment/src/main/scala/com/socrata/soql/environment/TableName.scala
@@ -30,6 +30,9 @@ object TableName {
   val PrimaryTable = TableName(SodaFountainPrefix)
   val This = SodaFountainPrefix + "this"
   val SingleRow = SodaFountainPrefix + "single_row"
+
+  val reservedNames = Set(This, SingleRow)
+
   val Field = "."
   val PrefixIndex = 1
 


### PR DESCRIPTION
This is so that you can create virtual tables containing a single row
(e.g., to force single evaluation of expressions) in a manner like this

```
select x, y, z
 join (select something_expensive() as a from @single_row) as vars on true
 where x > @vars.a
```
and ultimately get generated SQL that looks something like
```
select x, y, z
  join (select something_expensive() as a) vars -- note no FROM clause here
  where x > vars.a
```
This is a bit of a workaround for the fact that a SoQL expression
with no `FROM` clause means "select from the current ambient table",
contrary to SQL.