### PR TITLE
EN-55321: update substring function docs

### DIFF
--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -454,7 +454,9 @@ object SoQLFunctions {
   )
 
   val Substring = mf("substring", FunctionName("substring"), Seq(SoQLText, SoQLNumber), Seq(SoQLNumber), SoQLText)(
-    "Get a substring of a specified length of a text from a start index (1 base)"
+    "Get a substring of a specified length of a text from a start index (1 base). If length is not supplied, it returns the rest of the string.",
+    Example("Get a substring from the second character to the rest of the string", "substring('world', 2) => 'orld'", ""),
+    Example("Get a substring from the second character with a length of one", "substring('world', 2, 1) => 'o'", "")
   )
 
   val Chr = mf("chr", FunctionName("chr"), Seq(SoQLNumber), Seq.empty, SoQLText)(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.8.3"
+ThisBuild / version := "4.8.4"


### PR DESCRIPTION
* make it more explicit about accepting both starting point and optionally ending point, provide examples
* frontend is still going to show just one argument in the function signature, but reading +using the variable arguments is probably a frontend change