### PR TITLE
Table alias rework

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
@@ -583,7 +583,7 @@ case class JoinAnalysis[ColumnId, Type](subAnalysis: Either[TableName, SubAnalys
         (name, alias)
     }
 
-    List(Some(subAnasStr), itrToString("AS", aliasStrOpt.map { a => "`" + TableName.removeValidPrefix(a) + "`" })).flatString
+    List(Some(subAnasStr), itrToString("AS", aliasStrOpt.map { a => "@" + TableName.removeValidPrefix(a)})).flatString
   }
 }
 

--- a/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerQueryOperatorTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerQueryOperatorTest.scala
@@ -61,17 +61,17 @@ class SoQLAnalyzerQueryOperatorTest extends FunSuite with MustMatchers with Prop
        "SELECT Map(name -> name :: text, breed -> _dog.breed :: text) JOIN _dog ON TRUE :: boolean",
        "SELECT Map(name -> str_cat_name :: text, breed -> _dog.str_dog_breed :: text) JOIN _dog ON TRUE :: boolean"),
       ("SELECT name, @d1.breed join @dog as d1 on true",
-       "SELECT Map(name -> name :: text, breed -> _d1.breed :: text) JOIN _dog AS `d1` ON TRUE :: boolean",
-       "SELECT Map(name -> str_cat_name :: text, breed -> _d1.str_dog_breed :: text) JOIN _dog AS `d1` ON TRUE :: boolean"),
+       "SELECT Map(name -> name :: text, breed -> _d1.breed :: text) JOIN _dog AS @d1 ON TRUE :: boolean",
+       "SELECT Map(name -> str_cat_name :: text, breed -> _d1.str_dog_breed :: text) JOIN _dog AS @d1 ON TRUE :: boolean"),
       ("SELECT name, @j1.breed join (select name, breed from @dog) as j1 on true",
-       "SELECT Map(name -> name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> name :: text, breed -> breed :: text) FROM @dog) AS `j1` ON TRUE :: boolean",
-       "SELECT Map(name -> str_cat_name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> str_dog_name :: text, breed -> str_dog_breed :: text) FROM @dog) AS `j1` ON TRUE :: boolean"),
+       "SELECT Map(name -> name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> name :: text, breed -> breed :: text) FROM @dog) AS @j1 ON TRUE :: boolean",
+       "SELECT Map(name -> str_cat_name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> str_dog_name :: text, breed -> str_dog_breed :: text) FROM @dog) AS @j1 ON TRUE :: boolean"),
       ("SELECT name, @j1.breed join (select @dog.name, @dog.breed from @dog) as j1 on true",
-       "SELECT Map(name -> name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> _dog.name :: text, breed -> _dog.breed :: text) FROM @dog) AS `j1` ON TRUE :: boolean",
-       "SELECT Map(name -> str_cat_name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> _dog.str_dog_name :: text, breed -> _dog.str_dog_breed :: text) FROM @dog) AS `j1` ON TRUE :: boolean"),
+       "SELECT Map(name -> name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> _dog.name :: text, breed -> _dog.breed :: text) FROM @dog) AS @j1 ON TRUE :: boolean",
+       "SELECT Map(name -> str_cat_name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> _dog.str_dog_name :: text, breed -> _dog.str_dog_breed :: text) FROM @dog) AS @j1 ON TRUE :: boolean"),
       ("SELECT name, @j1.breed join (select @d1.name, @d1.breed from @dog as d1) as j1 on true",
-       "SELECT Map(name -> name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> _d1.name :: text, breed -> _d1.breed :: text) FROM @dog AS `d1`) AS `j1` ON TRUE :: boolean",
-       "SELECT Map(name -> str_cat_name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> _d1.str_dog_name :: text, breed -> _d1.str_dog_breed :: text) FROM @dog AS `d1`) AS `j1` ON TRUE :: boolean"),
+       "SELECT Map(name -> name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> _d1.name :: text, breed -> _d1.breed :: text) FROM @dog AS @d1) AS @j1 ON TRUE :: boolean",
+       "SELECT Map(name -> str_cat_name :: text, breed -> _j1.breed :: text) JOIN (SELECT Map(name -> _d1.str_dog_name :: text, breed -> _d1.str_dog_breed :: text) FROM @dog AS @d1) AS @j1 ON TRUE :: boolean"),
       ("SELECT name UNION SELECT name from @dog",
        "SELECT Map(name -> name :: text) UNION SELECT Map(name -> name :: text) FROM @dog",
        "SELECT Map(name -> str_cat_name :: text) UNION SELECT Map(name -> str_dog_name :: text) FROM @dog"),
