### PR TITLE
EN-54831 do not automatically insert a dash in generataed aliases

### DIFF
--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Expression.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Expression.scala
@@ -33,6 +33,8 @@ object Expression {
 
   def escapeString(s: String): String = "'" + s.replaceAll("'", "''") + "'"
 
+  private def foldDashes(s: String) = s.replaceAll("-","_")
+
   private def findIdentsAndLiterals(e: Expression): Seq[String] = e match {
     case v: Literal => Vector(v.toString)
     case ColumnOrAliasRef(aliasOpt, name) => aliasOpt ++: Vector(name.name)
@@ -65,7 +67,7 @@ object Expression {
     case Hole.SavedQuery(name, None) =>
       Vector("param", name.name)
     case Hole.SavedQuery(name, Some(v)) =>
-      Vector("param", v, name.name)
+      Vector("param", foldDashes(v), name.name)
   }
 
   private def findIdentsAndLiterals(windowFunctionInfo: Option[WindowFunctionInfo]): Seq[String] =  {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.8.4"
+ThisBuild / version := "4.8.5"


### PR DESCRIPTION
For a new param, we would generate a name like
param_aaaa-aaaa_something, and that would fail column name validation in core since it doesn't allow dashes