### PR TITLE
[EN-57981] fixing column mapping in piped queries

### DIFF
--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/mapping/ColumnNameMapper.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/mapping/ColumnNameMapper.scala
@@ -20,10 +20,11 @@ class ColumnNameMapper(rootSchemas: Map[String, Map[ColumnName, ColumnName]]) {
   def mapSelects(selects: BinaryTree[Select], generateAliases: Boolean = false): BinaryTree[Select] = {
     selects match {
       case PipeQuery(l, r) =>
-        // previously when pipe query is in seq form,
-        // mapSelect only operates on the first element
         val nl = mapSelects(l, true)
-        PipeQuery(nl, r)
+        // there is no root past the pipe, so removing "_" mapping from schemas
+        val mapper = new ColumnNameMapper(rootSchemas - "_")
+        val nr = mapper.mapSelects(r, false)
+        PipeQuery(nl, nr)
       case Compound(op, l, r) =>
         val nl = mapSelects(l, generateAliases)
         val nr = mapSelects(r, generateAliases)


### PR DESCRIPTION
In piped queries, there is no "root" (keyed as "_") after the first pipe, because all columns which do not have table name are intermediary columns.

Therefore, mapping of the piped selects after the first pipe should be done with another instance of the analyzer, which does not have root schema.