### PR TITLE
EN-49288: Follow syntactic order in findIdentsAndLiterals for filter …

### DIFF
--- a/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
@@ -703,9 +703,9 @@ SELECT visits, @x2.zx
   }
 
   test("filter") {
-    val analysis = analyzer.analyzeUnchainedQuery("SELECT max(name_first) FILTER(WHERE TRUE) OVER (PARTITION BY name_last) as x WHERE TRUE")
+    val analysis = analyzer.analyzeUnchainedQuery("SELECT max(name_first) FILTER(WHERE TRUE) OVER (PARTITION BY name_last) WHERE TRUE")
     val (cn: ColumnName, fc: FunctionCall[_, _]) = analysis.selection.head
     fc.filter must be(analysis.where)
-    cn.name must be("x")
+    cn.name must be("max_name_first_TRUE_over_partition_by_name_last")
   }
 }

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Expression.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Expression.scala
@@ -50,16 +50,15 @@ object Expression {
         case FunctionCall(SpecialFunctions.NotBetween, Seq(a,b,c), _, _) =>
           findIdentsAndLiterals(a) ++ Vector("not", "between") ++ findIdentsAndLiterals(b) ++ Vector("and") ++ findIdentsAndLiterals(c)
         case FunctionCall(SpecialFunctions.Case, args, _, _) =>
-          val whens = args.dropRight(2).grouped(2)
           val start = Vector("case") ++ args.dropRight(2).grouped(2).flatMap { case Seq(cond, expr) => Vector("when") ++ findIdentsAndLiterals(cond) ++ Vector("then") ++ findIdentsAndLiterals(expr) }
           val sinon = args.takeRight(2) match {
             case Seq(BooleanLiteral(false), _) => Vector.empty
             case Seq(BooleanLiteral(true), e) => Vector("else") ++ findIdentsAndLiterals(e)
           }
           start ++ sinon ++ Vector("end")
-        case FunctionCall(other, args, _, window) => Vector(other.name) ++ args.flatMap(findIdentsAndLiterals) ++ findIdentsAndLiterals(window)
+        case FunctionCall(other, args, _, _) => Vector(other.name) ++ args.flatMap(findIdentsAndLiterals)
       }
-      ils ++ fc.filter.toSeq.flatMap(findIdentsAndLiterals(_))
+      ils ++ fc.filter.toSeq.flatMap(findIdentsAndLiterals(_)) ++ findIdentsAndLiterals(fc.window)
     case Hole(name) =>
       Vector(name.name)
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.14.1"
+version in ThisBuild := "3.14.2"


### PR DESCRIPTION
…and window info.