### PR TITLE
EN-54117: stop resolving joined (qualified) cols to aliased selections

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.7.0"
+ThisBuild / version := "4.7.1"


### PR DESCRIPTION
bug: 'select `name_first` as name_last, @a1.`name_last` as a1_name_last' was resolving a1_name_last as a column ref of `name_first` on the not-joined dataset
this was because we did not take the selection qualifier into account when looking up the column in the alias map.