### PR TITLE
Teach the soql-renderer about precedence

### DIFF
--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Expression.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Expression.scala
@@ -7,6 +7,7 @@ import scala.collection.immutable.VectorBuilder
 
 import com.socrata.soql.environment.{ColumnName, FunctionName, HoleName, TableName, TypeName}
 import com.socrata.prettyprint.prelude._
+import com.socrata.soql.parsing.RecursiveDescentParser
 
 sealed abstract class Expression extends Product {
   val position: Position
@@ -24,6 +25,8 @@ sealed abstract class Expression extends Product {
 
   def replaceHoles(f: Hole => Expression): Expression
   def collectHoles(f: PartialFunction[Hole, Expression]): Expression
+
+  def removeSyntacticParens: Expression
 
   def doc: Doc[Nothing]
 }
@@ -177,12 +180,14 @@ case class ColumnOrAliasRef(qualifier: Option[String], column: ColumnName)(val p
   def allColumnRefs = Set(this)
   def replaceHoles(f: Hole => Expression): this.type = this
   def collectHoles(f: PartialFunction[Hole, Expression]): this.type = this
+  def removeSyntacticParens: this.type = this
 }
 
 sealed abstract class Literal extends Expression {
   def allColumnRefs = Set.empty
   def replaceHoles(f: Hole => Expression): this.type = this
   def collectHoles(f: PartialFunction[Hole, Expression]): this.type = this
+  def removeSyntacticParens: this.type = this
 }
 case class NumberLiteral(value: BigDecimal)(val position: Position) extends Literal {
   def doc = Doc(value.toString)
@@ -198,6 +203,17 @@ case class NullLiteral()(val position: Position) extends Literal {
 }
 
 case class FunctionCall(functionName: FunctionName, parameters: Seq[Expression], filter: Option[Expression] = None, window: Option[WindowFunctionInfo] = None)(val position: Position, val functionNamePosition: Position) extends Expression  {
+  def removeSyntacticParens =
+    if(functionName == SpecialFunctions.Parens) {
+      parameters(0).removeSyntacticParens
+    } else {
+      copy(
+        parameters = parameters.map(_.removeSyntacticParens),
+        filter = filter.map(_.removeSyntacticParens),
+        window = window.map(_.removeSyntacticParens)
+      )(position, functionNamePosition)
+    }
+
   private[ast] def variadizeAssociative(builder: VectorBuilder[Expression]): Unit = {
     require(parameters.length == 2)
     require(window.isEmpty)
@@ -226,6 +242,9 @@ case class FunctionCall(functionName: FunctionName, parameters: Seq[Expression],
       case other => other.doc
     }
 
+  private def parenify(e: Expression) =
+    d"(" ++ e.doc ++ d")"
+
   private def functionDoc(funDoc: Doc[Nothing]): Doc[Nothing] = {
     if (filter.isEmpty && window.isEmpty) {
       funDoc
@@ -237,18 +256,47 @@ case class FunctionCall(functionName: FunctionName, parameters: Seq[Expression],
     }
   }
 
-  def doc: Doc[Nothing] =
+  def doc: Doc[Nothing] = {
+    lazy val precLevel = RecursiveDescentParser.precedenceOf(this)
+
+    def opArg(op: Expression, parenLowerOnly: Boolean = false): Doc[Nothing] = {
+      op match {
+        case fc: FunctionCall =>
+          RecursiveDescentParser.precedenceOf(fc) match {
+            case Some(thatPrec) =>
+              precLevel match {
+                case Some(myPrec) =>
+                  // Both I and the argument have precedences at all,
+                  // so insert parens if appropriate.
+                  if(thatPrec < myPrec) {
+                    parenify(op)
+                  } else if(thatPrec == myPrec && !parenLowerOnly) {
+                    parenify(op)
+                  } else {
+                    maybeParens(op)
+                  }
+                case None =>
+                  maybeParens(op)
+              }
+            case None =>
+              maybeParens(op)
+          }
+        case _ =>
+          op.doc
+      }
+    }
+
     functionName match {
       case SpecialFunctions.Parens =>
         parameters(0).doc.enclose(d"(", d")")
       case SpecialFunctions.Subscript =>
-        parameters(0).doc ++ parameters(1).doc.enclose(d"[", d"]")
+        opArg(parameters(0), parenLowerOnly = true) ++ parameters(1).doc.enclose(d"[", d"]")
       case SpecialFunctions.StarFunc(f) =>
         functionDoc(d"$f(*)")
       case SpecialFunctions.Operator(op) if parameters.size == 1 =>
         op match {
           case "NOT" =>
-            d"NOT" +#+ parameters(0).doc
+            d"NOT" +#+ opArg(parameters(0))
           case _ =>
             // need to prevent "- -x" from formatting as "--x" but
             // otherwise we want the op to be right next to its
@@ -257,9 +305,9 @@ case class FunctionCall(functionName: FunctionName, parameters: Seq[Expression],
             // there.
             parameters(0) match {
               case FunctionCall(SpecialFunctions.Operator(_), Seq(_), _, _) =>
-                Doc(op) +#+ parameters(0).doc
+                Doc(op) +#+ opArg(parameters(0), parenLowerOnly = true)
               case _ =>
-                Doc(op) ++ parameters(0).doc
+                Doc(op) ++ opArg(parameters(0), parenLowerOnly = true)
             }
         }
       case SpecialFunctions.Operator(op) if parameters.size == 2 =>
@@ -273,30 +321,35 @@ case class FunctionCall(functionName: FunctionName, parameters: Seq[Expression],
             val builder = new VectorBuilder[Expression]
             variadizeAssociative(builder)
             val result = builder.result()
-            (maybeParens(result.head) +: result.drop(1).map { e => Doc(op) +#+ maybeParens(e) }).sep.hang(2)
+            // not higherOnly because of variadize hack
+            (opArg(result.head) +: result.drop(1).map { e => Doc(op) +#+ opArg(e) }).sep.hang(2)
           case _ =>
-            Seq(maybeParens(parameters(0)), Doc(op) +#+ maybeParens(parameters(1))).sep.hang(2)
+            val associativity = RecursiveDescentParser.associativityOf(this)
+            val isLeftAssoc = associativity == Some(RecursiveDescentParser.Associativity.Left)
+            val isRightAssoc = associativity == Some(RecursiveDescentParser.Associativity.Right)
+
+            Seq(opArg(parameters(0), parenLowerOnly = isLeftAssoc), Doc(op) +#+ opArg(parameters(1), parenLowerOnly = isRightAssoc)).sep.hang(2)
         }
       case SpecialFunctions.Operator(op) =>
         sys.error("Found a non-unary, non-binary operator: " + op + " at " + position)
       case SpecialFunctions.Cast(typ) if parameters.size == 1 =>
-        d"${parameters(0).doc} :: ${typ.toString}"
+        d"${opArg(parameters(0), parenLowerOnly = true)} :: ${typ.toString}"
       case SpecialFunctions.Between =>
-        Seq(parameters(0).doc, d"BETWEEN ${parameters(1).doc}", d"AND ${parameters(2).doc}").sep.hang(2)
+        Seq(opArg(parameters(0)), d"BETWEEN ${opArg(parameters(1))}", d"AND ${opArg(parameters(2))}").sep.hang(2)
       case SpecialFunctions.NotBetween =>
-        Seq(parameters(0).doc, d"NOT BETWEEN ${parameters(1).doc}", d"AND ${parameters(2).doc}").sep.hang(2)
+        Seq(opArg(parameters(0)), d"NOT BETWEEN ${opArg(parameters(1))}", d"AND ${opArg(parameters(2))}").sep.hang(2)
       case SpecialFunctions.IsNull =>
-        d"${parameters(0).doc} IS NULL"
+        d"${opArg(parameters(0))} IS NULL"
       case SpecialFunctions.IsNotNull =>
-        d"${parameters(0).doc} IS NOT NULL"
+        d"${opArg(parameters(0))} IS NOT NULL"
       case SpecialFunctions.In =>
-        parameters.iterator.drop(1).map(_.doc).to(LazyList).encloseNesting(d"${parameters(0).doc} IN (", Doc.Symbols.comma, d")").group
+        parameters.iterator.drop(1).map(_.doc).to(LazyList).encloseNesting(d"${opArg(parameters(0))} IN (", Doc.Symbols.comma, d")").group
       case SpecialFunctions.NotIn =>
-        parameters.iterator.drop(1).map(_.doc).to(LazyList).encloseNesting(d"${parameters(0).doc} NOT IN (", Doc.Symbols.comma, d")").group
+        parameters.iterator.drop(1).map(_.doc).to(LazyList).encloseNesting(d"${opArg(parameters(0))} NOT IN (", Doc.Symbols.comma, d")").group
       case SpecialFunctions.Like =>
-        d"${parameters(0).doc} LIKE ${parameters(1).doc}"
+        d"${opArg(parameters(0))} LIKE ${opArg(parameters(1))}"
       case SpecialFunctions.NotLike =>
-        d"${parameters(0).doc} NOT LIKE ${parameters(1).doc}"
+        d"${opArg(parameters(0))} NOT LIKE ${opArg(parameters(1))}"
       case SpecialFunctions.CountDistinct if parameters.length == 1 =>
         functionDoc(d"count(DISTINCT " ++ parameters(0).doc ++ d")")
       case SpecialFunctions.Case =>
@@ -322,6 +375,7 @@ case class FunctionCall(functionName: FunctionName, parameters: Seq[Expression],
           functionDoc(funDoc)
         }
     }
+  }
 
   private implicit class Interspersable[T](xs: Seq[T]) {
     def intersperse(t: T): Seq[T] = {
@@ -354,6 +408,12 @@ case class FunctionCall(functionName: FunctionName, parameters: Seq[Expression],
 }
 
 case class WindowFunctionInfo(partitions: Seq[Expression], orderings: Seq[OrderBy], frames: Seq[Expression]) {
+  def removeSyntacticParens =
+    WindowFunctionInfo(
+      partitions.map(_.removeSyntacticParens),
+      orderings.map(_.removeSyntacticParens),
+      frames.map(_.removeSyntacticParens)
+    )
 
   def doc: Doc[Nothing] = {
     val partitionDocs: Option[Doc[Nothing]] =
@@ -397,6 +457,7 @@ sealed abstract class Hole extends Expression {
   final def allColumnRefs = Set.empty
   final def replaceHoles(f: Hole => Expression) = f(this)
   final def collectHoles(f: PartialFunction[Hole, Expression]) = f.applyOrElse(this, Function.const(this))
+  final def removeSyntacticParens: this.type = this
 }
 
 object Hole {

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Select.scala
@@ -561,6 +561,8 @@ case class OrderBy(expression: Expression, ascending: Boolean, nullLast: Boolean
     val nullPlacement = if(nullLast) d"NULL LAST" else d"NULL FIRST"
     expression.doc +#+ direction +#+ nullPlacement
   }
+
+  def removeSyntacticParens = copy(expression = expression.removeSyntacticParens)
 }
 
 object SimpleSelect {

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/RecursiveDescentParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/RecursiveDescentParser.scala
@@ -261,15 +261,15 @@ object RecursiveDescentParser {
   object OperatorClass {
     sealed abstract class Simple extends OperatorClass
 
-    case class Binary(ops: Seq[Token], associativity: Associativity)(val expectation: ListSet[Expectation] = ops.map[Expectation](ActualToken(_)).to(ListSet)) extends Simple {
-      val opNames = ops.iterator.map { token => token -> SpecialFunctions.Operator(token.printable) }.to(ListMap)
+    case class Binary(ops: Seq[Token], associativity: Associativity)(val expectation: ListSet[Expectation] = ops.map(ActualToken(_) : Expectation).to(ListSet)) extends Simple {
+      val opNames = ListMap() ++ ops.iterator.map { token => token -> SpecialFunctions.Operator(token.printable) }
       val functions = opNames.values.toSet
 
       def parse(parser: RecursiveDescentParser, reader: Reader, nextParser: ExprParser): ParseResult[Expression] =
         parser.parseBinOp(this, reader, nextParser)
     }
-    case class Prefix(ops: Seq[Token])(val expectation: ListSet[Expectation] = ops.map[Expectation](ActualToken(_)).to(ListSet)) extends Simple {
-      val opNames = ops.iterator.map { t => t -> SpecialFunctions.Operator(t.printable) }.to(ListMap)
+    case class Prefix(ops: Seq[Token])(val expectation: ListSet[Expectation] = ops.map(ActualToken(_) : Expectation).to(ListSet)) extends Simple {
+      val opNames = ListMap() ++ ops.iterator.map { t => t -> SpecialFunctions.Operator(t.printable) }
       val functions = opNames.values.toSet
 
       def parse(parser: RecursiveDescentParser, reader: Reader, nextParser: ExprParser): ParseResult[Expression] = {
@@ -372,7 +372,7 @@ object RecursiveDescentParser {
   private val complexPrecedences: Array[(OperatorClass.Special, Int)] =
     precedenceTable.iterator.zipWithIndex.collect { case (special: OperatorClass.Special, precLevel) =>
       special -> precLevel
-    }.to(Array)
+    }.toArray
 
   def precedenceOf(node: FunctionCall): Option[Int] = {
     simplePrecedences.get((node.functionName, node.parameters.length)).orElse {

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/RecursiveDescentParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/RecursiveDescentParser.scala
@@ -1,6 +1,7 @@
 package com.socrata.soql.parsing
 
-import scala.collection.immutable.ListSet
+import scala.collection.immutable.{ListSet, ListMap}
+import scala.collection.compat._
 import scala.collection.compat.immutable.LazyList
 import scala.util.parsing.input.Position
 import scala.annotation.tailrec
@@ -181,7 +182,6 @@ object RecursiveDescentParser {
   // and recreating these sets on-site has a fairly hefty runtime
   // cost.
   private[this] def s(xs: Expectation*) = ListSet(xs : _*)
-  private val AND_SET = s(AND())
   private val LIMIT_OFFSET_SET = s(LIMIT(), OFFSET())
   private val LIMIT_SET = s(LIMIT())
   private val OFFSET_SET = s(OFFSET())
@@ -214,7 +214,6 @@ object RecursiveDescentParser {
   private val DOT_LBRACKET_SET = s(DOT(), LBRACKET())
 
   private val COLONCOLON_SET = s(COLONCOLON())
-  private val MINUS_PLUS_SET = s(MINUS(), PLUS())
 
   // These are all collapsed into "an operator" for ease of
   // interpretation by an end-user instead of getting a bunch of
@@ -230,6 +229,160 @@ object RecursiveDescentParser {
   private val LIKE_BETWEEN_IN_SET = s(IS(), AnIsNot, LIKE(), ANotLike, BETWEEN(), ANotBetween, IN(), ANotIn)
   private val NOT_SET = s(NOT())
   private val OR_SET = s(OR())
+
+  type ExprParser = Reader => ParseResult[Expression]
+
+  case class Precedented(
+    parser: (RecursiveDescentParser, Reader, ExprParser) => ParseResult[Expression],
+    candidateFunctions: Seq[(FunctionName => Boolean, Option[Int])]
+  )
+
+  sealed abstract class Associativity
+  object Associativity {
+    case object Left extends Associativity
+    case object Right extends Associativity
+  }
+
+  sealed abstract class Operator
+  object Operator {
+    case class Binary(token: Token, associativity: Associativity) extends Operator {
+      val name = SpecialFunctions.Operator(token.printable)
+    }
+    case class Unary(token: Token) extends Operator {
+      val name = SpecialFunctions.Operator(token.printable)
+    }
+    case class Special(name: FunctionName) extends Operator
+    case object Cast extends Operator
+  }
+
+  sealed abstract class OperatorClass {
+    def parse(parser: RecursiveDescentParser, reader: Reader, nextParser: ExprParser): ParseResult[Expression]
+  }
+  object OperatorClass {
+    sealed abstract class Simple extends OperatorClass
+
+    case class Binary(ops: Seq[Token], associativity: Associativity)(val expectation: ListSet[Expectation] = ops.map[Expectation](ActualToken(_)).to(ListSet)) extends Simple {
+      val opNames = ops.iterator.map { token => token -> SpecialFunctions.Operator(token.printable) }.to(ListMap)
+      val functions = opNames.values.toSet
+
+      def parse(parser: RecursiveDescentParser, reader: Reader, nextParser: ExprParser): ParseResult[Expression] =
+        parser.parseBinOp(this, reader, nextParser)
+    }
+    case class Prefix(ops: Seq[Token])(val expectation: ListSet[Expectation] = ops.map[Expectation](ActualToken(_)).to(ListSet)) extends Simple {
+      val opNames = ops.iterator.map { t => t -> SpecialFunctions.Operator(t.printable) }.to(ListMap)
+      val functions = opNames.values.toSet
+
+      def parse(parser: RecursiveDescentParser, reader: Reader, nextParser: ExprParser): ParseResult[Expression] = {
+        parser.parsePrefixOp(this, reader, nextParser)
+      }
+    }
+
+    sealed abstract class Special extends OperatorClass {
+      def matches(node: FunctionCall): Boolean
+    }
+
+    case object Cast extends Special {
+      def matches(node: FunctionCall) =
+        node.parameters.lengthCompare(1) == 0 &&
+          node.filter.isEmpty &&
+          node.window.isEmpty &&
+          SpecialFunctions.Cast.unapply(node.functionName).isDefined
+
+      def parse(parser: RecursiveDescentParser, reader: Reader, nextParser: ExprParser): ParseResult[Expression] =
+        parser.cast(reader, nextParser)
+    }
+
+    case object SqlishMultitoken extends Special {
+      private val functions = Map( // negative means "at least as many as the absolute value"
+        SpecialFunctions.IsNull -> 1,
+        SpecialFunctions.Between -> 3,
+        SpecialFunctions.Like -> 2,
+        SpecialFunctions.In -> -2,
+        SpecialFunctions.IsNotNull -> 1,
+        SpecialFunctions.NotBetween -> 3,
+        SpecialFunctions.NotLike -> 2,
+        SpecialFunctions.NotIn -> -2
+      )
+
+      def matches(node: FunctionCall) =
+        node.filter.isEmpty && node.window.isEmpty && (
+          functions.get(node.functionName) match {
+            case Some(n) if n >= 0 => node.parameters.lengthCompare(n) == 0
+            case Some(n) => node.parameters.lengthCompare(-n) >= 0
+            case None =>
+              false
+          }
+        )
+
+      def parse(parser: RecursiveDescentParser, reader: Reader, nextParser: ExprParser): ParseResult[Expression] =
+        parser.likeBetweenIn(reader, nextParser)
+    }
+
+    case object Subscript extends Special {
+      def matches(node: FunctionCall) =
+        node.filter.isEmpty && node.window.isEmpty && node.parameters.lengthCompare(2) == 0 && node.functionName == SpecialFunctions.Subscript
+      def parse(parser: RecursiveDescentParser, reader: Reader, nextParser: ExprParser): ParseResult[Expression] =
+        parser.dereference(reader, nextParser)
+    }
+  }
+
+  // higher index == binds more tightly
+  private val precedenceTable = Array(
+    OperatorClass.Binary(Seq(OR()), Associativity.Left)(),
+    OperatorClass.Binary(Seq(AND()), Associativity.Left)(),
+    OperatorClass.Prefix(Seq(NOT()))(),
+    OperatorClass.SqlishMultitoken,
+
+    // These all have an expectation of just "an operator" because
+    // it makes nicer error messages than listing out all the
+    // possibilities.
+    OperatorClass.Binary(Seq(EQUALS(), LESSGREATER(), LESSTHAN(), LESSTHANOREQUALS(), GREATERTHAN(), GREATERTHANOREQUALS(), EQUALSEQUALS(), BANGEQUALS()), Associativity.Left)(OPERATOR_SET),
+    OperatorClass.Binary(Seq(PLUS(), MINUS(), PIPEPIPE()), Associativity.Left)(OPERATOR_SET),
+    OperatorClass.Binary(Seq(STAR(), SLASH(), PERCENT()), Associativity.Left)(OPERATOR_SET),
+    OperatorClass.Binary(Seq(CARET()), Associativity.Right)(OPERATOR_SET),
+
+    OperatorClass.Prefix(Seq(PLUS(), MINUS()))(),
+    OperatorClass.Cast,
+    OperatorClass.Subscript
+  )
+
+  // (functionName, arity) => precedence map
+  private val simplePrecedences =
+    precedenceTable.iterator.zipWithIndex.foldLeft(Map.empty[(FunctionName, Int), Int]) { case (acc, (opClass, precLevel)) =>
+      opClass match {
+        case bin: OperatorClass.Binary =>
+          acc ++ bin.functions.iterator.map { fn => (fn, 2) -> precLevel }
+        case pfx: OperatorClass.Prefix =>
+          acc ++ pfx.functions.iterator.map { fn => (fn, 1) -> precLevel }
+        case _ : OperatorClass.Special =>
+          acc
+      }
+    }
+
+  private val simpleAssociativities =
+    precedenceTable.iterator.foldLeft(Map.empty[(FunctionName, Int), Associativity]) { (acc, opClass) =>
+      opClass match {
+        case bin: OperatorClass.Binary =>
+          acc ++ bin.functions.iterator.map { fn => (fn, 2) -> bin.associativity }
+        case _ =>
+          acc
+      }
+    }
+
+  private val complexPrecedences: Array[(OperatorClass.Special, Int)] =
+    precedenceTable.iterator.zipWithIndex.collect { case (special: OperatorClass.Special, precLevel) =>
+      special -> precLevel
+    }.to(Array)
+
+  def precedenceOf(node: FunctionCall): Option[Int] = {
+    simplePrecedences.get((node.functionName, node.parameters.length)).orElse {
+      complexPrecedences.find { case (cls, _) => cls.matches(node) }.map(_._2)
+    }
+  }
+
+  def associativityOf(node: FunctionCall): Option[Associativity] = {
+    simpleAssociativities.get((node.functionName, node.parameters.length))
+  }
 }
 
 abstract class RecursiveDescentParser(parameters: AbstractParser.Parameters = AbstractParser.defaultParameters) extends AbstractParser with RecursiveDescentHintParser {
@@ -1386,8 +1539,8 @@ abstract class RecursiveDescentParser(parameters: AbstractParser.Parameters = Ab
     }
   }
 
-  private def dereference(reader: Reader): ParseResult[Expression] = {
-    val ParseResult(r2, e) = atom(reader)
+  private def dereference(reader: Reader, nextParser: ExprParser): ParseResult[Expression] = {
+    val ParseResult(r2, e) = nextParser(reader)
     dereference_!(r2, e)
   }
 
@@ -1412,106 +1565,33 @@ abstract class RecursiveDescentParser(parameters: AbstractParser.Parameters = Ab
     }
   }
 
-  private def cast(reader: Reader): ParseResult[Expression] = {
-    val ParseResult(r2, arg) = dereference(reader)
-    cast_!(r2, arg)
+  private def cast(reader: Reader, nextParser: ExprParser): ParseResult[Expression] = {
+    val ParseResult(r2, arg) = nextParser(reader)
+    cast_!(r2, nextParser, arg)
   }
 
   @tailrec
-  private def cast_!(reader: Reader, arg: Expression): ParseResult[Expression] = {
+  private def cast_!(reader: Reader, higherPrecedence: ExprParser, arg: Expression): ParseResult[Expression] = {
     reader.first match {
       case op@COLONCOLON() =>
         val ParseResult(r2, (ident, identPos)) = simpleIdentifier(reader.rest)
-        cast_!(r2, FunctionCall(SpecialFunctions.Cast(TypeName(ident)), Seq(arg), None)(arg.position, identPos))
+        cast_!(r2, higherPrecedence, FunctionCall(SpecialFunctions.Cast(TypeName(ident)), Seq(arg), None)(arg.position, identPos))
       case _ =>
         reader.addAlternates(COLONCOLON_SET)
         ParseResult(reader, arg)
     }
   }
 
-  private def unary(reader: Reader): ParseResult[Expression] = {
-    reader.first match {
-      case op@(MINUS() | PLUS()) =>
-        unary(reader.rest).map { arg =>
-          FunctionCall(SpecialFunctions.Operator(op.printable), Seq(arg), None)(op.position, op.position)
+  private def parsePrefixOp(opCls: OperatorClass.Prefix, reader: Reader, nextParser: ExprParser): ParseResult[Expression] = {
+    val opToken = reader.first
+    opCls.opNames.get(opToken) match {
+      case Some(funcName) =>
+        parsePrefixOp(opCls, reader.rest, nextParser).map { arg =>
+          FunctionCall(funcName, Seq(arg), None)(opToken.position, opToken.position)
         }
-      case _ =>
-        reader.addAlternates(MINUS_PLUS_SET)
-        cast(reader)
-    }
-  }
-
-  private def exp(reader: Reader): ParseResult[Expression] = {
-    val ParseResult(r2, arg) = unary(reader)
-    r2.first match {
-      case op@CARET() =>
-        exp(r2.rest).map { arg2 =>
-          FunctionCall(SpecialFunctions.Operator(op.printable), Seq(arg, arg2), None)(arg.position, op.position)
-        }
-      case _ =>
-        reader.addAlternates(OPERATOR_SET) // CARETSET - See note in order_!()
-        ParseResult(r2, arg)
-    }
-  }
-
-  private def factor(reader: Reader): ParseResult[Expression] = {
-    val ParseResult(r2, e) = exp(reader)
-    factor_!(r2, e)
-  }
-
-  @tailrec
-  private def factor_!(reader: Reader, arg: Expression): ParseResult[Expression] = {
-    reader.first match {
-      case op@(STAR() | SLASH() | PERCENT()) =>
-        val ParseResult(r2, arg2) = exp(reader.rest)
-        factor_!(r2, FunctionCall(SpecialFunctions.Operator(op.printable), Seq(arg, arg2), None)(arg.position, op.position))
-      case _ =>
-        reader.addAlternates(OPERATOR_SET) // FACTORSET - See note in order_!()
-        ParseResult(reader, arg)
-    }
-  }
-
-  private def term(reader: Reader): ParseResult[Expression] = {
-    val ParseResult(r2, e) = factor(reader)
-    term_!(r2, e)
-  }
-
-  @tailrec
-  private def term_!(reader: Reader, arg: Expression): ParseResult[Expression] = {
-    reader.first match {
-      case op@(PLUS() | MINUS() | PIPEPIPE()) =>
-        val ParseResult(r2, arg2) = factor(reader.rest)
-        term_!(r2, FunctionCall(SpecialFunctions.Operator(op.printable), Seq(arg, arg2), None)(arg.position, op.position))
-      case _ =>
-        reader.addAlternates(OPERATOR_SET) // TERMSET - See note in order_!()
-        ParseResult(reader, arg)
-    }
-  }
-
-  private def order(reader: Reader): ParseResult[Expression] = {
-    val ParseResult(r2, e) = term(reader)
-    order_!(r2, e)
-  }
-
-  @tailrec
-  private def order_!(reader: Reader, arg: Expression): ParseResult[Expression] = {
-    reader.first match {
-      case op@(EQUALS() | LESSGREATER() | LESSTHAN() | LESSTHANOREQUALS() | GREATERTHAN() | GREATERTHANOREQUALS() | EQUALSEQUALS() | BANGEQUALS()) =>
-        val ParseResult(r2, arg2) = term(reader.rest)
-        order_!(r2, FunctionCall(SpecialFunctions.Operator(op.printable), Seq(arg, arg2), None)(arg.position, op.position))
-      case _ =>
-        // So a bunch this adds an expectation of just "an operator"
-        // rather than specifying the operators it expects, and the
-        // functions above up through `exp` do not.  This only works
-        // because these handful of functions are a unique chain of
-        // parser functions - everything that enters enter order()
-        // (and _only_ those things) will be able to pass through
-        // those, and they pass through them without any intervening
-        // parsing steps.  As a result, we can just collapse _all_ of
-        // their expectations into just "we want some operator here".
-
-        reader.addAlternates(OPERATOR_SET) // COMPARISONSET
-        ParseResult(reader, arg)
+      case None =>
+        reader.addAlternates(opCls.expectation)
+        nextParser(reader)
     }
   }
 
@@ -1543,7 +1623,7 @@ abstract class RecursiveDescentParser(parameters: AbstractParser.Parameters = Ab
     }
   }
 
-  private def parseIn(name: FunctionName, scrutinee: Expression, op: Token, reader: Reader): ParseResult[Expression] = {
+  private def parseIn(name: FunctionName, scrutinee: Expression, op: Token, reader: Reader, higherPrecedence: ExprParser): ParseResult[Expression] = {
     reader.first match {
       case LPAREN() =>
         parseArgList(reader.rest, arg0 = Some(scrutinee)).map { args =>
@@ -1554,17 +1634,17 @@ abstract class RecursiveDescentParser(parameters: AbstractParser.Parameters = Ab
     }
   }
 
-  private def parseLike(name: FunctionName, scrutinee: Expression, op: Token, reader: Reader): ParseResult[Expression] = {
-    likeBetweenIn(reader).map { pattern =>
+  private def parseLike(name: FunctionName, scrutinee: Expression, op: Token, reader: Reader, higherPrecedence: ExprParser): ParseResult[Expression] = {
+    likeBetweenIn(reader, higherPrecedence).map { pattern =>
       FunctionCall(name, Seq(scrutinee, pattern), None)(scrutinee.position, op.position)
     }
   }
 
-  private def parseBetween(name: FunctionName, scrutinee: Expression, op: Token, reader: Reader): ParseResult[Expression] = {
-    val ParseResult(r2, lowerBound) = likeBetweenIn(reader)
+  private def parseBetween(name: FunctionName, scrutinee: Expression, op: Token, reader: Reader, higherPrecedence: ExprParser): ParseResult[Expression] = {
+    val ParseResult(r2, lowerBound) = likeBetweenIn(reader, higherPrecedence)
     r2.first match {
       case AND() =>
-        likeBetweenIn(r2.rest).map { upperBound =>
+        likeBetweenIn(r2.rest, higherPrecedence).map { upperBound =>
           FunctionCall(name, Seq(scrutinee, lowerBound, upperBound), None)(scrutinee.position, op.position)
         }
       case _ =>
@@ -1579,13 +1659,13 @@ abstract class RecursiveDescentParser(parameters: AbstractParser.Parameters = Ab
   // Again, it becomes
   //    lBI = order lBI'
   //    lBI' = [the various cases] lBI' | ε
-  private def likeBetweenIn(reader: Reader): ParseResult[Expression] = {
-    val ParseResult(r2, arg) = order(reader)
-    likeBetweenIn_!(r2, arg)
+  private def likeBetweenIn(reader: Reader, nextParser: ExprParser): ParseResult[Expression] = {
+    val ParseResult(r2, arg) = nextParser(reader)
+    likeBetweenIn_!(r2, nextParser, arg)
   }
 
   @tailrec
-  private def likeBetweenIn_!(reader: Reader, arg: Expression): ParseResult[Expression] = {
+  private def likeBetweenIn_!(reader: Reader, nextParser: ExprParser, arg: Expression): ParseResult[Expression] = {
     reader.first match {
       case is: IS =>
         // This is either IS NULL or IS NOT NULL
@@ -1603,97 +1683,98 @@ abstract class RecursiveDescentParser(parameters: AbstractParser.Parameters = Ab
             case _ =>
               fail(reader.rest, NULL(), NOT())
           }
-        likeBetweenIn_!(r2, arg2)
+        likeBetweenIn_!(r2, nextParser, arg2)
       case like: LIKE =>
         // woo only one possibility!
-        val ParseResult(r2, arg2) = parseLike(SpecialFunctions.Like, arg, like, reader.rest)
-        likeBetweenIn_!(r2, arg2)
+        val ParseResult(r2, arg2) = parseLike(SpecialFunctions.Like, arg, like, reader.rest, nextParser)
+        likeBetweenIn_!(r2, nextParser, arg2)
       case between: BETWEEN =>
-        val ParseResult(r2, arg2) = parseBetween(SpecialFunctions.Between, arg, between, reader.rest)
-        likeBetweenIn_!(r2, arg2)
+        val ParseResult(r2, arg2) = parseBetween(SpecialFunctions.Between, arg, between, reader.rest, nextParser)
+        likeBetweenIn_!(r2, nextParser, arg2)
       case not: NOT =>
         // could be NOT BETWEEN, NOT IN, or NOT LIKE
         reader.rest.first match {
           case between: BETWEEN =>
-            val ParseResult(r2, arg2) = parseBetween(SpecialFunctions.NotBetween, arg, not, reader.rest.rest)
-            likeBetweenIn_!(r2, arg2)
+            val ParseResult(r2, arg2) = parseBetween(SpecialFunctions.NotBetween, arg, not, reader.rest.rest, nextParser)
+            likeBetweenIn_!(r2, nextParser, arg2)
           case in: IN =>
-            val ParseResult(r2, arg2) = parseIn(SpecialFunctions.NotIn, arg, not, reader.rest.rest)
-            likeBetweenIn_!(r2, arg2)
+            val ParseResult(r2, arg2) = parseIn(SpecialFunctions.NotIn, arg, not, reader.rest.rest, nextParser)
+            likeBetweenIn_!(r2, nextParser, arg2)
           case like: LIKE =>
-            val ParseResult(r2, arg2) = parseLike(SpecialFunctions.NotLike, arg, not, reader.rest.rest)
-            likeBetweenIn_!(r2, arg2)
+            val ParseResult(r2, arg2) = parseLike(SpecialFunctions.NotLike, arg, not, reader.rest.rest, nextParser)
+            likeBetweenIn_!(r2, nextParser, arg2)
           case other =>
             fail(reader.rest, BETWEEN(), IN(), LIKE())
         }
       case in: IN =>
         // Again only one possibility!
-        val ParseResult(r2, arg2) = parseIn(SpecialFunctions.In, arg, in, reader.rest)
-        likeBetweenIn_!(r2, arg2)
+        val ParseResult(r2, arg2) = parseIn(SpecialFunctions.In, arg, in, reader.rest, nextParser)
+        likeBetweenIn_!(r2, nextParser, arg2)
       case _ =>
         reader.addAlternates(LIKE_BETWEEN_IN_SET)
         ParseResult(reader, arg)
     }
   }
 
-  private def negation(reader: Reader): ParseResult[Expression] = {
-    reader.first match {
-      case op: NOT =>
-        negation(reader.rest).map { arg =>
-          FunctionCall(SpecialFunctions.Operator(op.printable), Seq(arg), None)(op.position, op.position)
+  private def parseBinOp(opCls: OperatorClass.Binary, reader: Reader, nextParser: ExprParser): ParseResult[Expression] = {
+    opCls.associativity match {
+      case Associativity.Left =>
+        // This is a pattern which uses a standard trick to eliminate
+        // left-recursion (which is tricky for a recursive-descent parser
+        // to handle).  The grammar we want to parse is
+        //    thisParser = (thisParser OP nextParser) | nextParser
+        // but instead we're parsing
+        //    thisParser = nextParser thisParser'
+        //    thisParser' = (OP nextParser thisParser') | ε
+        // which is right-recursive.
+        val ParseResult(r2, e) = nextParser(reader)
+        parseBinOpLeft_!(opCls, r2, nextParser, e)
+      case Associativity.Right =>
+        parseBinOpRight_!(opCls, reader, nextParser)
+    }
+  }
+
+  @tailrec
+  private def parseBinOpLeft_!(opCls: OperatorClass.Binary, reader: Reader, nextParser: ExprParser, arg1: Expression): ParseResult[Expression] = {
+    val opToken = reader.first
+    opCls.opNames.get(opToken) match {
+      case Some(funcName) =>
+        val ParseResult(r2, arg2) = nextParser(reader.rest)
+        parseBinOpLeft_!(opCls, r2, nextParser, FunctionCall(funcName, Seq(arg1, arg2), None)(arg1.position, opToken.position))
+      case None =>
+        reader.addAlternates(opCls.expectation)
+        ParseResult(reader, arg1)
+    }
+  }
+
+  private def parseBinOpRight_!(opCls: OperatorClass.Binary, reader: Reader, nextParser: ExprParser): ParseResult[Expression] = {
+    val ParseResult(r2, arg1) = nextParser(reader)
+    val opToken = r2.first
+    opCls.opNames.get(opToken) match {
+      case Some(funcName) =>
+        parseBinOpRight_!(opCls, r2.rest, nextParser).map { arg2 =>
+          FunctionCall(funcName, Seq(arg1, arg2), None)(arg1.position, opToken.position)
         }
-      case _ =>
-        reader.addAlternates(NOT_SET)
-        likeBetweenIn(reader)
+      case None =>
+        reader.addAlternates(opCls.expectation)
+        ParseResult(r2, arg1)
     }
   }
 
-  private def conjunction(reader: Reader): ParseResult[Expression] = {
-    val ParseResult(r2, e) = negation(reader)
-    conjunction_!(r2, e)
-  }
-
-  @tailrec
-  private def conjunction_!(reader: Reader, arg: Expression): ParseResult[Expression] = {
-    reader.first match {
-      case and: AND =>
-        val ParseResult(r2, arg2) = negation(reader.rest)
-        conjunction_!(r2, FunctionCall(SpecialFunctions.Operator(and.printable), Seq(arg, arg2), None)(arg.position, and.pos))
-      case _ =>
-        reader.addAlternates(AND_SET)
-        ParseResult(reader, arg)
-    }
-  }
-
-  // This is a pattern that'll be used all over this parser.  The
-  // combinators approach was
-  //    disjunction = (disjunction `OR` conjunction) | conjunction;
-  // which is left-recursive.  We can eliminate that by instead doing
-  //    disjunction = conjunction disjunction'
-  //    disjunction' = `OR` conjunction disjunction' | ε
-  private def disjunction(reader: Reader): ParseResult[Expression] = {
-    val ParseResult(r2, e) = conjunction(reader)
-    disjunction_!(r2, e)
-  }
-
-  @tailrec
-  private def disjunction_!(reader: Reader, arg: Expression): ParseResult[Expression] = {
-    reader.first match {
-      case or: OR =>
-        val ParseResult(r2, arg2) = conjunction(reader.rest)
-        disjunction_!(r2, FunctionCall(SpecialFunctions.Operator(or.printable), Seq(arg, arg2), None)(arg.position, or.pos))
-      case _ =>
-        reader.addAlternates(OR_SET)
-        ParseResult(reader, arg)
+  private def precedented(reader: Reader, at: Int): ParseResult[Expression] = {
+    if(at == precedenceTable.length) {
+      atom(reader)
+    } else {
+      precedenceTable(at).parse(this, reader, precedented(_, at+1))
     }
   }
 
   protected final def nestedExpr(reader: Reader): ParseResult[Expression] = {
-    disjunction(reader)
+    precedented(reader, 0)
   }
 
   protected def topLevelExpr(reader: Reader): ParseResult[Expression] = {
-    val r = disjunction(reader)
+    val r = precedented(reader, 0)
     r.reader.resetAlternates()
     r
   }

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/RecursiveDescentParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/RecursiveDescentParser.scala
@@ -227,8 +227,6 @@ object RecursiveDescentParser {
   private val OPERATOR_SET = s(AnOperator)
 
   private val LIKE_BETWEEN_IN_SET = s(IS(), AnIsNot, LIKE(), ANotLike, BETWEEN(), ANotBetween, IN(), ANotIn)
-  private val NOT_SET = s(NOT())
-  private val OR_SET = s(OR())
 
   type ExprParser = Reader => ParseResult[Expression]
 
@@ -241,18 +239,6 @@ object RecursiveDescentParser {
   object Associativity {
     case object Left extends Associativity
     case object Right extends Associativity
-  }
-
-  sealed abstract class Operator
-  object Operator {
-    case class Binary(token: Token, associativity: Associativity) extends Operator {
-      val name = SpecialFunctions.Operator(token.printable)
-    }
-    case class Unary(token: Token) extends Operator {
-      val name = SpecialFunctions.Operator(token.printable)
-    }
-    case class Special(name: FunctionName) extends Operator
-    case object Cast extends Operator
   }
 
   sealed abstract class OperatorClass {


### PR DESCRIPTION
In order to make this not a completely horrible mess of duplicated logic, this entailed a refactor of the parser to encode precedence more explicitly (which has the pleasing side-effect of removing a bunch of code there, at the cost of using slightly more stack-space at runtime)