@@ -87,8 +87,8 @@ class SoQLAnalyzerQueryOperatorTest extends FunSuite with MustMatchers with Prop
                 UNION ALL
                SELECT @cat.name, @cat.cat FROM @cat) as j4 ON TRUE
       """,
-       "SELECT Map(name -> name :: text, dogname -> _dog.name :: text, j2catname -> _j2.name :: text, j4name -> _j4.name :: text, dog -> _dog.dog :: text, j2cat -> _j2.cat :: text, j3cat -> _j3.cat :: text, j4bird -> _j4.bird :: text) JOIN _dog ON TRUE :: boolean JOIN _cat AS `j2` ON TRUE :: boolean JOIN _cat AS `j3` ON TRUE :: boolean JOIN (SELECT Map(name -> _b1.name :: text, bird -> _b1.bird :: text) FROM @bird AS `b1` UNION (SELECT Map(name -> name :: text, fish -> fish :: text, cat2 -> _c2.cat :: text) FROM @fish JOIN _cat AS `c2` ON TRUE :: boolean |> SELECT Map(name -> name :: text, cat2 -> cat2 :: text)) UNION ALL SELECT Map(name -> _cat.name :: text, cat -> _cat.cat :: text) FROM @cat) AS `j4` ON TRUE :: boolean",
-       "SELECT Map(name -> str_cat_name :: text, dogname -> _dog.str_dog_name :: text, j2catname -> _j2.str_cat_name :: text, j4name -> _j4.name :: text, dog -> _dog.str_dog_dog :: text, j2cat -> _j2.str_cat_cat :: text, j3cat -> _j3.str_cat_cat :: text, j4bird -> _j4.bird :: text) JOIN _dog ON TRUE :: boolean JOIN _cat AS `j2` ON TRUE :: boolean JOIN _cat AS `j3` ON TRUE :: boolean JOIN (SELECT Map(name -> _b1.str_bird_name :: text, bird -> _b1.str_bird_bird :: text) FROM @bird AS `b1` UNION (SELECT Map(name -> str_fish_name :: text, fish -> str_fish_fish :: text, cat2 -> _c2.str_cat_cat :: text) FROM @fish JOIN _cat AS `c2` ON TRUE :: boolean |> SELECT Map(name -> name :: text, cat2 -> cat2 :: text)) UNION ALL SELECT Map(name -> _cat.str_cat_name :: text, cat -> _cat.str_cat_cat :: text) FROM @cat) AS `j4` ON TRUE :: boolean")
+       "SELECT Map(name -> name :: text, dogname -> _dog.name :: text, j2catname -> _j2.name :: text, j4name -> _j4.name :: text, dog -> _dog.dog :: text, j2cat -> _j2.cat :: text, j3cat -> _j3.cat :: text, j4bird -> _j4.bird :: text) JOIN _dog ON TRUE :: boolean JOIN _cat AS @j2 ON TRUE :: boolean JOIN _cat AS @j3 ON TRUE :: boolean JOIN (SELECT Map(name -> _b1.name :: text, bird -> _b1.bird :: text) FROM @bird AS @b1 UNION (SELECT Map(name -> name :: text, fish -> fish :: text, cat2 -> _c2.cat :: text) FROM @fish JOIN _cat AS @c2 ON TRUE :: boolean |> SELECT Map(name -> name :: text, cat2 -> cat2 :: text)) UNION ALL SELECT Map(name -> _cat.name :: text, cat -> _cat.cat :: text) FROM @cat) AS @j4 ON TRUE :: boolean",
+       "SELECT Map(name -> str_cat_name :: text, dogname -> _dog.str_dog_name :: text, j2catname -> _j2.str_cat_name :: text, j4name -> _j4.name :: text, dog -> _dog.str_dog_dog :: text, j2cat -> _j2.str_cat_cat :: text, j3cat -> _j3.str_cat_cat :: text, j4bird -> _j4.bird :: text) JOIN _dog ON TRUE :: boolean JOIN _cat AS @j2 ON TRUE :: boolean JOIN _cat AS @j3 ON TRUE :: boolean JOIN (SELECT Map(name -> _b1.str_bird_name :: text, bird -> _b1.str_bird_bird :: text) FROM @bird AS @b1 UNION (SELECT Map(name -> str_fish_name :: text, fish -> str_fish_fish :: text, cat2 -> _c2.str_cat_cat :: text) FROM @fish JOIN _cat AS @c2 ON TRUE :: boolean |> SELECT Map(name -> name :: text, cat2 -> cat2 :: text)) UNION ALL SELECT Map(name -> _cat.str_cat_name :: text, cat -> _cat.str_cat_cat :: text) FROM @cat) AS @j4 ON TRUE :: boolean")
     )
 
     val qColumnIdNewColumnIdMap = Map(

--- a/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
@@ -453,7 +453,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with PropertyChecks {
     val soql = "select visits, @a1.name_first join @aaaa-aaaa as a1 on name_last = @a1.name_last"
     val parsed = new Parser().unchainedSelectStatement(soql)
 
-    val expected = "SELECT `visits`, @a1.`name_first` JOIN @aaaa-aaaa AS `a1` ON `name_last` = @a1.`name_last`"
+    val expected = "SELECT `visits`, @a1.`name_first` JOIN @aaaa-aaaa AS @a1 ON `name_last` = @a1.`name_last`"
     parsed.toString must equal(expected)
 
     val parsedAgain = new Parser().unchainedSelectStatement(expected)
@@ -464,7 +464,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with PropertyChecks {
     val soql = "select visits, @a1.name_first left outer join @aaaa-aaaa as a1 on name_last = @a1.name_last"
     val parsed = new Parser().unchainedSelectStatement(soql)
 
-    val expected = "SELECT `visits`, @a1.`name_first` LEFT OUTER JOIN @aaaa-aaaa AS `a1` ON `name_last` = @a1.`name_last`"
+    val expected = "SELECT `visits`, @a1.`name_first` LEFT OUTER JOIN @aaaa-aaaa AS @a1 ON `name_last` = @a1.`name_last`"
     parsed.toString must equal(expected)
 
     val parsedAgain = new Parser().unchainedSelectStatement(expected)
@@ -475,7 +475,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with PropertyChecks {
     val soql = "select visits, @a1.name_first right outer join @aaaa-aaaa as a1 on name_last = @a1.name_last"
     val parsed = new Parser().unchainedSelectStatement(soql)
 
-    val expected = "SELECT `visits`, @a1.`name_first` RIGHT OUTER JOIN @aaaa-aaaa AS `a1` ON `name_last` = @a1.`name_last`"
+    val expected = "SELECT `visits`, @a1.`name_first` RIGHT OUTER JOIN @aaaa-aaaa AS @a1 ON `name_last` = @a1.`name_last`"
     parsed.toString must equal(expected)
 
     val parsedAgain = new Parser().unchainedSelectStatement(expected)
@@ -506,7 +506,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with PropertyChecks {
     val soql = "SELECT @a1.:*, @a1.*, * JOIN @aaaa-aaax AS x1 ON visits > 10"
     val parsed = new Parser().unchainedSelectStatement(soql)
 
-    val expected = "SELECT @a1.:*, @a1.*, * JOIN @aaaa-aaax AS `x1` ON `visits` > 10"
+    val expected = "SELECT @a1.:*, @a1.*, * JOIN @aaaa-aaax AS @x1 ON `visits` > 10"
     parsed.toString must equal(expected)
 
     val parsedAgain = new Parser().unchainedSelectStatement(expected)
@@ -665,7 +665,7 @@ SELECT visits, @x2.zx
   test("lateral join with this alias") {
     val soql = "SELECT @t1.name_first, @j.x FROM @this as t1 JOIN LATERAL (SELECT @t2.x, @t2.y FROM @aaaa-aaax as t2 WHERE @t2.x=@t1.name_last) as j ON TRUE"
     val parsed = new Parser().unchainedSelectStatement(soql)
-    parsed.toString must equal ("SELECT @t1.`name_first`, @j.`x` FROM @this AS `t1` JOIN LATERAL (SELECT @t2.`x`, @t2.`y` FROM @aaaa-aaax AS `t2` WHERE @t2.`x` = @t1.`name_last`) AS `j` ON TRUE")
+    parsed.toString must equal ("SELECT @t1.`name_first`, @j.`x` FROM @this AS @t1 JOIN LATERAL (SELECT @t2.`x`, @t2.`y` FROM @aaaa-aaax AS @t2 WHERE @t2.`x` = @t1.`name_last`) AS @j ON TRUE")
     val analysis = analyzer.analyzeFullQueryBinary(soql)
 
     // And with chained soql

--- a/soql-environment/src/main/scala/com/socrata/soql/environment/TableName.scala
+++ b/soql-environment/src/main/scala/com/socrata/soql/environment/TableName.scala
@@ -2,7 +2,7 @@ package com.socrata.soql.environment
 
 case class TableName(name: String, alias: Option[String] = None) {
   override def toString(): String = {
-    aliasWithoutPrefix.foldLeft(TableName.withSoqlPrefix(name))((n, a) => s"$n AS `$a`")
+    aliasWithoutPrefix.foldLeft(TableName.withSoqlPrefix(name))((n, a) => s"$n AS @$a")
   }
 
   def qualifier: String = alias.getOrElse(name)

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
@@ -42,7 +42,7 @@ case class JoinTable(tableName: TableName) extends JoinSelect {
 }
 case class JoinQuery(selects: BinaryTree[Select], definiteAlias: String) extends JoinSelect {
   val alias = Some(definiteAlias)
-  override def toString = "(" + Select.toString(selects) + ") AS @" + TableName.removeValidPrefix(definiteAlias) + ""
+  override def toString = "(" + Select.toString(selects) + ") AS @" + TableName.removeValidPrefix(definiteAlias)
   def replaceHoles(f: Hole => Expression): JoinQuery =
     copy(Select.walkTreeReplacingHoles(selects, f))
   def rewriteJoinFuncs(f: Map[TableName, UDF], aliasProvider: AliasProvider): JoinQuery =

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
@@ -42,7 +42,7 @@ case class JoinTable(tableName: TableName) extends JoinSelect {
 }
 case class JoinQuery(selects: BinaryTree[Select], definiteAlias: String) extends JoinSelect {
   val alias = Some(definiteAlias)
-  override def toString = "(" + Select.toString(selects) + ") AS `" + TableName.removeValidPrefix(definiteAlias) + "`"
+  override def toString = "(" + Select.toString(selects) + ") AS @" + TableName.removeValidPrefix(definiteAlias) + ""
   def replaceHoles(f: Hole => Expression): JoinQuery =
     copy(Select.walkTreeReplacingHoles(selects, f))
   def rewriteJoinFuncs(f: Map[TableName, UDF], aliasProvider: AliasProvider): JoinQuery =
@@ -54,7 +54,7 @@ case class JoinQuery(selects: BinaryTree[Select], definiteAlias: String) extends
 case class JoinFunc(tableName: TableName, params: Seq[Expression])(val position: Position) extends JoinSelect {
   val alias = tableName.alias
   override def toString =
-    TableName.withSoqlPrefix(tableName.name) + "(" + params.mkString(", ") + ")" + tableName.aliasWithoutPrefix.map(" AS `" + _ + "`").getOrElse("")
+    TableName.withSoqlPrefix(tableName.name) + "(" + params.mkString(", ") + ")" + tableName.aliasWithoutPrefix.map(" AS @" + _).getOrElse("")
 
   def allTableNames = {
     val result = Set.newBuilder[String]

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
@@ -206,7 +206,7 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
 
   val simpleIdentifier: Parser[(String, Position)] = simpleSystemIdentifier | simpleUserIdentifier | failure(errors.missingIdentifier)
 
-  val tableAlias: Parser[String] = simpleIdentifier ^^ {
+  val tableAlias: Parser[String] = (simpleIdentifier | tableIdentifier) ^^ {
     case (alias, _) => TableName.withSodaFountainPrefix(alias)
   }
 
@@ -224,9 +224,9 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
     if(allowJoinFunctions) {
       // I'd like this alias to be optional, but it would take a
       // surprisingly major change to get that working.
-      tableIdentifier ~ (LPAREN() ~> repsep(expr, COMMA()) <~ RPAREN()) ~ (AS() ~> tableAlias) ^^ {
+      tableIdentifier ~ (LPAREN() ~> repsep(expr, COMMA()) <~ RPAREN()) ~ opt(AS() ~> tableAlias) ^^ {
         case ((tid: String, pos)) ~ args ~ alias =>
-          JoinFunc(TableName(tid, Some(alias)), args)(pos)
+          JoinFunc(TableName(tid, alias), args)(pos)
       } | base
     } else {
       base

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
@@ -222,8 +222,6 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
       }
 
     if(allowJoinFunctions) {
-      // I'd like this alias to be optional, but it would take a
-      // surprisingly major change to get that working.
       tableIdentifier ~ (LPAREN() ~> repsep(expr, COMMA()) <~ RPAREN()) ~ opt(AS() ~> tableAlias) ^^ {
         case ((tid: String, pos)) ~ args ~ alias =>
           JoinFunc(TableName(tid, alias), args)(pos)

--- a/soql-standalone-parser/src/test/scala/com/socrata/soql/mapping/ColumnNameMapperTest.scala
+++ b/soql-standalone-parser/src/test/scala/com/socrata/soql/mapping/ColumnNameMapperTest.scala
@@ -110,7 +110,7 @@ class ColumnNameMapperTest extends FunSuite with MustMatchers with Assertions {
                SELECT @cat.name, @cat.cat FROM @cat) as j4 ON TRUE
       """
 
