### PR TITLE
reproject soql function

### DIFF
--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -698,6 +698,11 @@ object SoQLFunctions {
   val PointToLatitude = field(SoQLPoint, "latitude", SoQLNumber)
   val PointToLongitude = field(SoQLPoint, "longitude", SoQLNumber)
 
+  val Reproject = f("reproject", FunctionName("reproject"), Map("a" -> GeospatialLike), Seq(VariableType("a"), FixedType(SoQLText), FixedType(SoQLText)), Seq.empty, VariableType("a"))(
+    "Reproject the incoming geometry from the incoming PROJ.4 spatial reference to an outgoing spatial reference", 
+    Example("Reproject Point", "reproject('POINT (372728.3308536674 69825.24782297359)'::point, '+init=epsg:3627', '+init=epsg:4326')", "")
+  )
+
   val PhoneToPhoneNumber = field(SoQLPhone, "phone_number", SoQLText)
   val PhoneToPhoneType = field(SoQLPhone, "phone_type", SoQLText)
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.0.3"
+ThisBuild / version := "4.1.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.0.2-SNAPSHOT"
+ThisBuild / version := "4.0.3"


### PR DESCRIPTION
Adds:
A `reproject` SoQL function that loosely does what ST_Transform does in PostGIS, however it is setup to accept only the Proj4 projection text, rather than SRID integers, in order to allow for greater flexibility as well as match what DSMAPI does as a transform: https://dev.socrata.com/docs/transforms/reproject.html

Example: 
```
reproject('POINT (372728.3308536674 69825.24782297359)'::point, '+init=epsg:3627', '+init=epsg:4326')
```
