### PR TITLE
Fix WKT JSON decoding

### DIFF
--- a/soql-types/src/main/scala/com/socrata/soql/types/SoQLGeometryLike.scala
+++ b/soql-types/src/main/scala/com/socrata/soql/types/SoQLGeometryLike.scala
@@ -62,8 +62,17 @@ trait SoQLGeometryLike[T <: Geometry] {
 
   // Fast Base64 WKB representation (for CJSON transport)
   object Wkb64Rep {
-    def unapply(text: String): Option[T] = WkbRep.unapply(Base64.getDecoder.decode(text))
-    def apply(geom: T): String           = Base64.getEncoder.encodeToString(WkbRep.apply(geom))
+    def unapply(text: String): Option[T] = {
+      val bits = try {
+        Base64.getDecoder.decode(text)
+      } catch {
+        case _ : IllegalArgumentException =>
+          // Sadness
+          return None
+      }
+      WkbRep.unapply(bits)
+    }
+    def apply(geom: T): String = Base64.getEncoder.encodeToString(WkbRep.apply(geom))
   }
 
   object EWktRep {


### PR DESCRIPTION
Fallout of 9e6696805c76b5511cd0e1198bb19a0700222b8e - the old base64 decoder was more lenient, and java.util's is stricter.  So where the old CJSON WKT decode codepath was "decode base64, then fail to parse WKB, then try as WKT", the new one would throw an exception at that first step.

So.. don't do that.  If it's not valid base64, just return None straightaway and don't even try to parse Wkb.