-    val expected = "SELECT `MAP_name`, @dog.`MAP_name` AS `dogname`, @j2.`MAP_name` AS `j2catname`, @j4.`MAP_name` AS `j4name`, @dog.`MAP_dog`, @j2.`MAP_cat` AS `j2cat`, @j3.`MAP_cat` AS `j3cat`, @j4.`MAP_bird` AS `j4bird` JOIN @dog ON TRUE JOIN @cat AS `j2` ON TRUE JOIN @cat AS `j3` ON TRUE JOIN (SELECT @b1.`MAP_name`, @b1.`MAP_bird` FROM @bird AS `b1` UNION SELECT `MAP_name`, `MAP_fish`, @c2.`MAP_cat` AS `cat2` FROM @fish JOIN @cat AS `c2` ON TRUE |> SELECT `name`, `cat2` UNION ALL SELECT @cat.`MAP_name`, @cat.`MAP_cat` FROM @cat) AS `j4` ON TRUE"
+    val expected = "SELECT `MAP_name`, @dog.`MAP_name` AS `dogname`, @j2.`MAP_name` AS `j2catname`, @j4.`MAP_name` AS `j4name`, @dog.`MAP_dog`, @j2.`MAP_cat` AS `j2cat`, @j3.`MAP_cat` AS `j3cat`, @j4.`MAP_bird` AS `j4bird` JOIN @dog ON TRUE JOIN @cat AS @j2 ON TRUE JOIN @cat AS @j3 ON TRUE JOIN (SELECT @b1.`MAP_name`, @b1.`MAP_bird` FROM @bird AS @b1 UNION SELECT `MAP_name`, `MAP_fish`, @c2.`MAP_cat` AS `cat2` FROM @fish JOIN @cat AS @c2 ON TRUE |> SELECT `name`, `cat2` UNION ALL SELECT @cat.`MAP_name`, @cat.`MAP_cat` FROM @cat) AS @j4 ON TRUE"
     val s = parser.binaryTreeSelect(soql)
     val actual = mapper.mapSelect(s)
     // Note that the (second) chained query in join union is not mapped and retains "SELECT name, cat2" because this is not supported.

