### PR TITLE
TableFinder.Result is just Either

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/MockTableFinder.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/MockTableFinder.scala
@@ -240,7 +240,7 @@ class MockTableFinder[RNS, CT](private val raw: Map[(RNS, String), Thing[RNS, CT
     }
   }
 
-  def apply(names: (RNS, String)*): Success[TableMap] = {
+  def apply(names: (RNS, String)*): Result[TableMap] = {
     val r = names.foldLeft(TableMap.empty[RNS, CT]) { (tableMap, scopeName) =>
       val (scope, n) = scopeName
       val name = ResourceName(n)
@@ -251,6 +251,6 @@ class MockTableFinder[RNS, CT](private val raw: Map[(RNS, String), Thing[RNS, CT
       throw new Exception("Malformed table list")
     }
 
-    Success(r)
+    Right(r)
   }
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -1,8 +1,6 @@
 // TODO:
 //  * Errors
 //     - everything needs position info
-//  * More postprocessing passes in the SoQLAnalysis
-//     - provide_order(using_column: DatabaseTableName => DatabaseColumnName)
 
 package com.socrata.soql.analyzer2
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -37,11 +37,11 @@ class SoQLAnalyzer[RNS, CT, CV](typeInfo: TypeInfo2[CT, CV], functionInfo: Funct
 
   type UdfParameters = Map[HoleName, Position => Expr[CT, CV]]
 
-  private case class Bail(result: SoQLAnalyzerError[RNS, SoQLAnalyzerError.AnalysisError]) extends Exception with NoStackTrace
+  private case class Bail(result: AnalysisError[RNS]) extends Exception with NoStackTrace
 
   private val Error = SoQLAnalyzerError.AnalysisError
 
-  def apply(start: FoundTables, userParameters: UserParameters): Either[SoQLAnalyzerError[RNS, SoQLAnalyzerError.AnalysisError], SoQLAnalysis[RNS, CT, CV]] = {
+  def apply(start: FoundTables, userParameters: UserParameters): Either[AnalysisError[RNS], SoQLAnalysis[RNS, CT, CV]] = {
     try {
       validateUserParameters(start.knownUserParameters, userParameters)
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/TableFinder.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/TableFinder.scala
@@ -20,7 +20,7 @@ trait TableFinder {
 
   /** The way in which `parse` can fail.
     */
-  type ParseError = SoQLAnalyzerError.TextualError[ResourceNameScope, SoQLAnalyzerError.ParserError]
+  type ParseError = ParserError[ResourceNameScope]
 
   /** The way in which saved queries are scoped.  This is nearly opaque
     * as far as TableFinder is concerned, requiring only that a tuple
@@ -102,7 +102,7 @@ trait TableFinder {
     case object PermissionDenied extends LookupError
   }
 
-  type Result[T] = Either[SoQLAnalyzerError.TextualError[ResourceNameScope, SoQLAnalyzerError.TableFinderError], T]
+  type Result[T] = Either[TableFinderError[ResourceNameScope], T]
 
   type TableMap = com.socrata.soql.analyzer2.TableMap[ResourceNameScope, ColumnType]
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Typechecker.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Typechecker.scala
@@ -18,7 +18,7 @@ class Typechecker[RNS, CT, CV](
   typeInfo: TypeInfo2[CT, CV],
   functionInfo: FunctionInfo[CT]
 ) {
-  type Error = SoQLAnalyzerError.TextualError[RNS, SoQLAnalyzerError.AnalysisError.TypecheckError]
+  type Error = TypecheckError[RNS]
   private val TypecheckError = SoQLAnalyzerError.AnalysisError.TypecheckError
   import TypecheckError._
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/package.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/package.scala
@@ -4,4 +4,15 @@ package object analyzer2 {
   // type alias for referring to any generic soql error since Scala
   // doesn't have type-parameter defaulting.
   type SoQLError[+RNS] = SoQLAnalyzerError[RNS, SoQLAnalyzerError.Payload]
+
+  // And some handy type aliases for specific sorts of SoQLErrors
+  type TableFinderError[+RNS] = SoQLAnalyzerError.TextualError[RNS, SoQLAnalyzerError.TableFinderError]
+  type ParserError[+RNS] = SoQLAnalyzerError.TextualError[RNS, SoQLAnalyzerError.ParserError]
+
+  // This one isn't specifically a TextualError because analysis is
+  // where "wrong parameters provided" comes out.
+  type AnalysisError[+RNS] = SoQLAnalyzerError[RNS, SoQLAnalyzerError.AnalysisError]
+
+  type AliasAnalysisError[+RNS] = SoQLAnalyzerError.TextualError[RNS, SoQLAnalyzerError.AnalysisError.AliasAnalysisError]
+  type TypecheckError[+RNS] = SoQLAnalyzerError.TextualError[RNS, SoQLAnalyzerError.AnalysisError.TypecheckError]
 }

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
@@ -16,7 +16,7 @@ import mocktablefinder._
 class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
   test("alias analysis qualifiers are correct") {
     val tf = MockTableFinder.empty[Int, TestType]
-    val tf.Success(start) = tf.findTables(0, "select @bleh.whatever from @single_row", Map.empty)
+    val Right(start) = tf.findTables(0, "select @bleh.whatever from @single_row", Map.empty)
     analyzer(start, UserParameters.empty) match {
       case Right(_) => fail("Expected an error")
       case Left(SoQLAnalyzerError.TextualError(_, _, _, nsc: SoQLAnalyzerError.AnalysisError.TypecheckError.NoSuchColumn)) =>

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/TableFinderTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/TableFinderTest.scala
@@ -43,7 +43,7 @@ class TableFinderTest extends FunSuite with MustMatchers {
     def apply(err: tables.Result[Any]) =
       MatchResult(
         err match {
-          case tables.Error(SoQLAnalyzerError.TextualError(`scope`, _, _, SoQLAnalyzerError.TableFinderError.NotFound(nf))) =>
+          case Left(SoQLAnalyzerError.TextualError(`scope`, _, _, SoQLAnalyzerError.TableFinderError.NotFound(nf))) =>
             nf == name
           case _ =>
             false
@@ -59,7 +59,7 @@ class TableFinderTest extends FunSuite with MustMatchers {
     def apply(err: tables.Result[Any]) =
       MatchResult(
         err match {
-          case tables.Error(SoQLAnalyzerError.TextualError(_, _, _, SoQLAnalyzerError.TableFinderError.RecursiveQuery(path))) =>
+          case Left(SoQLAnalyzerError.TextualError(_, _, _, SoQLAnalyzerError.TableFinderError.RecursiveQuery(path))) =>
             path == names
           case _ =>
             false
@@ -117,7 +117,7 @@ class TableFinderTest extends FunSuite with MustMatchers {
 
   test("can rountdtrip a FoundTables through JSON") {
     def go(ft: tables.Result[FoundTables[Int, String]]): Unit = {
-      val orig = ft.asInstanceOf[tables.Success[FoundTables[Int, String]]].value
+      val orig = ft.toOption.get
       val jsonized = JsonEncode.toJValue(orig)
 
       // first, can bounce it through UnparsedFoundTables and get the same JSON back out

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/TestHelper.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/TestHelper.scala
@@ -53,7 +53,7 @@ trait TestHelper { this: Assertions =>
     def onAnalyzerError(err: SoQLAnalyzerError[Int, SoQLAnalyzerError.AnalysisError]): Nothing =
       fail(err.toString)
 
-    def onTableFinderError(err: TableFinder#Error): Nothing =
+    def onTableFinderError(err: SoQLAnalyzerError[Int, SoQLAnalyzerError.TableFinderError]): Nothing =
       fail(err.toString)
   }
 
@@ -72,9 +72,9 @@ trait TestHelper { this: Assertions =>
 
   def analyzeSaved(tf: TF[TestType], ctx: String, params: UserParameters[TestType, TestValue])(implicit onFail: OnFail): SoQLAnalysis[Int, TestType, TestValue] = {
     tf.findTables(0, rn(ctx)) match {
-      case tf.Success(start) =>
+      case Right(start) =>
         finishAnalysis(start, params)(onFail)
-      case e: tf.Error =>
+      case Left(e) =>
         onFail.onTableFinderError(e)
     }
   }
@@ -85,18 +85,18 @@ trait TestHelper { this: Assertions =>
 
   def analyze(tf: TF[TestType], ctx: String, query: String, params: UserParameters[TestType, TestValue])(implicit onFail: OnFail): SoQLAnalysis[Int, TestType, TestValue] = {
     tf.findTables(0, rn(ctx), query, specFor(params.unqualified)) match {
-      case tf.Success(start) =>
+      case Right(start) =>
         finishAnalysis(start, params)(onFail)
-      case e: tf.Error =>
+      case Left(e) =>
         onFail.onTableFinderError(e)
     }
   }
 
   def analyze(tf: TF[TestType], ctx: String, query: String, canonicalName: CanonicalName, params: UserParameters[TestType, TestValue])(implicit onFail: OnFail): SoQLAnalysis[Int, TestType, TestValue] = {
     tf.findTables(0, rn(ctx), query, Map.empty, canonicalName) match {
-      case tf.Success(start) =>
+      case Right(start) =>
         finishAnalysis(start, params)(onFail)
-      case e: tf.Error =>
+      case Left(e) =>
         onFail.onTableFinderError(e)
     }
   }
@@ -107,9 +107,9 @@ trait TestHelper { this: Assertions =>
 
   def analyze(tf: TF[TestType], query: String, params: UserParameters[TestType, TestValue])(implicit onFail: OnFail): SoQLAnalysis[Int, TestType, TestValue] = {
     tf.findTables(0, query, specFor(params.unqualified)) match {
-      case tf.Success(start) =>
+      case Right(start) =>
         finishAnalysis(start, params)(onFail)
-      case e: tf.Error =>
+      case Left(e) =>
         onFail.onTableFinderError(e)
     }
   }


### PR DESCRIPTION
Plus aliases for the various error types for ease of use, and a no-longer-relevant todo comment removed.