### PR TITLE
Be able to preserve parentheses in compound queries

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisDeserializer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisDeserializer.scala
@@ -28,7 +28,6 @@ private trait DeserializationDictionary[C, T] {
 
 object AnalysisDeserializer {
   val CurrentVersion = 9
-  val LastVersion = 7
   val NonEmptySeqVersion = 6
 
   // This is odd and for smooth deploy transition.
@@ -333,7 +332,7 @@ class AnalysisDeserializer[C, T](columnDeserializer: String => C, typeDeserializ
         val seq: NonEmptySeq[SoQLAnalysis[C, T]] = deserializer.read()
         val bt: BinaryTree[SoQLAnalysis[C, T]] = toBinaryTree(seq.seq)
         bt
-      case v if v >= LastVersion =>
+      case v if v > NonEmptySeqVersion =>
         val dictionary = DeserializationDictionaryImpl.fromInput(cis)
         val deserializer = new Deserializer(cis, dictionary, v)
         val bt: BinaryTree[SoQLAnalysis[C, T]] = deserializer.readBinaryTree(deserializer.readAnalysis)

--- a/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisSerializer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/AnalysisSerializer.scala
@@ -256,13 +256,15 @@ class AnalysisSerializer[C,T](serializeColumn: C => String, serializeType: T => 
 
     def writeBinaryTree[A](bt: BinaryTree[A])(f: A => Unit): Unit = {
       bt match {
-        case Compound(op: String, l, r) =>
+        case c@Compound(op: String, l, r) =>
           out.writeUInt32NoTag(2)
           out.writeStringNoTag(op)
+          out.writeBoolNoTag(c.inParen)
           writeBinaryTree(l)(f)
           writeBinaryTree(r)(f)
-        case Leaf(a) =>
+        case Leaf(a, inParen) =>
           out.writeUInt32NoTag(1)
+          out.writeBoolNoTag(inParen)
           f(a)
       }
     }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
@@ -76,26 +76,26 @@ class SoQLAnalyzer[Type](typeInfo: TypeInfo[Type],
 
   def analyzeBinary(bSelect: BinaryTree[Select])(implicit ctx: AnalysisContext): BinaryTree[Analysis] = {
     bSelect match {
-      case Leaf(s) =>
-        Leaf(analyzeWithSelection(s)(ctx))
-      case PipeQuery(ls, rs) =>
+      case Leaf(s, inParen) =>
+        Leaf(analyzeWithSelection(s)(ctx), inParen)
+      case PipeQuery(ls, rs, inParen) =>
         val la = ls match {
-          case Leaf(s) => Leaf(analyzeWithSelection(s)(ctx))
+          case Leaf(s, inParen) => Leaf(analyzeWithSelection(s)(ctx), inParen)
           case _ => analyzeBinary(ls)
         }
         val ra = rs match {
-          case Leaf(s) =>
+          case Leaf(s, inParen) =>
             val prev = la.outputSchema.leaf
-            Leaf(analyzeInOuterSelectionContext(ctx)(prev, s))
+            Leaf(analyzeInOuterSelectionContext(ctx)(prev, s), inParen)
           case _ =>
             analyzeBinary(ls)
         }
         PipeQuery(la, ra)
-      case Compound(op, ls, rs) =>
+      case c@Compound(op, ls, rs) =>
         val la = analyzeBinary(ls)
         val ra = analyzeBinary(rs)
         validateTableShapes(la.outputSchema.leaf, ra.outputSchema.leaf, rs.outputSchema.leaf)
-        Compound(op, la, ra)
+        Compound(op, la, ra, c.inParen)
     }
   }
 
@@ -578,7 +578,8 @@ case class JoinAnalysis[ColumnId, Type](subAnalysis: Either[TableName, SubAnalys
     val (subAnasStr, aliasStrOpt) = subAnalysis match {
       case Right(SubAnalysis(subAnalysis, subAlias)) =>
         val selectStr = subAnalysis.toString
-        (s"($selectStr)", Some(subAlias))
+        if (subAnalysis.inParen) (s"$selectStr", Some(subAlias))
+        else (s"($selectStr)", Some(subAlias))
       case Left(TableName(name, alias)) =>
         (name, alias)
     }
@@ -734,7 +735,7 @@ private class Merger[T](andFunction: MonomorphicFunction[T]) {
 
   def merge(stages: BinaryTree[Analysis]): BinaryTree[Analysis] = {
     stages match {
-      case PipeQuery(l, r) =>
+      case PipeQuery(l, r, inParen) =>
         val ml = merge(l)
         leftMergeCandidate(ml) match {
           case Some(mlCandidate) =>
@@ -744,24 +745,24 @@ private class Merger[T](andFunction: MonomorphicFunction[T]) {
                 if (ml.asLeaf.isDefined) Leaf(merged)
                 else ml.replace(mlCandidate, Leaf(merged))
               case None =>
-                PipeQuery(ml, r)
+                PipeQuery(ml, r, inParen)
             }
           case None =>
-            PipeQuery(ml, r)
+            PipeQuery(ml, r, inParen)
         }
-      case Compound(op, l, r) =>
+      case c@Compound(op, l, r) =>
         val nl = merge(l)
         val nr = merge(r)
-        Compound(op, nl, nr)
-      case Leaf(_) =>
+        Compound(op, nl, nr, c.inParen)
+      case Leaf(_, _) =>
         stages
     }
   }
 
   private def leftMergeCandidate(left: BinaryTree[Analysis]): Option[Leaf[Analysis]] = {
     left match {
-      case leaf@Leaf(_) => Some(leaf)
-      case PipeQuery(_, _) => Some(left.outputSchema)
+      case leaf@Leaf(_, _) => Some(leaf)
+      case PipeQuery(_, _, _) => Some(left.outputSchema)
       case Compound(_, _, _) => None // UNIONs etc are not mergeable
     }
   }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/mapping/ColumnIdMapper.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/mapping/ColumnIdMapper.scala
@@ -15,7 +15,7 @@ object ColumnIdMapper {
                                                 columnIdToNewColumnId: ColumnId => NewColumnId):
   BinaryTree[SoQLAnalysis[NewColumnId, Type]] = {
     bt match {
-      case PipeQuery(l, r) =>
+      case PipeQuery(l, r, inParen) =>
         val nl = mapColumnIds(l)(qColumnIdNewColumnIdMap, qColumnNameToQColumnId, columnNameToNewColumnId, columnIdToNewColumnId)
         val prev = nl.outputSchema.leaf
         val prevAlias = r.outputSchema.leaf.from match {
@@ -31,14 +31,14 @@ object ColumnIdMapper {
         val newQColumnIdToQColumnIdMap = qColumnIdNewColumnIdMap ++ prevQColumnIdToQColumnIdMap
         val rightLeaf = r.asLeaf.getOrElse(throw RightSideOfChainQueryMustBeLeaf(NoPosition))
         val nr = rightLeaf.mapColumnIds(newQColumnIdToQColumnIdMap, qColumnNameToQColumnId, columnNameToNewColumnId, columnIdToNewColumnId)
-        PipeQuery(nl, Leaf(nr))
-      case Compound(op, l, r) =>
+        PipeQuery(nl, Leaf(nr), inParen)
+      case c@Compound(op, l, r) =>
         val nl = mapColumnIds(l)(qColumnIdNewColumnIdMap, qColumnNameToQColumnId, columnNameToNewColumnId, columnIdToNewColumnId)
         val nr = mapColumnIds(r)(qColumnIdNewColumnIdMap, qColumnNameToQColumnId, columnNameToNewColumnId, columnIdToNewColumnId)
-        Compound(op, nl, nr)
-      case Leaf(ana) =>
+        Compound(op, nl, nr, c.inParen)
+      case Leaf(ana, inParen) =>
         val nana = ana.mapColumnIds(qColumnIdNewColumnIdMap, qColumnNameToQColumnId, columnNameToNewColumnId, columnIdToNewColumnId)
-        Leaf(nana)
+        Leaf(nana, inParen)
     }
   }
 }

--- a/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
@@ -207,7 +207,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with PropertyChecks {
   }
 
   test("a subselect makes the output of the inner select available to the outer") {
-    val PipeQuery(inner, outer) = analyzer.analyzeFullQueryBinary("select 5 :: money as x |> select max(x)")
+    val PipeQuery(inner, outer, _) = analyzer.analyzeFullQueryBinary("select 5 :: money as x |> select max(x)")
     outer.asLeaf.get.selection(ColumnName("max_x")) must equal (typed.FunctionCall(MonomorphicFunction(TestFunctions.Max, Map("a" -> TestMoney)), Seq(typed.ColumnRef(None, ColumnName("x"), TestMoney : TestType)(NoPosition)), None)(NoPosition, NoPosition))
     inner.asLeaf.get.selection(ColumnName("x")) must equal (typed.FunctionCall(TestFunctions.castIdentities.find(_.result == functions.FixedType(TestMoney)).get.monomorphic.get,
       Seq(typed.FunctionCall(TestFunctions.NumberToMoney.monomorphic.get, Seq(typed.NumberLiteral(java.math.BigDecimal.valueOf(5), TestNumber.t)(NoPosition)), None)(NoPosition, NoPosition)), None)(NoPosition, NoPosition))

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/BinaryTree.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/BinaryTree.scala
@@ -143,7 +143,7 @@ sealed trait Compound[T] extends BinaryTree[T] {
   def opString: String = op
 
   override def toString: String = {
-    val s = if (right.isInstanceOf[Compound[T]]) s"${left.toString} $opString (${right.toString})"
+    val s = if (right.isInstanceOf[Compound[T]] && !right.inParen) s"${left.toString} $opString (${right.toString})"
             else s"${left.toString} $opString ${right.toString}"
     if (inParen) s"(${s})"
     else s

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
@@ -167,11 +167,13 @@ object Select {
       case PipeQuery(l, r, inParen) =>
         val ls = Select.toString(l)
         val rs = Select.toString(r)
-        s"$ls |> $rs"
-      case Compound(op, l, r) =>
+        if (inParen) s"($ls |> $rs)"
+        else s"$ls |> $rs"
+      case c@Compound(op, l, r) =>
         val ls = Select.toString(l)
         val rs = Select.toString(r)
-        s"$ls $op $rs"
+        if (c.inParen) s"($ls $op $rs)"
+        else s"$ls $op $rs"
       case Leaf(select, inParen) =>
         if (inParen) s"(${select.toString})"
         else select.toString

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
@@ -42,11 +42,21 @@ case class JoinTable(tableName: TableName) extends JoinSelect {
 }
 case class JoinQuery(selects: BinaryTree[Select], definiteAlias: String) extends JoinSelect {
   val alias = Some(definiteAlias)
-  override def toString = "(" + Select.toString(selects) + ") AS @" + TableName.removeValidPrefix(definiteAlias)
+
+  override def toString = {
+    if (selects.inParen) {
+      Select.toString(selects) + " AS @" + TableName.removeValidPrefix(definiteAlias)
+    } else {
+      "(" + Select.toString(selects) + ") AS @" + TableName.removeValidPrefix(definiteAlias)
+    }
+  }
+
   def replaceHoles(f: Hole => Expression): JoinQuery =
     copy(Select.walkTreeReplacingHoles(selects, f))
+
   def rewriteJoinFuncs(f: Map[TableName, UDF], aliasProvider: AliasProvider): JoinQuery =
     copy(selects = Select.rewriteJoinFuncs(selects, f)(aliasProvider))
+
   def directlyReferencedJoinFuncs = Select.findDirectlyReferencedJoinFuncs(selects)
 
   val allTableNames = Select.allTableNames(selects) + definiteAlias
@@ -152,7 +162,7 @@ object Select {
 
   def toString(selects: BinaryTree[Select]): String = {
     selects match {
-      case PipeQuery(l, r) =>
+      case PipeQuery(l, r, inParen) =>
         val ls = Select.toString(l)
         val rs = Select.toString(r)
         s"$ls |> $rs"
@@ -160,8 +170,9 @@ object Select {
         val ls = Select.toString(l)
         val rs = Select.toString(r)
         s"$ls $op $rs"
-      case Leaf(select) =>
-        select.toString
+      case Leaf(select, inParen) =>
+        if (inParen) s"(${select.toString})"
+        else select.toString
     }
   }
 
@@ -182,7 +193,7 @@ object Select {
   def findDirectlyReferencedJoinFuncs(node: BinaryTree[Select]): Set[TableName] = {
     node match {
       case c: Compound[Select] => findDirectlyReferencedJoinFuncs(c.left) union findDirectlyReferencedJoinFuncs(c.right)
-      case Leaf(select) => select.directlyReferencedJoinFuncs
+      case Leaf(select, _) => select.directlyReferencedJoinFuncs
     }
   }
 

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
@@ -54,8 +54,10 @@ case class JoinQuery(selects: BinaryTree[Select], definiteAlias: String) extends
   def replaceHoles(f: Hole => Expression): JoinQuery =
     copy(Select.walkTreeReplacingHoles(selects, f))
 
-  def rewriteJoinFuncs(f: Map[TableName, UDF], aliasProvider: AliasProvider): JoinQuery =
-    copy(selects = Select.rewriteJoinFuncs(selects, f)(aliasProvider))
+  def rewriteJoinFuncs(f: Map[TableName, UDF], aliasProvider: AliasProvider): JoinQuery = {
+    val rewritten = Select.rewriteJoinFuncs(selects, f)(aliasProvider)
+    copy(selects = rewritten.wrapInParen)
+  }
 
   def directlyReferencedJoinFuncs = Select.findDirectlyReferencedJoinFuncs(selects)
 

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/mapping/ColumnNameMapper.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/mapping/ColumnNameMapper.scala
@@ -18,16 +18,16 @@ class ColumnNameMapper(columnNameMap: Map[ColumnName, ColumnName]) {
 
   def mapSelect(selects: BinaryTree[Select]): BinaryTree[Select] = {
     selects match {
-      case PipeQuery(l, r) =>
+      case PipeQuery(l, r, inParen) =>
         // previously when pipe query is in seq form,
         // mapSelect only operates on the first element
         val nl = mapSelect(l)
-        PipeQuery(nl, r)
-      case Compound(op, l, r) =>
+        PipeQuery(nl, r, inParen)
+      case c@Compound(op, l, r) =>
         val nl = mapSelect(l)
         val nr = mapSelect(r)
-        Compound(op, nl, nr)
-      case Leaf(h) =>
+        Compound(op, nl, nr, c.inParen)
+      case Leaf(h, inParen) =>
         Leaf(Select(
           distinct = h.distinct,
           selection = mapSelection(h.selection),
@@ -40,7 +40,7 @@ class ColumnNameMapper(columnNameMap: Map[ColumnName, ColumnName]) {
           limit = h.limit,
           offset = h.offset,
           search = h.search
-        ))
+        ), inParen)
     }
   }
 

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/AbstractParser.scala
@@ -155,7 +155,7 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
     QUERYUNIONALL() | QUERYINTERSECTALL() | QUERYMINUSALL()
 
   def parenSelect: Parser[BinaryTree[Select]] =
-    LPAREN() ~> compoundSelect <~ RPAREN() ^^ { s => s }
+    LPAREN() ~> compoundSelect <~ RPAREN() ^^ { s => s.wrapInParen }
 
   lazy val compoundSelect: PackratParser[BinaryTree[Select]] =
     opt(compoundSelect ~ query_op) ~ atomSelect ^^ {
@@ -169,7 +169,7 @@ abstract class AbstractParser(parameters: AbstractParser.Parameters = AbstractPa
             badParse(errors.leafQueryOnTheRightExpected, op.position)
         }
       case Some(a ~ op) ~ b =>
-        Compound(op.printable, a, b)
+        Compound(op.printable, a, b, false)
     }
 
   def atomSelect: Parser[BinaryTree[Select]] =

--- a/soql-standalone-parser/src/test/scala/com/socrata/soql/BinaryTreeSelectTest.scala
+++ b/soql-standalone-parser/src/test/scala/com/socrata/soql/BinaryTreeSelectTest.scala
@@ -34,7 +34,7 @@ class BinaryTreeSelectTest extends FunSpec with MustMatchers {
     it ("leftMost update compare uses reference equality") {
       val soql = "SELECT 1 as a UNION SELECT 1 as a"
       val binaryTree = parser.binaryTreeSelect(soql)
-      val compound@Compound(_, l@Leaf(_), r@Leaf(_)) = binaryTree
+      val compound@Compound(_, l@Leaf(_, _), r@Leaf(_, _)) = binaryTree
       l.eq(r) must be (false)
       val leftCopy = l.copy()
       leftCopy.eq(l) must be (false)

--- a/soql-standalone-parser/src/test/scala/com/socrata/soql/mapping/ColumnNameMapperTest.scala
+++ b/soql-standalone-parser/src/test/scala/com/socrata/soql/mapping/ColumnNameMapperTest.scala
@@ -110,7 +110,7 @@ class ColumnNameMapperTest extends FunSuite with MustMatchers with Assertions {
                SELECT @cat.name, @cat.cat FROM @cat) as j4 ON TRUE
       """
 
-    val expected = "SELECT `MAP_name`, @dog.`MAP_name` AS `dogname`, @j2.`MAP_name` AS `j2catname`, @j4.`MAP_name` AS `j4name`, @dog.`MAP_dog`, @j2.`MAP_cat` AS `j2cat`, @j3.`MAP_cat` AS `j3cat`, @j4.`MAP_bird` AS `j4bird` JOIN @dog ON TRUE JOIN @cat AS @j2 ON TRUE JOIN @cat AS @j3 ON TRUE JOIN (SELECT @b1.`MAP_name`, @b1.`MAP_bird` FROM @bird AS @b1 UNION SELECT `MAP_name`, `MAP_fish`, @c2.`MAP_cat` AS `cat2` FROM @fish JOIN @cat AS @c2 ON TRUE |> SELECT `name`, `cat2` UNION ALL SELECT @cat.`MAP_name`, @cat.`MAP_cat` FROM @cat) AS @j4 ON TRUE"
+    val expected = "SELECT `MAP_name`, @dog.`MAP_name` AS `dogname`, @j2.`MAP_name` AS `j2catname`, @j4.`MAP_name` AS `j4name`, @dog.`MAP_dog`, @j2.`MAP_cat` AS `j2cat`, @j3.`MAP_cat` AS `j3cat`, @j4.`MAP_bird` AS `j4bird` JOIN @dog ON TRUE JOIN @cat AS @j2 ON TRUE JOIN @cat AS @j3 ON TRUE JOIN (SELECT @b1.`MAP_name`, @b1.`MAP_bird` FROM @bird AS @b1 UNION (SELECT `MAP_name`, `MAP_fish`, @c2.`MAP_cat` AS `cat2` FROM @fish JOIN @cat AS @c2 ON TRUE |> SELECT `name`, `cat2`) UNION ALL SELECT @cat.`MAP_name`, @cat.`MAP_cat` FROM @cat) AS @j4 ON TRUE"
     val s = parser.binaryTreeSelect(soql)
     val actual = mapper.mapSelect(s)
     // Note that the (second) chained query in join union is not mapped and retains "SELECT name, cat2" because this is not supported.

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.7.3"
+version in ThisBuild := "3.8.0"


### PR DESCRIPTION
Previously, parentheses can only influence the left, right structure of binary tree.  This doesn't work well with set operations that are different in precedence, for example:

(SELECT a FROM a UNION SELECT b FROM b) INTERSECT SELECT c FROM c