--- a/soql-standalone-parser/src/test/scala/com/socrata/soql/parsing/ToStringTest.scala
+++ b/soql-standalone-parser/src/test/scala/com/socrata/soql/parsing/ToStringTest.scala
@@ -131,14 +131,14 @@ class ToStringTest extends FunSpec with MustMatchers {
 
     it("simple 2") {
       val query = "select :id, @a.name_last join @aaaa-aaaa as a on name_last = @a.name_last"
-      val expected = "SELECT `:id`, @a.`name_last` JOIN @aaaa-aaaa AS `a` ON `name_last` = @a.`name_last`"
+      val expected = "SELECT `:id`, @a.`name_last` JOIN @aaaa-aaaa AS @a ON `name_last` = @a.`name_last`"
       val parsed = parser.selectStatement(query).map(_.toString)
       parsed must equal(NonEmptySeq(expected))
     }
 
     it("complex") {
       val query = "select :id, balance, @b.name_last join (select * from @aaaa-aaaa as a |> select @a.name_last) as b on name_last = @b.name_last |> select :id"
-      val expected1 = "SELECT `:id`, `balance`, @b.`name_last` JOIN (SELECT * FROM @aaaa-aaaa AS `a` |> SELECT @a.`name_last`) AS `b` ON `name_last` = @b.`name_last`"
+      val expected1 = "SELECT `:id`, `balance`, @b.`name_last` JOIN (SELECT * FROM @aaaa-aaaa AS @a |> SELECT @a.`name_last`) AS @b ON `name_last` = @b.`name_last`"
       val expected2 = "SELECT `:id`"
       val parsed = parser.selectStatement(query).map(_.toString)
       parsed must equal(NonEmptySeq(expected1, List(expected2)))
@@ -151,7 +151,7 @@ class ToStringTest extends FunSpec with MustMatchers {
         "SELECT 1 |> SELECT 2 |> SELECT 3",
         "SELECT 1 |> SELECT 2 UNION (SELECT 3 |> SELECT 4 |> SELECT 5 |> SELECT 6)",
         "SELECT 1 UNION (SELECT 2 UNION ALL (SELECT 3 UNION SELECT 4) UNION SELECT 5) UNION SELECT 6",
-        "SELECT `x`, @a.`a1`, @jb.`b1`, @jcd.`c1` JOIN @a ON TRUE JOIN (SELECT @b.`b1` FROM @b) AS `jb` ON TRUE JOIN (SELECT @cc.`c1` FROM @c AS `cc` UNION SELECT `d1` FROM @d) AS `jcd` ON TRUE |> SELECT `x`, `c1`, 1 + 2 ORDER BY `x` ASC NULL LAST, `c1` ASC NULL LAST"
+        "SELECT `x`, @a.`a1`, @jb.`b1`, @jcd.`c1` JOIN @a ON TRUE JOIN (SELECT @b.`b1` FROM @b) AS @jb ON TRUE JOIN (SELECT @cc.`c1` FROM @c AS @cc UNION SELECT `d1` FROM @d) AS @jcd ON TRUE |> SELECT `x`, `c1`, 1 + 2 ORDER BY `x` ASC NULL LAST, `c1` ASC NULL LAST"
       )
 
       soqls.foreach { soql =>


### PR DESCRIPTION
Before: table aliases were declared with `AS identifier` where
"identifier" had to conform to the lexical rules for identifier-ness.

Now: table aliases can still be declared that way, but they can
also be declared with `AS @tablename`.  This has two advantages:

1. It makes declaration reflect use.
2. Lexically it allows 4x4s to be used for table identifiers.

Note that even before, `@tablename` wasn't necessarily always a 4x4,
thanks to resource names.

The upshot of all this is that we can expand `JOIN @some-thng` where
"some-thng" is a derived view or other structure that isn't just a
bare table into `JOIN (select ...) AS @some-thng` and have it work.

Also this makes the alias on table-functions optional, as we can use
the function-name as the alias reliably now.