### PR TITLE
Produce better error messages around *-positioning in select lists.

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/exceptions/Exceptions.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/exceptions/Exceptions.scala
@@ -148,6 +148,33 @@ object BadParse {
       "Expected a non-compound query on the right side of a pipe operator"
     }
   }
+
+  class UnexpectedStarSelect(val reader: Reader)
+      extends BadParse(UnexpectedStarSelect.msg(reader), reader.first.position)
+      with ParseException
+  {
+    override val position = super.position
+  }
+
+  object UnexpectedStarSelect {
+    private def msg(reader: Reader) = {
+      "Star selections must come at the start of the select-list"
+    }
+  }
+
+
+  class UnexpectedSystemStarSelect(val reader: Reader)
+      extends BadParse(UnexpectedSystemStarSelect.msg(reader), reader.first.position)
+      with ParseException
+  {
+    override val position = super.position
+  }
+
+  object UnexpectedSystemStarSelect {
+    private def msg(reader: Reader) = {
+      "System column star selections must come before user column star selections"
+    }
+  }
 }
 
 case class ReservedTableAlias(alias: String, position: Position) extends SoQLException("Reserved table alias", position)

--- a/soql-analyzer/src/main/scala/com/socrata/soql/parsing/Parser.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/parsing/Parser.scala
@@ -10,5 +10,11 @@ class Parser(parameters: AbstractParser.Parameters = AbstractParser.defaultParam
   protected def expectedLeafQuery(reader: RecursiveDescentParser.Reader) =
     new BadParse.ExpectedLeafQuery(reader)
 
+  protected def unexpectedStarSelect(reader: RecursiveDescentParser.Reader) =
+    new BadParse.UnexpectedStarSelect(reader)
+
+  protected def unexpectedSystemStarSelect(reader: RecursiveDescentParser.Reader) =
+    new BadParse.UnexpectedSystemStarSelect(reader)
+
   override protected def lexer(s: String): AbstractLexer = new Lexer(s)
 }

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/StandaloneParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/StandaloneParser.scala
@@ -11,6 +11,12 @@ class StandaloneParser(parameters: AbstractParser.Parameters = AbstractParser.de
   protected def expectedLeafQuery(reader: RecursiveDescentParser.Reader) =
     new BadParse.ExpectedLeafQuery(reader)
 
+  protected def unexpectedStarSelect(reader: RecursiveDescentParser.Reader) =
+    new BadParse.UnexpectedStarSelect(reader)
+
+  protected def unexpectedSystemStarSelect(reader: RecursiveDescentParser.Reader) =
+    new BadParse.UnexpectedSystemStarSelect(reader)
+
   protected def lexer(s: String): AbstractLexer = new StandaloneLexer(s)
 }
 

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/standalone_exceptions/BadParse.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/standalone_exceptions/BadParse.scala
@@ -34,4 +34,30 @@ object BadParse {
       "Expected a non-compound query on the right side of a pipe operator"
     }
   }
+
+  class UnexpectedStarSelect(val reader: Reader)
+      extends BadParse(UnexpectedStarSelect.msg(reader), reader.first.position)
+      with ParseException
+  {
+    override val position = super.position
+  }
+
+  object UnexpectedStarSelect {
+    private def msg(reader: Reader) = {
+      "Star selections must come at the start of the select-list"
+    }
+  }
+
+  class UnexpectedSystemStarSelect(val reader: Reader)
+      extends BadParse(UnexpectedSystemStarSelect.msg(reader), reader.first.position)
+      with ParseException
+  {
+    override val position = super.position
+  }
+
+  object UnexpectedSystemStarSelect {
+    private def msg(reader: Reader) = {
+      "System column star selections must come before user column star selections"
+    }
+  }
 }


### PR DESCRIPTION
In particular, tell the user that `:*` and `*` must come first, and
that `:*` must come before `*`.