### PR TITLE
EN-52940: Rollup query select column alias cannot be used in group by

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.4.1"
+ThisBuild / version := "4.4.2"


### PR DESCRIPTION
regression from adding join/multi-table support in rollup - EN-51708