### PR TITLE
Fix publish task

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 lazy val root = (project in file(".")).
-  settings(Seq(publishArtifact := false)).
+  settings(BuildSettings.buildSettings ++ Seq(publishArtifact := false)).
   aggregate (soqlEnvironment, soqlParser, soqlAnalyzer, soqlTypes, soqlStdlib, soqlToy, soqlPack)
 
 lazy val soqlEnvironment = (project in file("soql-environment")).

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -7,7 +7,7 @@ object BuildSettings {
   val buildSettings: Seq[Setting[_]] = Seq(
     organization := "com.socrata",
     scalaVersion := "2.13.6",
-    crossScalaVersions := Seq("2.12.10", scalaVersion.value),
+    crossScalaVersions := Seq("2.12.14", scalaVersion.value),
     externalResolvers ++= Seq("socrata artifactory" at "https://repo.socrata.com/artifactory/libs-release")
   )
 


### PR DESCRIPTION
It was trying to build with scala 2.12.10, then 2.12.14, and of course
the publish of the latter was failing due to 2.12 artifacts already
existing.  I don't quite understand why - the state SBT was in was
that the root project was set to 2.12.14 from SBT's default and the
subprojects had settings of 2.12.10.  I'm not sure why `+publish` was
taking the union of all of that even for the subprojects.

But now, all the projects use the base `BuildSettings.buildSettings` so
they all agree on the set of scala versions in use.  Also I updated the
build to the newer 2.12 Just Because.