### PR TITLE
EN-46401 - add round function

### DIFF
--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -384,6 +384,9 @@ object SoQLFunctions {
   val Floor = f("floor", FunctionName("floor"), Map("a" -> NumLike), Seq(VariableType("a")), Seq.empty, VariableType("a"))(
     NoDocs
   )
+  val Round = mf("round", FunctionName("round"), Seq(SoQLNumber, SoQLNumber), Seq.empty, SoQLNumber)(
+    "Round a number to a specified decimal point, example: round(10.3012, 3) => 10.301; round(25, -1) => 30"
+  )
 
   val NumberToMoney = mf("number to money", SpecialFunctions.Cast(SoQLMoney.name), Seq(SoQLNumber), Seq.empty, SoQLMoney)(
     NoDocs

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.4.2"
+version in ThisBuild := "3.4.3"


### PR DESCRIPTION
Introduces:
`round(N, x)` function to round a number to the nearest x digits. 
E.g. 
round(3.1415, 3) => 3.142
round(315, -1) => 320