### PR TITLE
When pretty-printing strings, use JSON-style rather than SQL-style

### DIFF
--- a/soql-standalone-parser/src/main/jflex/SoQLLexer.flex
+++ b/soql-standalone-parser/src/main/jflex/SoQLLexer.flex
@@ -204,6 +204,7 @@ TableIdentifier = "@" ("-" | [:jletterdigit:])+
 <DOUBLEQUOTESTRING> {
   \"           { yybegin(YYINITIAL); return finishString(); }
   [^\n\"\\]+   { string.append(yytext()); }
+  \\[/]        { string.append('/'); }
   \\[n]        { string.append('\n'); }
   \\[t]        { string.append('\t'); }
   \\[b]        { string.append('\b'); }

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Expression.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Expression.scala
@@ -5,6 +5,8 @@ import scala.util.parsing.input.{NoPosition, Position}
 import scala.runtime.ScalaRunTime
 import scala.collection.immutable.VectorBuilder
 
+import com.rojoma.json.v3.ast.JString
+
 import com.socrata.soql.environment.{ColumnName, FunctionName, HoleName, TableName, TypeName}
 import com.socrata.prettyprint.prelude._
 import com.socrata.soql.parsing.RecursiveDescentParser
@@ -34,7 +36,7 @@ sealed abstract class Expression extends Product {
 object Expression {
   val pretty = AST.pretty
 
-  def escapeString(s: String): String = "'" + s.replaceAll("'", "''") + "'"
+  def escapeString(s: String): String = JString(s).toString
 
   private def foldDashes(s: String) = s.replaceAll("-","_")
 
@@ -193,7 +195,7 @@ case class NumberLiteral(value: BigDecimal)(val position: Position) extends Lite
   def doc = Doc(value.toString)
 }
 case class StringLiteral(value: String)(val position: Position) extends Literal {
-  def doc = Doc("'" + value.replaceAll("'", "''") + "'")
+  def doc = Doc(Expression.escapeString(value))
 }
 case class BooleanLiteral(value: Boolean)(val position: Position) extends Literal {
   def doc = Doc(value.toString.toUpperCase)


### PR DESCRIPTION
Because JSON-style strings with control characters print in a more useful way than SQL-style.