### PR TITLE
Refactor various rewrite-pass stuff

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/From.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/From.scala
@@ -38,8 +38,6 @@ sealed abstract class From[+RNS, +CT, +CV] {
     wantOrderingColumn: Boolean
   ): (Option[(TableLabel, AutoColumnLabel)], Self[RNS, CT2, CV])
 
-  def useSelectListReferences: Self[RNS, CT, CV]
-
   def find(predicate: Expr[CT, CV] => Boolean): Option[Expr[CT, CV]]
   def contains[CT2 >: CT, CV2 >: CV](e: Expr[CT2, CV2]): Boolean
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/From.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/From.scala
@@ -31,13 +31,6 @@ sealed abstract class From[+RNS, +CT, +CV] {
   private[analyzer2] def findIsomorphism[RNS2 >: RNS, CT2 >: CT, CV2 >: CV](state: IsomorphismState, that: From[RNS2, CT2, CV2]): Boolean
   private[analyzer2] def columnReferences: Map[TableLabel, Set[ColumnLabel]]
 
-  private[analyzer2] def preserveOrdering[CT2 >: CT](
-    provider: LabelProvider,
-    rowNumberFunction: MonomorphicFunction[CT2],
-    wantOutputOrdered: Boolean,
-    wantOrderingColumn: Boolean
-  ): (Option[(TableLabel, AutoColumnLabel)], Self[RNS, CT2, CV])
-
   def find(predicate: Expr[CT, CV] => Boolean): Option[Expr[CT, CV]]
   def contains[CT2 >: CT, CV2 >: CV](e: Expr[CT2, CV2]): Boolean
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/From.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/From.scala
@@ -26,8 +26,6 @@ sealed abstract class From[+RNS, +CT, +CV] {
 
   private[analyzer2] def doLabelMap[RNS2 >: RNS](state: LabelMapState[RNS2]): Unit
 
-  private[analyzer2] def doRemoveUnusedColumns(used: Map[TableLabel, Set[ColumnLabel]]): Self[RNS, CT, CV]
-
   private[analyzer2] def realTables: Map[AutoTableLabel, DatabaseTableName]
 
   private[analyzer2] def findIsomorphism[RNS2 >: RNS, CT2 >: CT, CV2 >: CV](state: IsomorphismState, that: From[RNS2, CT2, CV2]): Boolean

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalysis.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalysis.scala
@@ -38,7 +38,7 @@ class SoQLAnalysis[RNS, CT, CV] private (
     * indexes instead. */
   def useSelectListReferences =
     if(usesSelectListReferences) this
-    else copy(statement = statement.useSelectListReferences, usesSelectListReferences = true)
+    else copy(statement = rewrite.SelectListReferences.use(statement), usesSelectListReferences = true)
 
   private def copy[RNS2, CT2, CV2](
     labelProvider: LabelProvider = this.labelProvider,
@@ -49,7 +49,7 @@ class SoQLAnalysis[RNS, CT, CV] private (
 
   private def withoutSelectListReferences(f: SoQLAnalysis[RNS, CT, CV] => SoQLAnalysis[RNS, CT, CV]) =
     if(usesSelectListReferences) {
-      f(this.copy(statement = statement.unuseSelectListReferences)).useSelectListReferences
+      f(this.copy(statement = rewrite.SelectListReferences.unuse(statement))).useSelectListReferences
     } else {
       f(this)
     }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalysis.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalysis.scala
@@ -15,11 +15,11 @@ class SoQLAnalysis[RNS, CT, CV] private (
   /** Rewrite the analysis plumbing through enough information to
     * preserve table-ordering (except across joins and aggregates,
     * which of course destroy ordering). */
-  def preserveOrdering(rowNumberFunction: MonomorphicFunction[CT]): SoQLAnalysis[RNS, CT, CV] = {
+  def preserveOrdering: SoQLAnalysis[RNS, CT, CV] = {
     val nlp = labelProvider.clone()
     copy(
       labelProvider = nlp,
-      statement = rewrite.PreserveOrdering(nlp, rowNumberFunction, statement)
+      statement = rewrite.PreserveOrdering(nlp, statement)
     )
   }
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalysis.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalysis.scala
@@ -19,7 +19,7 @@ class SoQLAnalysis[RNS, CT, CV] private (
     val nlp = labelProvider.clone()
     copy(
       labelProvider = nlp,
-      statement = statement.preserveOrdering(nlp, rowNumberFunction, true, false)._2
+      statement = rewrite.PreserveOrdering(nlp, rowNumberFunction, statement)
     )
   }
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalysis.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalysis.scala
@@ -16,11 +16,13 @@ class SoQLAnalysis[RNS, CT, CV] private (
     * preserve table-ordering (except across joins and aggregates,
     * which of course destroy ordering). */
   def preserveOrdering: SoQLAnalysis[RNS, CT, CV] = {
-    val nlp = labelProvider.clone()
-    copy(
-      labelProvider = nlp,
-      statement = rewrite.PreserveOrdering(nlp, statement)
-    )
+    withoutSelectListReferences { self =>
+      val nlp = self.labelProvider.clone()
+      self.copy(
+        labelProvider = nlp,
+        statement = rewrite.PreserveOrdering(nlp, self.statement)
+      )
+    }
   }
 
   /** Simplify subselects on a best-effort basis. */

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Statement.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Statement.scala
@@ -52,13 +52,6 @@ sealed abstract class Statement[+RNS, +CT, +CV] {
 
   private[analyzer2] def doRewriteDatabaseNames(state: RewriteDatabaseNamesState): Self[RNS, CT, CV]
 
-  private[analyzer2] def preserveOrdering[CT2 >: CT](
-    provider: LabelProvider,
-    rowNumberFunction: MonomorphicFunction[CT2],
-    wantOutputOrdered: Boolean,
-    wantOrderingColumn: Boolean
-  ): (Option[AutoColumnLabel], Self[RNS, CT2, CV])
-
   def find(predicate: Expr[CT, CV] => Boolean): Option[Expr[CT, CV]]
   def contains[CT2 >: CT, CV2 >: CV](e: Expr[CT2, CV2]): Boolean
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Statement.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Statement.scala
@@ -50,13 +50,6 @@ sealed abstract class Statement[+RNS, +CT, +CV] {
     * not roundtrip perfectly through these two calls. */
   def unuseSelectListReferences: Self[RNS, CT, CV]
 
-  /** Remove columns that are not useful from inner selects.
-    * SelectListReferences must not be present. */
-  def removeUnusedColumns: Self[RNS, CT, CV] = doRemoveUnusedColumns(columnReferences, None)
-
-  // If "myLabel" is "None" it means "keep all output columns"
-  private[analyzer2] def doRemoveUnusedColumns(used: Map[TableLabel, Set[ColumnLabel]], myLabel: Option[TableLabel]): Self[RNS, CT, CV]
-
   private[analyzer2] def columnReferences: Map[TableLabel, Set[ColumnLabel]]
 
   def isIsomorphic[RNS2 >: RNS, CT2 >: CT, CV2 >: CV](that: Statement[RNS2, CT2, CV2]): Boolean =

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Statement.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Statement.scala
@@ -38,18 +38,6 @@ sealed abstract class Statement[+RNS, +CT, +CV] {
 
   private[analyzer2] def doRelabel(state: RelabelState): Self[RNS, CT, CV]
 
-  /** For SQL forms that can refer to the select-columns by number, replace relevant
-    * entries in those forms with the relevant select-column-index.
-    *
-    * e.g., this will rewrite a Statement that corresponds to "select
-    * x+1, count(*) group by x+1 order by count(*)" to one that
-    * corresponds to "select x+1, count(*) group by 1 order by 2"
-    */
-  def useSelectListReferences: Self[RNS, CT, CV]
-  /** Undoes `useSelectListReferences`.  Note position information may
-    * not roundtrip perfectly through these two calls. */
-  def unuseSelectListReferences: Self[RNS, CT, CV]
-
   private[analyzer2] def columnReferences: Map[TableLabel, Set[ColumnLabel]]
 
   def isIsomorphic[RNS2 >: RNS, CT2 >: CT, CV2 >: CV](that: Statement[RNS2, CT2, CV2]): Boolean =

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromSingleRow.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromSingleRow.scala
@@ -56,14 +56,6 @@ trait FromSingleRowImpl[+RNS] { this: FromSingleRow[RNS] =>
     // no columns
   }
 
-  private[analyzer2] override def preserveOrdering[CT2](
-    provider: LabelProvider,
-    rowNumberFunction: MonomorphicFunction[CT2],
-    wantOutputOrdered: Boolean,
-    wantOrderingColumn: Boolean
-  ): (Option[(TableLabel, AutoColumnLabel)], Self[RNS, Nothing, Nothing]) =
-    (None, this)
-
   def debugDoc(implicit ev: HasDoc[Nothing]) =
     (d"(SELECT)" +#+ d"AS" +#+ label.debugDoc.annotate(Annotation.TableAliasDefinition(alias, label))).annotate(Annotation.TableDefinition(label))
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromSingleRow.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromSingleRow.scala
@@ -23,8 +23,6 @@ trait FromSingleRowImpl[+RNS] { this: FromSingleRow[RNS] =>
       label
     )
 
-  def useSelectListReferences = this
-
   def find(predicate: Expr[Nothing, Nothing] => Boolean) = None
   def contains[CT, CV](e: Expr[CT, CV]): Boolean = false
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromSingleRow.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromSingleRow.scala
@@ -24,7 +24,6 @@ trait FromSingleRowImpl[+RNS] { this: FromSingleRow[RNS] =>
     )
 
   def useSelectListReferences = this
-  private[analyzer2] def doRemoveUnusedColumns(used: Map[TableLabel, Set[ColumnLabel]]) = this
 
   def find(predicate: Expr[Nothing, Nothing] => Boolean) = None
   def contains[CT, CV](e: Expr[CT, CV]): Boolean = false

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromStatement.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromStatement.scala
@@ -60,18 +60,6 @@ trait FromStatementImpl[+RNS, +CT, +CV] { this: FromStatement[RNS, CT, CV] =>
     }
   }
 
-  private[analyzer2] override def preserveOrdering[CT2 >: CT](
-    provider: LabelProvider,
-    rowNumberFunction: MonomorphicFunction[CT2],
-    wantOutputOrdered: Boolean,
-    wantOrderingColumn: Boolean
-  ): (Option[(TableLabel, AutoColumnLabel)], Self[RNS, CT2, CV]) = {
-    val (orderColumn, stmt) =
-      statement.preserveOrdering(provider, rowNumberFunction, wantOutputOrdered, wantOrderingColumn)
-
-    (orderColumn.map((label, _)), copy(statement = stmt))
-  }
-
   def debugDoc(implicit ev: HasDoc[CV]) =
     (statement.debugDoc.encloseNesting(d"(", d")") +#+ d"AS" +#+ label.debugDoc.annotate(Annotation.TableAliasDefinition(alias, label))).annotate(Annotation.TableDefinition(label))
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromStatement.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromStatement.scala
@@ -38,8 +38,6 @@ trait FromStatementImpl[+RNS, +CT, +CV] { this: FromStatement[RNS, CT, CV] =>
   private[analyzer2] def doRewriteDatabaseNames(state: RewriteDatabaseNamesState) =
     copy(statement = statement.doRewriteDatabaseNames(state))
 
-  def useSelectListReferences = copy(statement = statement.useSelectListReferences)
-
   private[analyzer2] def doRelabel(state: RelabelState) = {
     copy(statement = statement.doRelabel(state),
          label = state.convert(label))

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromStatement.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromStatement.scala
@@ -20,10 +20,6 @@ trait FromStatementImpl[+RNS, +CT, +CV] { this: FromStatement[RNS, CT, CV] =>
 
   private[analyzer2] def columnReferences: Map[TableLabel, Set[ColumnLabel]] = statement.columnReferences
 
-  private[analyzer2] def doRemoveUnusedColumns(used: Map[TableLabel, Set[ColumnLabel]]): Self[RNS, CT, CV] = {
-    copy(statement = statement.doRemoveUnusedColumns(used, Some(label)))
-  }
-
   def find(predicate: Expr[CT, CV] => Boolean) = statement.find(predicate)
   def contains[CT2 >: CT, CV2 >: CV](e: Expr[CT2, CV2]): Boolean =
     statement.contains(e)

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
@@ -79,8 +79,6 @@ trait FromTableImpl[+RNS, +CT] { this: FromTable[RNS, CT] =>
       state.columnMap += (label, columnLabel) -> (tr, columnName)
     }
   }
-
-  def useSelectListReferences: this.type = this
 }
 
 trait OFromTableImpl { this: FromTable.type =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
@@ -47,9 +47,6 @@ trait FromTableImpl[+RNS, +CT] { this: FromTable[RNS, CT] =>
     copy(label = state.convert(label))
   }
 
-  // A table has its columns whether or not they're selected, so this is just "this"
-  private[analyzer2] def doRemoveUnusedColumns(used: Map[TableLabel, Set[ColumnLabel]]) = this
-
   private[analyzer2] final def findIsomorphism[RNS2 >: RNS, CT2 >: CT, CV2](state: IsomorphismState, that: From[RNS2, CT2, CV2]): Boolean =
     // TODO: make this constant-stack if it ever gets used outside of tests
     that match {

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
@@ -26,14 +26,6 @@ trait FromTableImpl[+RNS, +CT] { this: FromTable[RNS, CT] =>
 
   private[analyzer2] override final val scope: Scope[CT] = Scope(columns, label)
 
-  private[analyzer2] override def preserveOrdering[CT2 >: CT](
-    provider: LabelProvider,
-    rowNumberFunction: MonomorphicFunction[CT2],
-    wantOutputOrdered: Boolean,
-    wantOrderingColumn: Boolean
-  ): (Option[(TableLabel, AutoColumnLabel)], Self[RNS, CT2, Nothing]) =
-    (None, asSelf)
-
   def debugDoc(implicit ev: HasDoc[Nothing]) =
     (tableName.debugDoc ++ Doc.softlineSep ++ d"AS" +#+ label.debugDoc.annotate(Annotation.TableAliasDefinition(alias, label))).annotate(Annotation.TableDefinition(label))
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/Join.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/Join.scala
@@ -137,20 +137,6 @@ trait JoinImpl[+RNS, +CT, +CV] { this: Join[RNS, CT, CV] =>
   def contains[CT2 >: CT, CV2 >: CV](e: Expr[CT2, CV2]): Boolean =
     reduce[Boolean](_.contains(e), { (acc, join) => acc || join.right.contains(e) || join.on.contains(e) })
 
-  private[analyzer2] override def preserveOrdering[CT2 >: CT](
-    provider: LabelProvider,
-    rowNumberFunction: MonomorphicFunction[CT2],
-    wantOutputOrdered: Boolean,
-    wantOrderingColumn: Boolean
-  ): (Option[(TableLabel, AutoColumnLabel)], Self[RNS, CT2, CV]) = {
-    // JOIN builds a new table, which is unordered (hence false, false)
-    val result = map[RNS, CT2, CV](
-      { _.preserveOrdering(provider, rowNumberFunction, false, false)._2 },
-      { (joinType, lateral, left, right, on) => Join(joinType, lateral, left, right.preserveOrdering(provider, rowNumberFunction, false, false)._2, on) },
-    )
-    (None, result)
-  }
-
   private[analyzer2] final def findIsomorphism[RNS2 >: RNS, CT2 >: CT, CV2 >: CV](state: IsomorphismState, that: From[RNS2, CT2, CV2]): Boolean =
     // TODO: make this constant-stack if it ever gets used outside of tests
     that match {

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/Join.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/Join.scala
@@ -87,12 +87,6 @@ trait JoinImpl[+RNS, +CT, +CV] { this: Join[RNS, CT, CV] =>
       (acc, join) => acc.mergeWith(join.right.columnReferences)(_ ++ _).mergeWith(join.on.columnReferences)(_ ++ _)
     )
 
-  private[analyzer2] def doRemoveUnusedColumns(used: Map[TableLabel, Set[ColumnLabel]]): Self[RNS, CT, CV] =
-    map[RNS, CT, CV](
-      _.doRemoveUnusedColumns(used),
-      { (joinType, lateral, left, right, on) => Join(joinType, lateral, left, right.doRemoveUnusedColumns(used), on) }
-    )
-
   private[analyzer2] def realTables: Map[AutoTableLabel, DatabaseTableName] = {
     reduce[Map[AutoTableLabel, DatabaseTableName]] (
       { other => other.realTables },

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/Join.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/Join.scala
@@ -123,16 +123,6 @@ trait JoinImpl[+RNS, +CT, +CV] { this: Join[RNS, CT, CV] =>
     )
   }
 
-  def useSelectListReferences: Join[RNS, CT, CV] = {
-    map[RNS, CT, CV](
-      _.useSelectListReferences,
-      { (joinType, lateral, left, right, on) =>
-        val newRight = right.useSelectListReferences
-        Join(joinType, lateral, left, newRight, on)
-      }
-    )
-  }
-
   def mapAlias(f: Option[ResourceName] => Option[ResourceName]): Self[RNS, CT, CV] =
     map[RNS, CT, CV](
       _.mapAlias(f),

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/Merger.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/Merger.scala
@@ -1,4 +1,4 @@
-package com.socrata.soql.analyzer2
+package com.socrata.soql.analyzer2.rewrite
 
 import scala.annotation.tailrec
 import scala.util.parsing.input.NoPosition
@@ -7,6 +7,7 @@ import com.socrata.soql.collection._
 import com.socrata.soql.environment.ResourceName
 import com.socrata.soql.functions.MonomorphicFunction
 import com.socrata.soql.typechecker.HasDoc
+import com.socrata.soql.analyzer2._
 
 class Merger[RNS, CT, CV](and: MonomorphicFunction[CT]) {
   private implicit val hd = new HasDoc[CV] {

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveOrdering.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveOrdering.scala
@@ -117,6 +117,8 @@ class PreserveOrdering[RNS, CT, CV] private (provider: LabelProvider) {
   }
 }
 
+/** Attempt to preserve ordering from inner queries to outer ones.
+  * SelectListReferences must not be present (this is unchecked!!). */
 object PreserveOrdering {
   def apply[RNS, CT, CV](labelProvider: LabelProvider, stmt: Statement[RNS, CT, CV]): Statement[RNS, CT, CV] = {
     new PreserveOrdering[RNS, CT, CV](labelProvider).rewriteStatement(stmt, true, false)._2

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveOrdering.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveOrdering.scala
@@ -73,7 +73,7 @@ class PreserveOrdering[RNS, CT, CV] private (provider: LabelProvider) {
         )
         if(wantOrderingColumns) {
           // ..and our caller wants to know how we're ordered, so
-          // make sure we've put the relevant expressins in our
+          // make sure we've put the relevant expressions in our
           // select list and return them.
           val (newColumns, outputInfo) = orderedSelf.orderBy.map { case OrderBy(expr, asc, nullLast) =>
             selectList.find { case (label, NamedExpr(e, _)) => expr == e } match {

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveOrdering.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveOrdering.scala
@@ -1,5 +1,6 @@
 package com.socrata.soql.analyzer2.rewrite
 
+import scala.collection.compat._
 import scala.collection.{mutable => scm}
 
 import com.socrata.soql.analyzer2

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveOrdering.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveOrdering.scala
@@ -1,0 +1,124 @@
+package com.socrata.soql.analyzer2.rewrite
+
+import com.socrata.soql.analyzer2
+import com.socrata.soql.analyzer2._
+import com.socrata.soql.environment.ColumnName
+import com.socrata.soql.functions.MonomorphicFunction
+
+class PreserveOrdering[RNS, CT, CV] private (provider: LabelProvider, rowNumberFunction: MonomorphicFunction[CT]) {
+  type Statement = analyzer2.Statement[RNS, CT, CV]
+  type Select = analyzer2.Select[RNS, CT, CV]
+  type From = analyzer2.From[RNS, CT, CV]
+  type Join = analyzer2.Join[RNS, CT, CV]
+  type AtomicFrom = analyzer2.AtomicFrom[RNS, CT, CV]
+  type FromTable = analyzer2.FromTable[RNS, CT]
+  type FromSingleRow = analyzer2.FromSingleRow[RNS]
+
+  def rewriteStatement(stmt: Statement, wantOutputOrdered: Boolean, wantOrderingColumn: Boolean): (Option[AutoColumnLabel], Statement) = {
+    stmt match {
+      case CombinedTables(op, left, right) =>
+        // table ops never preserve ordering
+        (None, CombinedTables(op, rewriteStatement(left, false, false)._2, rewriteStatement(right, false, false)._2))
+
+      case cte@CTE(defLabel, defAlias, defQuery, matHint, useQuery) =>
+        val (orderingColumn, newUseQuery) = rewriteStatement(useQuery, wantOutputOrdered, wantOrderingColumn)
+
+        (
+          orderingColumn,
+          cte.copy(
+            definitionQuery = rewriteStatement(defQuery, false, false)._2,
+            useQuery = newUseQuery
+          )
+        )
+
+      case v@Values(_) =>
+        // TODO, should this rewrite into a SELECT ... FROM (values...) ORDER BY synthetic_column ?
+        // If so, we'll need a way to generate synthetic_column
+        (None, v)
+
+      case select@Select(distinctiveness, selectList, from, where, groupBy, having, orderBy, limit, offset, search, hint) =>
+        // If we're windowed, we want the underlying query ordered if
+        // possible even if our caller doesn't care, unless there's an
+        // aggregate in the way, in which case the aggregate will
+        // destroy any underlying ordering anyway so we stop caring.
+
+        def freshName(base: String) = {
+          val names = selectList.valuesIterator.map(_.name).toSet
+          Iterator.from(1).map { i => ColumnName(base + "_" + i) }.find { n =>
+            !names.contains(n)
+          }.get
+        }
+
+        val wantSubqueryOrdered = (select.isWindowed || wantOutputOrdered) && !select.isAggregated && distinctiveness == Distinctiveness.Indistinct
+        rewriteFrom(from, wantSubqueryOrdered, wantSubqueryOrdered) match {
+          case (Some((table, column)), newFrom) =>
+            val col = Column(table, column, rowNumberFunction.result)(AtomicPositionInfo.None)
+
+            val orderedSelf = select.copy(
+              from = newFrom,
+              orderBy = orderBy :+ OrderBy(col, true, true)
+            )
+
+            if(wantOrderingColumn) {
+              val rowNumberLabel = provider.columnLabel()
+              val newSelf = orderedSelf.copy(
+                selectList = selectList + (rowNumberLabel -> (NamedExpr(col, freshName("order"))))
+              )
+
+              (Some(rowNumberLabel), newSelf)
+            } else {
+              (None, orderedSelf)
+            }
+
+          case (None, newFrom) =>
+            if(wantOrderingColumn && orderBy.nonEmpty) {
+              // assume the given order by provides a total order and
+              // reflect that in our ordering column
+
+              val rowNumberLabel = provider.columnLabel()
+              val newSelf = select.copy(
+                selectList = selectList + (rowNumberLabel -> NamedExpr(WindowedFunctionCall(rowNumberFunction, Nil, None, Nil, Nil, None)(FuncallPositionInfo.None), freshName("order"))),
+                from = newFrom
+              )
+
+              (Some(rowNumberLabel), newSelf)
+            } else {
+              // No ordered FROM _and_ no ORDER BY?  You don't get a column even though you asked for one
+              (None, select.copy(from = newFrom))
+            }
+        }
+    }
+  }
+
+  def rewriteFrom(from: From, wantOutputOrdered: Boolean, wantOrderingColumn: Boolean): (Option[(TableLabel, AutoColumnLabel)], From) = {
+    from match {
+      case join: Join =>
+        // JOIN builds a new table, which is unordered (hence (false,
+        // false) and why this entire rewriteFrom method isn't just a
+        // call to from.map
+        val result = join.map[RNS, CT, CV](
+          rewriteAtomicFrom(_, false, false)._2,
+          { (joinType, lateral, left, right, on) => Join(joinType, lateral, left, rewriteAtomicFrom(right, false, false)._2, on) }
+        )
+        (None, result)
+      case af: AtomicFrom =>
+        rewriteAtomicFrom(af, wantOutputOrdered, wantOrderingColumn)
+    }
+  }
+
+  def rewriteAtomicFrom(from: AtomicFrom, wantOutputOrdered: Boolean, wantOrderingColumn: Boolean): (Option[(TableLabel, AutoColumnLabel)], AtomicFrom) = {
+    from match {
+      case ft: FromTable => (None, ft)
+      case fs: FromSingleRow => (None, fs)
+      case fs@FromStatement(stmt, label, resourceName, alias) =>
+        val (orderColumn, newStmt) = rewriteStatement(stmt, wantOutputOrdered, wantOrderingColumn)
+        (orderColumn.map((label, _)), fs.copy(statement = newStmt))
+    }
+  }
+}
+
+object PreserveOrdering {
+  def apply[RNS, CT, CV](labelProvider: LabelProvider, rowNumberFunction: MonomorphicFunction[CT], stmt: Statement[RNS, CT, CV]): Statement[RNS, CT, CV] = {
+    new PreserveOrdering[RNS, CT, CV](labelProvider, rowNumberFunction).rewriteStatement(stmt, true, false)._2
+  }
+}

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveOrdering.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveOrdering.scala
@@ -1,11 +1,13 @@
 package com.socrata.soql.analyzer2.rewrite
 
+import scala.collection.{mutable => scm}
+
 import com.socrata.soql.analyzer2
 import com.socrata.soql.analyzer2._
 import com.socrata.soql.environment.ColumnName
 import com.socrata.soql.functions.MonomorphicFunction
 
-class PreserveOrdering[RNS, CT, CV] private (provider: LabelProvider, rowNumberFunction: MonomorphicFunction[CT]) {
+class PreserveOrdering[RNS, CT, CV] private (provider: LabelProvider) {
   type Statement = analyzer2.Statement[RNS, CT, CV]
   type Select = analyzer2.Select[RNS, CT, CV]
   type From = analyzer2.From[RNS, CT, CV]
@@ -13,84 +15,82 @@ class PreserveOrdering[RNS, CT, CV] private (provider: LabelProvider, rowNumberF
   type AtomicFrom = analyzer2.AtomicFrom[RNS, CT, CV]
   type FromTable = analyzer2.FromTable[RNS, CT]
   type FromSingleRow = analyzer2.FromSingleRow[RNS]
+  type OrderBy = analyzer2.OrderBy[CT, CV]
 
-  def rewriteStatement(stmt: Statement, wantOutputOrdered: Boolean, wantOrderingColumn: Boolean): (Option[AutoColumnLabel], Statement) = {
+  // "wantOutputOrdered" == "if this statement can be rewritten to
+  // preserve the ordering of its underlying query, do so".
+  // "wantOrderingColumns" == "The caller needs column from this table
+  // to order itself".  Note that just because the caller wants a
+  // thing, it will not necessarily get it!
+  def rewriteStatement(stmt: Statement, wantOutputOrdered: Boolean, wantOrderingColumns: Boolean): (Seq[(ColumnLabel, CT, Boolean, Boolean)], Statement) = {
     stmt match {
       case CombinedTables(op, left, right) =>
         // table ops never preserve ordering
-        (None, CombinedTables(op, rewriteStatement(left, false, false)._2, rewriteStatement(right, false, false)._2))
+        (Nil, CombinedTables(op, rewriteStatement(left, false, false)._2, rewriteStatement(right, false, false)._2))
 
       case cte@CTE(defLabel, defAlias, defQuery, matHint, useQuery) =>
-        val (orderingColumn, newUseQuery) = rewriteStatement(useQuery, wantOutputOrdered, wantOrderingColumn)
+        val (orderingColumns, newUseQuery) = rewriteStatement(useQuery, wantOutputOrdered, wantOrderingColumns)
 
         (
-          orderingColumn,
+          orderingColumns,
           cte.copy(
-            definitionQuery = rewriteStatement(defQuery, false, false)._2,
+            definitionQuery = rewriteStatement(defQuery, true, false)._2,
             useQuery = newUseQuery
           )
         )
 
       case v@Values(_) =>
-        // TODO, should this rewrite into a SELECT ... FROM (values...) ORDER BY synthetic_column ?
-        // If so, we'll need a way to generate synthetic_column
-        (None, v)
+        // TODO, should this rewrite into a SELECT ... FROM
+        // (values...) ORDER BY synthetic_column ?  If so, we'll need
+        // a way to generate synthetic_column (== have a way to turn
+        // an integer into a CV)
+        (Nil, v)
 
       case select@Select(distinctiveness, selectList, from, where, groupBy, having, orderBy, limit, offset, search, hint) =>
+        val usedNames = selectList.valuesIterator.map(_.name).to(scm.HashSet)
+        def freshName(base: String) = {
+          val created = Iterator.from(1).map { i => ColumnName(base + "_" + i) }.find { n =>
+            !usedNames.contains(n)
+          }.get
+          usedNames += created
+          created
+        }
+
         // If we're windowed, we want the underlying query ordered if
         // possible even if our caller doesn't care, unless there's an
         // aggregate in the way, in which case the aggregate will
         // destroy any underlying ordering anyway so we stop caring.
 
-        def freshName(base: String) = {
-          val names = selectList.valuesIterator.map(_.name).toSet
-          Iterator.from(1).map { i => ColumnName(base + "_" + i) }.find { n =>
-            !names.contains(n)
-          }.get
-        }
-
         val wantSubqueryOrdered = (select.isWindowed || wantOutputOrdered) && !select.isAggregated && distinctiveness == Distinctiveness.Indistinct
-        rewriteFrom(from, wantSubqueryOrdered, wantSubqueryOrdered) match {
-          case (Some((table, column)), newFrom) =>
-            val col = Column(table, column, rowNumberFunction.result)(AtomicPositionInfo.None)
+        val (extraOrdering, newFrom) = rewriteFrom(from, wantSubqueryOrdered, wantSubqueryOrdered)
 
-            val orderedSelf = select.copy(
-              from = newFrom,
-              orderBy = orderBy :+ OrderBy(col, true, true)
-            )
+        // We will at the very least want to add the ordering
+        // columns from the subquery onto the end of our order-by...
+        val orderedSelf = select.copy(
+          from = newFrom,
+          orderBy = orderBy ++ extraOrdering
+        )
+        if(wantOrderingColumns) {
+          // ..and our caller wants to know how we're ordered, so
+          // make sure we've put the relevant expressins in our
+          // select list and return them.
+          val (newColumns, outputInfo) = orderedSelf.orderBy.map { case OrderBy(expr, asc, nullLast) =>
+            val columnLabel = provider.columnLabel()
+            (columnLabel -> NamedExpr(expr, freshName("order")), (columnLabel, expr.typ, asc, nullLast))
+          }.unzip
 
-            if(wantOrderingColumn) {
-              val rowNumberLabel = provider.columnLabel()
-              val newSelf = orderedSelf.copy(
-                selectList = selectList + (rowNumberLabel -> (NamedExpr(col, freshName("order"))))
-              )
+          val newSelf = orderedSelf.copy(selectList = selectList ++ newColumns)
 
-              (Some(rowNumberLabel), newSelf)
-            } else {
-              (None, orderedSelf)
-            }
-
-          case (None, newFrom) =>
-            if(wantOrderingColumn && orderBy.nonEmpty) {
-              // assume the given order by provides a total order and
-              // reflect that in our ordering column
-
-              val rowNumberLabel = provider.columnLabel()
-              val newSelf = select.copy(
-                selectList = selectList + (rowNumberLabel -> NamedExpr(WindowedFunctionCall(rowNumberFunction, Nil, None, Nil, Nil, None)(FuncallPositionInfo.None), freshName("order"))),
-                from = newFrom
-              )
-
-              (Some(rowNumberLabel), newSelf)
-            } else {
-              // No ordered FROM _and_ no ORDER BY?  You don't get a column even though you asked for one
-              (None, select.copy(from = newFrom))
-            }
+          (outputInfo, newSelf)
+        } else {
+          // Caller doesn't care what we're ordered by, so no need
+          // to select anything to accomodate them.
+          (Nil, orderedSelf)
         }
     }
   }
 
-  def rewriteFrom(from: From, wantOutputOrdered: Boolean, wantOrderingColumn: Boolean): (Option[(TableLabel, AutoColumnLabel)], From) = {
+  def rewriteFrom(from: From, wantOutputOrdered: Boolean, wantOrderingColumns: Boolean): (Seq[OrderBy], From) = {
     from match {
       case join: Join =>
         // JOIN builds a new table, which is unordered (hence (false,
@@ -100,25 +100,25 @@ class PreserveOrdering[RNS, CT, CV] private (provider: LabelProvider, rowNumberF
           rewriteAtomicFrom(_, false, false)._2,
           { (joinType, lateral, left, right, on) => Join(joinType, lateral, left, rewriteAtomicFrom(right, false, false)._2, on) }
         )
-        (None, result)
+        (Nil, result)
       case af: AtomicFrom =>
-        rewriteAtomicFrom(af, wantOutputOrdered, wantOrderingColumn)
+        rewriteAtomicFrom(af, wantOutputOrdered, wantOrderingColumns)
     }
   }
 
-  def rewriteAtomicFrom(from: AtomicFrom, wantOutputOrdered: Boolean, wantOrderingColumn: Boolean): (Option[(TableLabel, AutoColumnLabel)], AtomicFrom) = {
+  def rewriteAtomicFrom(from: AtomicFrom, wantOutputOrdered: Boolean, wantOrderingColumns: Boolean): (Seq[OrderBy], AtomicFrom) = {
     from match {
-      case ft: FromTable => (None, ft)
-      case fs: FromSingleRow => (None, fs)
+      case ft: FromTable => (Nil, ft)
+      case fs: FromSingleRow => (Nil, fs)
       case fs@FromStatement(stmt, label, resourceName, alias) =>
-        val (orderColumn, newStmt) = rewriteStatement(stmt, wantOutputOrdered, wantOrderingColumn)
-        (orderColumn.map((label, _)), fs.copy(statement = newStmt))
+        val (orderColumn, newStmt) = rewriteStatement(stmt, wantOutputOrdered, wantOrderingColumns)
+        (orderColumn.map { case (col, typ, asc, nullLast) => OrderBy(Column(label, col, typ)(AtomicPositionInfo.None), asc, nullLast) }, fs.copy(statement = newStmt))
     }
   }
 }
 
 object PreserveOrdering {
-  def apply[RNS, CT, CV](labelProvider: LabelProvider, rowNumberFunction: MonomorphicFunction[CT], stmt: Statement[RNS, CT, CV]): Statement[RNS, CT, CV] = {
-    new PreserveOrdering[RNS, CT, CV](labelProvider, rowNumberFunction).rewriteStatement(stmt, true, false)._2
+  def apply[RNS, CT, CV](labelProvider: LabelProvider, stmt: Statement[RNS, CT, CV]): Statement[RNS, CT, CV] = {
+    new PreserveOrdering[RNS, CT, CV](labelProvider).rewriteStatement(stmt, true, false)._2
   }
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/RemoveUnusedColumns.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/RemoveUnusedColumns.scala
@@ -1,0 +1,97 @@
+package com.socrata.soql.analyzer2.rewrite
+
+import com.socrata.soql.analyzer2
+import com.socrata.soql.analyzer2._
+
+class RemoveUnusedColumns[RNS, CT, CV] private (columnReferences: Map[TableLabel, Set[ColumnLabel]]) {
+  type Statement = analyzer2.Statement[RNS, CT, CV]
+  type From = analyzer2.From[RNS, CT, CV]
+  type Join = analyzer2.Join[RNS, CT, CV]
+  type AtomicFrom = analyzer2.AtomicFrom[RNS, CT, CV]
+  type FromTable = analyzer2.FromTable[RNS, CT]
+  type FromSingleRow = analyzer2.FromSingleRow[RNS]
+
+  // myLabel being "None" means "keep all of my output columns,
+  // whether or not they appear to be used".  This is for both the
+  // top-level (where of course all the columns will be used by
+  // whatever's running the query) as well as inside CombinedTables,
+  // where the operation combining the tables will care about
+  // apparently-unused columns.
+  def rewriteStatement(stmt: Statement, myLabel: Option[TableLabel]): (Statement, Boolean) = {
+    stmt match {
+      case CombinedTables(op, left, right) =>
+        val (newLeft, removedAnythingLeft) = rewriteStatement(left, None)
+        val (newRight, removedAnythingRight) = rewriteStatement(right, None)
+        (CombinedTables(op, newLeft, newRight), removedAnythingLeft || removedAnythingRight)
+
+      case CTE(defLabel, defAlias, defQuery, materializedHint, useQuery) =>
+        val (newDefQuery, removedAnythingDef) = rewriteStatement(defQuery, Some(defLabel))
+        val (newUseQuery, removedAnythingUse) = rewriteStatement(useQuery, myLabel)
+        (CTE(defLabel, defAlias, newDefQuery, materializedHint, newUseQuery), removedAnythingDef || removedAnythingUse)
+
+      case v@Values(_) =>
+        (v, false)
+
+      case stmt@Select(distinctiveness, selectList, from, where, groupBy, having, orderBy, limit, offset, search, hint) =>
+        val newSelectList = (myLabel, distinctiveness) match {
+          case (_, Distinctiveness.FullyDistinct) | (None, _) =>
+            // need to keep all my columns
+            selectList
+          case (Some(tl), _) =>
+            val wantedColumns = columnReferences.getOrElse(tl, Set.empty)
+            selectList.filter { case (cl, _) => wantedColumns(cl) }
+        }
+        val removedAnythingSelectList = selectList.size != newSelectList.size
+
+        val (newFrom, removedAnythingFrom) = rewriteFrom(from)
+        val candidate = stmt.copy(selectList = newSelectList, from = newFrom)
+        if(candidate.isAggregated != stmt.isAggregated) {
+          // this is a super-extreme edge case, but consider
+          //   select x.x from (select count(*), 1 as x from whatever) as x
+          // Doing a naive "remove unused columns" would result in
+          //  select x.x from (select 1 as x from whatever) as x
+          // ..which changes the semantics of that inner query.  So, if removing
+          // columns from our select list changed whether or not we're aggregated,
+          // keep our column-list as-is.  This should hopefully basically never
+          // happen in practice.
+          (stmt.copy(from = newFrom), removedAnythingFrom)
+        } else {
+          (candidate, removedAnythingSelectList || removedAnythingFrom)
+        }
+    }
+  }
+
+  def rewriteFrom(from: From): (From, Boolean) = {
+    from.reduceMap[Boolean, RNS, CT, CV](
+      rewriteAtomicFrom(_).swap,
+      { (removedAnythingLeft, joinType, lateral, left, right, on) =>
+        val (newRight, removedAnythingRight) = rewriteAtomicFrom(right)
+        (removedAnythingLeft || removedAnythingRight, Join(joinType, lateral, left, newRight, on))
+      }
+    ).swap
+  }
+
+  def rewriteAtomicFrom(from: AtomicFrom): (AtomicFrom, Boolean) = {
+    from match {
+      case ft: FromTable => (ft, false)
+      case fsr: FromSingleRow => (fsr, false)
+      case FromStatement(stmt, label, resourceName, alias) =>
+        val (newStmt, removedAnything) = rewriteStatement(stmt, Some(label))
+        (FromStatement(newStmt, label, resourceName, alias), removedAnything)
+    }
+  }
+}
+
+/** Remove columns that are not useful from inner selects.
+  * SelectListReferences must not be present (this is unchecked!!). */
+object RemoveUnusedColumns {
+  def apply[RNS, CT, CV](stmt: Statement[RNS, CT, CV]): Statement[RNS, CT, CV] = {
+    val (newStmt, removedAnything) =
+      new RemoveUnusedColumns[RNS, CT, CV](stmt.columnReferences).rewriteStatement(stmt, None)
+    if(removedAnything) {
+      this(newStmt)
+    } else {
+      newStmt
+    }
+  }
+}

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/SelectListReferences.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/SelectListReferences.scala
@@ -1,0 +1,140 @@
+package com.socrata.soql.analyzer2.rewrite
+
+import com.socrata.soql.analyzer2
+import com.socrata.soql.analyzer2._
+
+class SelectListReferences[RNS, CT, CV] private () {
+  type Statement = analyzer2.Statement[RNS, CT, CV]
+  type From = analyzer2.From[RNS, CT, CV]
+  type Join = analyzer2.Join[RNS, CT, CV]
+  type AtomicFrom = analyzer2.AtomicFrom[RNS, CT, CV]
+  type FromTable = analyzer2.FromTable[RNS, CT]
+  type FromSingleRow = analyzer2.FromSingleRow[RNS]
+
+  object Use {
+    def rewriteStatement(stmt: Statement): Statement = {
+      stmt match {
+        case CombinedTables(op, left, right) =>
+          CombinedTables(op, rewriteStatement(left), rewriteStatement(right))
+
+        case CTE(defLabel, defAlias, defQuery, materializedHint, useQuery) =>
+          CTE(defLabel, defAlias, rewriteStatement(defQuery), materializedHint, rewriteStatement(useQuery))
+
+        case v@Values(_) =>
+          v
+
+        case stmt@Select(distinctiveness, selectList, from, where, groupBy, having, orderBy, limit, offset, search, hint) =>
+          val selectListIndices = selectList.valuesIterator.map(_.expr).toVector.zipWithIndex.reverseIterator.toMap
+
+          def numericateExpr(e: Expr[CT, CV]): Expr[CT, CV] = {
+            e match {
+              case c: Column[CT] =>
+                c // don't bother rewriting column references
+              case e =>
+                selectListIndices.get(e) match {
+                  case Some(idx) => SelectListReference(idx + 1, e.isAggregated, e.isWindowed, e.typ)(e.position.asAtomic)
+                  case None => e
+                }
+            }
+          }
+
+          stmt.copy(
+            distinctiveness = distinctiveness match {
+              case Distinctiveness.Indistinct | Distinctiveness.FullyDistinct => distinctiveness
+              case Distinctiveness.On(exprs) => Distinctiveness.On(exprs.map(numericateExpr))
+            },
+            from = rewriteFrom(from),
+            groupBy = groupBy.map(numericateExpr),
+            orderBy = orderBy.map { ob => ob.copy(expr = numericateExpr(ob.expr)) }
+          )
+      }
+    }
+
+    def rewriteFrom(from: From): From = {
+      from.map[RNS, CT, CV](
+        rewriteAtomicFrom(_),
+        { (joinType, lateral, left, right, on) => Join(joinType, lateral, left, rewriteAtomicFrom(right), on) }
+      )
+    }
+
+    def rewriteAtomicFrom(from: AtomicFrom): AtomicFrom = {
+      from match {
+        case ft: FromTable => ft
+        case fsr: FromSingleRow => fsr
+        case fs@FromStatement(stmt, label, resourceName, alias) =>
+          fs.copy(statement = rewriteStatement(stmt))
+      }
+    }
+  }
+
+  object Unuse {
+    def rewriteStatement(stmt: Statement): Statement = {
+      stmt match {
+        case CombinedTables(op, left, right) =>
+          CombinedTables(op, rewriteStatement(left), rewriteStatement(right))
+
+        case CTE(defLabel, defAlias, defQuery, materializedHint, useQuery) =>
+          CTE(defLabel, defAlias, rewriteStatement(defQuery), materializedHint, rewriteStatement(useQuery))
+
+        case v@Values(_) =>
+          v
+
+        case stmt@Select(distinctiveness, selectList, from, where, groupBy, having, orderBy, limit, offset, search, hint) =>
+          val selectListIndices = selectList.valuesIterator.map(_.expr).toVector
+
+          def unnumericateExpr(e: Expr[CT, CV]): Expr[CT, CV] = {
+            e match {
+              case r@SelectListReference(idxPlusOne, _, _, _) =>
+                selectListIndices(idxPlusOne - 1).reposition(r.position.logicalPosition)
+              case other =>
+                other
+            }
+          }
+
+          stmt.copy(
+            distinctiveness = distinctiveness match {
+              case Distinctiveness.Indistinct | Distinctiveness.FullyDistinct => distinctiveness
+              case Distinctiveness.On(exprs) => Distinctiveness.On(exprs.map(unnumericateExpr))
+            },
+            from = rewriteFrom(from),
+            groupBy = groupBy.map(unnumericateExpr),
+            orderBy = orderBy.map { ob => ob.copy(expr = unnumericateExpr(ob.expr)) }
+          )
+      }
+    }
+
+    def rewriteFrom(from: From): From = {
+      from.map[RNS, CT, CV](
+        rewriteAtomicFrom(_),
+        { (joinType, lateral, left, right, on) => Join(joinType, lateral, left, rewriteAtomicFrom(right), on) }
+      )
+    }
+
+    def rewriteAtomicFrom(from: AtomicFrom): AtomicFrom = {
+      from match {
+        case ft: FromTable => ft
+        case fsr: FromSingleRow => fsr
+        case fs@FromStatement(stmt, label, resourceName, alias) =>
+          fs.copy(statement = rewriteStatement(stmt))
+      }
+    }
+  }
+}
+
+/** Rewrite the given statement to either use or stop using
+  * select-list references in DISTINCT ON, GROUP BY, and ORDER BY
+  * clauses.
+  *
+  * e.g., this will rewrite a Statement that corresponds to "select
+  * x+1, count(*) group by x+1 order by count(*)" to one that
+  * corresponds to "select x+1, count(*) group by 1 order by 2"
+  */
+object SelectListReferences {
+  def use[RNS, CT, CV](stmt: Statement[RNS, CT, CV]): Statement[RNS, CT, CV] = {
+    new SelectListReferences[RNS, CT, CV]().Use.rewriteStatement(stmt)
+  }
+
+  def unuse[RNS, CT, CV](stmt: Statement[RNS, CT, CV]): Statement[RNS, CT, CV] = {
+    new SelectListReferences[RNS, CT, CV]().Unuse.rewriteStatement(stmt)
+  }
+}

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CTE.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CTE.scala
@@ -32,12 +32,6 @@ trait CTEImpl[+RNS, +CT, +CV] { this: CTE[RNS, CT, CV] =>
   def useSelectListReferences = copy(definitionQuery = definitionQuery.useSelectListReferences, useQuery = useQuery.useSelectListReferences)
   def unuseSelectListReferences = copy(definitionQuery = definitionQuery.unuseSelectListReferences, useQuery = useQuery.unuseSelectListReferences)
 
-  private[analyzer2] def doRemoveUnusedColumns(used: Map[TableLabel, Set[ColumnLabel]], myLabel: Option[TableLabel]): Self[RNS, CT, CV] =
-    copy(
-      definitionQuery = definitionQuery.doRemoveUnusedColumns(used, Some(definitionLabel)),
-      useQuery = useQuery.doRemoveUnusedColumns(used, myLabel)
-    )
-
   private[analyzer2] def doRewriteDatabaseNames(state: RewriteDatabaseNamesState) =
     copy(
       definitionQuery = definitionQuery.doRewriteDatabaseNames(state),

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CTE.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CTE.scala
@@ -29,9 +29,6 @@ trait CTEImpl[+RNS, +CT, +CV] { this: CTE[RNS, CT, CV] =>
   private[analyzer2] def columnReferences: Map[TableLabel, Set[ColumnLabel]] =
     definitionQuery.columnReferences.mergeWith(useQuery.columnReferences)(_ ++ _)
 
-  def useSelectListReferences = copy(definitionQuery = definitionQuery.useSelectListReferences, useQuery = useQuery.useSelectListReferences)
-  def unuseSelectListReferences = copy(definitionQuery = definitionQuery.unuseSelectListReferences, useQuery = useQuery.unuseSelectListReferences)
-
   private[analyzer2] def doRewriteDatabaseNames(state: RewriteDatabaseNamesState) =
     copy(
       definitionQuery = definitionQuery.doRewriteDatabaseNames(state),

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CTE.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CTE.scala
@@ -40,22 +40,6 @@ trait CTEImpl[+RNS, +CT, +CV] { this: CTE[RNS, CT, CV] =>
          definitionQuery = definitionQuery.doRelabel(state),
          useQuery = useQuery.doRelabel(state))
 
-  private[analyzer2] override def preserveOrdering[CT2 >: CT](
-    provider: LabelProvider,
-    rowNumberFunction: MonomorphicFunction[CT2],
-    wantOutputOrdered: Boolean,
-    wantOrderingColumn: Boolean
-  ): (Option[AutoColumnLabel], Self[RNS, CT2, CV]) = {
-    val (orderingColumn, newUseQuery) = useQuery.preserveOrdering(provider, rowNumberFunction, wantOutputOrdered, wantOrderingColumn)
-    (
-      orderingColumn,
-      copy(
-        definitionQuery = definitionQuery.preserveOrdering(provider, rowNumberFunction, false, false)._2,
-        useQuery = newUseQuery
-      )
-    )
-  }
-
   private[analyzer2] def findIsomorphism[RNS2 >: RNS, CT2 >: CT, CV2 >: CV](
     state: IsomorphismState,
     thisCurrentTableLabel: Option[TableLabel],

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CombinedTables.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CombinedTables.scala
@@ -43,13 +43,6 @@ trait CombinedTablesImpl[+RNS, +CT, +CV] { this: CombinedTables[RNS, CT, CV] =>
     right.doLabelMap(state)
   }
 
-  private[analyzer2] def doRemoveUnusedColumns(used: Map[TableLabel, Set[ColumnLabel]], myLabel: Option[TableLabel]): Self[RNS, CT, CV] =
-    // We need all the columns in our subqueries to correctly do our
-    // table operation, so ignore what we're told are used and just
-    // tell our subqueries "go clean yourselves up without affecting
-    // your output schemas".
-    copy(left = left.doRemoveUnusedColumns(used, None), right = right.doRemoveUnusedColumns(used, None))
-
   private[analyzer2] def findIsomorphism[RNS2 >: RNS, CT2 >: CT, CV2 >: CV](
     state: IsomorphismState,
     thisCurrentTableLabel: Option[TableLabel],

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CombinedTables.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CombinedTables.scala
@@ -72,9 +72,6 @@ trait CombinedTablesImpl[+RNS, +CT, +CV] { this: CombinedTables[RNS, CT, CV] =>
       )
     )
 
-  def useSelectListReferences = copy(left = left.useSelectListReferences, right = right.useSelectListReferences)
-  def unuseSelectListReferences = copy(left = left.unuseSelectListReferences, right = right.unuseSelectListReferences)
-
   def mapAlias(f: Option[ResourceName] => Option[ResourceName]): Self[RNS, CT, CV] =
     copy(left = left.mapAlias(f), right = right.mapAlias(f))
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CombinedTables.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CombinedTables.scala
@@ -57,21 +57,6 @@ trait CombinedTablesImpl[+RNS, +CT, +CV] { this: CombinedTables[RNS, CT, CV] =>
         false
     }
 
-  private[analyzer2] override def preserveOrdering[CT2 >: CT](
-    provider: LabelProvider,
-    rowNumberFunction: MonomorphicFunction[CT2],
-    wantOutputOrdered: Boolean,
-    wantOrderingColumn: Boolean
-  ): (Option[AutoColumnLabel], Self[RNS, CT2, CV]) =
-    (
-      // table ops never preserve ordering
-      None,
-      copy(
-        left = left.preserveOrdering(provider, rowNumberFunction, false, false)._2,
-        right = right.preserveOrdering(provider, rowNumberFunction, false, false)._2
-      )
-    )
-
   def mapAlias(f: Option[ResourceName] => Option[ResourceName]): Self[RNS, CT, CV] =
     copy(left = left.mapAlias(f), right = right.mapAlias(f))
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Values.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Values.scala
@@ -65,16 +65,6 @@ trait ValuesImpl[+CT, +CV] { this: Values[CT, CV] =>
   private[analyzer2] def doRelabel(state: RelabelState): Self[Nothing, CT, CV] =
     copy(values = values.map(_.map(_.doRelabel(state))))
 
-  private[analyzer2] override def preserveOrdering[CT2 >: CT](
-    provider: LabelProvider,
-    rowNumberFunction: MonomorphicFunction[CT2],
-    wantOutputOrdered: Boolean,
-    wantOrderingColumn: Boolean
-  ): (Option[AutoColumnLabel], Self[Nothing, CT2, CV]) = {
-    // VALUES are a table and hence unordered
-    (None, this)
-  }
-
   override def debugDoc(implicit ev: HasDoc[CV]): Doc[Annotation[Nothing, CT]] = {
     Seq(
       d"VALUES",

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Values.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Values.scala
@@ -26,9 +26,6 @@ trait ValuesImpl[+CT, +CV] { this: Values[CT, CV] =>
   private[analyzer2] def columnReferences: Map[TableLabel, Set[ColumnLabel]] =
     Map.empty
 
-  private[analyzer2] def doRemoveUnusedColumns(used: Map[TableLabel, Set[ColumnLabel]], myLabel: Option[TableLabel]): Self[Nothing, CT, CV] =
-    this
-
   private[analyzer2] def findIsomorphism[RNS2, CT2 >: CT, CV2 >: CV](
     state: IsomorphismState,
     thisCurrentTableLabel: Option[TableLabel],

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Values.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Values.scala
@@ -47,9 +47,6 @@ trait ValuesImpl[+CT, +CV] { this: Values[CT, CV] =>
 
   val schema = typeVariedSchema
 
-  def useSelectListReferences = this
-  def unuseSelectListReferences = this
-
   def find(predicate: Expr[CT, CV] => Boolean): Option[Expr[CT, CV]] =
     values.iterator.flatMap(_.iterator.flatMap(_.find(predicate))).nextOption()
 


### PR DESCRIPTION
Mostly pulling it them out into their own files, and putting them all in the `rewrite` sub-package of analyzer2, but also heavily reworking the preserveOrdering rewrite so that it doesn't need the `row_number` function anymore (which both makes it easier to use and might let PG's query optimizer see what we're doing with this?)