### PR TITLE
protobuf shouldn't be an optional dep of soql-serialize

### DIFF
--- a/project/SoQLSerialize.scala
+++ b/project/SoQLSerialize.scala
@@ -5,7 +5,7 @@ object SoqlSerialize {
   lazy val settings: Seq[Setting[_]] = BuildSettings.projectSettings() ++ Seq(
     name := "soql-serialize",
     libraryDependencies ++= Seq(
-      "com.google.protobuf" % "protobuf-java" % "2.6.1" % "optional"
+      "com.google.protobuf" % "protobuf-java" % "2.6.1"
     ),
     Compile / sourceGenerators += Def.task { TuplesBuilder.write((Compile / sourceManaged).value) },
     Compile / sourceGenerators += Def.task { TuplesBuilder.read((Compile / sourceManaged).value) }


### PR DESCRIPTION
The whole point of this subproject is to serialize things using this library