### PR TITLE
add wrapper for ST_Area, ST_Intersection, and NTILE(N) functionality

### DIFF
--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -167,9 +167,9 @@ object SoQLFunctions {
     Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLBoolean))(
     "Return the rows that where the locations 'spatially overlap', meaning they intersect, but one does not completely contain another and they share interior points")
   
-  val Intersection = f("intersection", FunctionName("intersection"), Map("a" -> Set(SoQLMultiPolygon, SoQLPolygon), "b" -> Set(SoQLMultiPolygon, SoQLPolygon)),
+  val Intersection = f("polygon_intersection", FunctionName("polygon_intersection"), Map("a" -> Set(SoQLMultiPolygon, SoQLPolygon), "b" -> Set(SoQLMultiPolygon, SoQLPolygon)),
     Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLMultiPolygon))(
-    "Returns the geometry of the intersection between two polygon or multipolygon geometries")
+    "Returns the geometry of the overlapping multipolygon intersection between two polygon or multipolygon geometries")
   
   val Area = f("area", FunctionName("area"), Map("a" -> Set(SoQLMultiPolygon, SoQLPolygon)),
     Seq(VariableType("a")), Seq.empty, FixedType(SoQLNumber))(

--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -167,13 +167,13 @@ object SoQLFunctions {
     Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLBoolean))(
     "Return the rows that where the locations 'spatially overlap', meaning they intersect, but one does not completely contain another and they share interior points")
   
-  val Intersection = f("intersection", FunctionName("intersection"), Map("a" -> GeospatialLike, "b" -> GeospatialLike),
-    Seq(VariableType("a"), VariableType("b")), Seq.empty, VariableType("a"))(
-    "Returns the geometry of the intersection between two geometries")
+  val Intersection = f("intersection", FunctionName("intersection"), Map("a" -> Set(SoQLMultiPolygon, SoQLPolygon), "b" -> Set(SoQLMultiPolygon, SoQLPolygon)),
+    Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLMultiPolygon))(
+    "Returns the geometry of the intersection between two polygon or multipolygon geometries")
   
-  val Area = f("area", FunctionName("area"), Map("a" -> GeospatialLike),
+  val Area = f("area", FunctionName("area"), Map("a" -> Set(SoQLMultiPolygon, SoQLPolygon)),
     Seq(VariableType("a")), Seq.empty, FixedType(SoQLNumber))(
-    "Returns the area of the geometry")
+    "Returns the area of a polygon or multipolygon geometry")
 
   val DistanceInMeters = f("distance_in_meters", FunctionName("distance_in_meters"), Map("a" -> GeospatialLike, "b" -> GeospatialLike),
     Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLNumber))(NoDocs)
@@ -508,7 +508,7 @@ object SoQLFunctions {
   val Lag = f("lag", FunctionName("lag"), Map.empty, Seq(VariableType("a")), Seq.empty, VariableType("a"), needsWindow = true)(
     NoDocs
   )
-  val Ntile = f("ntile", FunctionName("ntile"), Map.empty, Seq(VariableType("a")), Seq.empty, FixedType(SoQLNumber), needsWindow=true)(
+  val Ntile = f("ntile", FunctionName("ntile"), Map("a" -> NumLike), Seq(VariableType("a")), Seq.empty, FixedType(SoQLNumber), needsWindow=true)(
     NoDocs
   )
 

--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -166,6 +166,15 @@ object SoQLFunctions {
   val Overlaps = f("overlaps", FunctionName("overlaps"), Map("a" -> GeospatialLike, "b" -> GeospatialLike),
     Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLBoolean))(
     "Return the rows that where the locations 'spatially overlap', meaning they intersect, but one does not completely contain another and they share interior points")
+  
+  val Intersection = f("intersection", FunctionName("intersection"), Map("a" -> GeospatialLike, "b" -> GeospatialLike),
+    Seq(VariableType("a"), VariableType("b")), Seq.empty, VariableType("a"))(
+    "Returns the geometry of the intersection between two geometries")
+  
+  val Area = f("area", FunctionName("area"), Map("a" -> GeospatialLike),
+    Seq(VariableType("a")), Seq.empty, FixedType(SoQLNumber))(
+    "Returns the area of the geometry")
+
   val DistanceInMeters = f("distance_in_meters", FunctionName("distance_in_meters"), Map("a" -> GeospatialLike, "b" -> GeospatialLike),
     Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLNumber))(NoDocs)
   val GeoMakeValid = f("geo_make_valid", FunctionName("geo_make_valid"), Map("a" -> GeospatialLike),
@@ -497,6 +506,9 @@ object SoQLFunctions {
     NoDocs
   )
   val Lag = f("lag", FunctionName("lag"), Map.empty, Seq(VariableType("a")), Seq.empty, VariableType("a"), needsWindow = true)(
+    NoDocs
+  )
+  val Ntile = f("ntile", FunctionName("ntile"), Map.empty, Seq(VariableType("a")), Seq.empty, FixedType(SoQLNumber), needsWindow=true)(
     NoDocs
   )
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.13.0"
+version in ThisBuild := "3.13.1"


### PR DESCRIPTION
Adding:
`area` => ST_Area - return the area of a geometry
`polygon_intersection` => ST_Intersection - return the geometry of a an intersecting area (or null if they don't intersect)
`ntile(N)` => NTILE - integer ranging from 1 to the argument value, dividing the partition as equally as possible. Useful for getting quantiles through SoQL.

Bump version
