### PR TITLE
Generalize "remove trivial selects"

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/From.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/From.scala
@@ -29,6 +29,8 @@ sealed abstract class From[MT <: MetaTypes] extends LabelUniverse[MT] {
   // into a corner?
   def unique: LazyList[Seq[Column[MT]]]
 
+  def schema: Seq[(AutoTableLabel, ColumnLabel, CT)]
+
   // extend the given environment with names introduced by this FROM clause
   private[analyzer2] def extendEnvironment(base: Environment[MT]): Either[AddScopeError, Environment[MT]]
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromSingleRow.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromSingleRow.scala
@@ -20,6 +20,8 @@ trait FromSingleRowImpl[MT <: MetaTypes] { this: FromSingleRow[MT] =>
   // We have a unique ordering and no columns are required to achieve it
   def unique = LazyList(Nil)
 
+  def schema = Nil
+
   private[analyzer2] val scope: Scope[MT] =
     new Scope.Virtual(label, OrderedMap.empty)
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromStatement.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromStatement.scala
@@ -17,6 +17,10 @@ trait FromStatementImpl[MT <: MetaTypes] { this: FromStatement[MT] =>
   type Self[MT <: MetaTypes] = FromStatement[MT]
   def asSelf = this
 
+  def schema = statement.schema.map { case (acl, NameEntry(_, typ)) =>
+    (label, acl, typ)
+  }.toVector
+
   private[analyzer2] val scope: Scope[MT] = new Scope.Virtual[MT](label, statement.schema)
 
   private[analyzer2] def columnReferences: Map[AutoTableLabel, Set[ColumnLabel]] = statement.columnReferences

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
@@ -18,6 +18,10 @@ trait FromTableImpl[MT <: MetaTypes] { this: FromTable[MT] =>
   def find(predicate: Expr[MT] => Boolean) = None
   def contains(e: Expr[MT]): Boolean = false
 
+  def schema = columns.iterator.map { case (dcn, NameEntry(_, typ)) =>
+    (label, dcn, typ)
+  }.toVector
+
   def unique = primaryKeys.to(LazyList).map(_.map { dcn => PhysicalColumn[MT](label, canonicalName, dcn, columns(dcn).typ)(AtomicPositionInfo.None) })
 
   lazy val resourceName = Some(definiteResourceName)

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/Join.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/Join.scala
@@ -183,6 +183,11 @@ trait JoinImpl[MT <: MetaTypes] { this: Join[MT] =>
         }
       }
     ).map(_.reverse.flatten)
+
+  def schema = reduce[List[Seq[(AutoTableLabel, ColumnLabel, CT)]]](
+    { leftmost => List(leftmost.schema) },
+    { (schemaSoFar, join) => join.right.schema :: schemaSoFar }
+  ).reverse.flatten
 }
 
 trait OJoinImpl { this: Join.type =>

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalysisTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalysisTest.scala
@@ -743,8 +743,8 @@ select count(*), 1 as x |> select x
       (0, "threecol") -> D("text" -> TestText, "num" -> TestNumber, "num2" -> TestNumber),
       (0, "threemorecol") -> D("t" -> TestText, "n1" -> TestNumber, "n2" -> TestNumber)
     )
-    val analysis = analyze(tf, "threecol", "select * join (select t as text, n1 from @threemorecol |> select text) as @x on true").removeTrivialSelects
-    val expected = analyze(tf, "threecol", "select text, num, num2 join @threemorecol as @x on true")
+    val analysis = analyze(tf, "threecol", "select *, @x.text as xtext join (select t as text, n1 from @threemorecol |> select text) as @x on true").removeTrivialSelects
+    val expected = analyze(tf, "threecol", "select text, num, num2, @x.t as xtext join @threemorecol as @x on true")
 
     analysis.statement must be (isomorphicTo(expected.statement))
   }
@@ -754,8 +754,8 @@ select count(*), 1 as x |> select x
       (0, "threecol") -> D("text" -> TestText, "num" -> TestNumber, "num2" -> TestNumber),
       (0, "threemorecol") -> D("t" -> TestText, "n1" -> TestNumber, "n2" -> TestNumber)
     )
-    val analysis = analyze(tf, "threecol", "select * join (select t as text, n1 from @threemorecol |> select text+text) as @x on true").removeTrivialSelects
-    val expected = analyze(tf, "threecol", "select text, num, num2 join (select t+t from @threemorecol) as @x on true")
+    val analysis = analyze(tf, "threecol", "select *, @x.t2 join (select t as text, n1 from @threemorecol |> select text+text as t2) as @x on true").removeTrivialSelects
+    val expected = analyze(tf, "threecol", "select text, num, num2, @x.t2 join (select t+t as t2 from @threemorecol) as @x on true")
 
     analysis.statement must be (isomorphicTo(expected.statement))
   }
@@ -767,6 +767,45 @@ select count(*), 1 as x |> select x
     )
     val analysis = analyze(tf, "threecol", "select * |> select text, num join lateral (select t as text, n1 from @threemorecol |> select text, num2) as @x on true").removeTrivialSelects
     val expected = analyze(tf, "threecol", "select text, num join lateral (select t, num2 from @threemorecol) as @x on true")
+
+    analysis.statement must be (isomorphicTo(expected.statement))
+  }
+
+  test("remove trivial selects - search with rewrite permitted") {
+    val tf = tableFinder(
+      (0, "threecol") -> D("text" -> TestText, "num" -> TestNumber, "num2" -> TestNumber)
+    )
+
+    val analysis = analyze(tf, "threecol", "select * |> select * search 'search'").removeTrivialSelects
+    val expected = analyze(tf, "threecol", "select text, num, num2 search 'search'")
+
+    analysis.statement must be (isomorphicTo(expected.statement))
+  }
+
+  test("remove trivial selects - search with rewrite not permitted") {
+    val tf = tableFinder(
+      (0, "threecol") -> D("text" -> TestText, "num" -> TestNumber, "num2" -> TestNumber)
+    )
+
+    // Can't rewrite here because "search" in the third stage cares
+    // about the whole input schema, so the fact that `select
+    // text,num` narrows it from three columns to two is important.
+    val analysis = analyze(tf, "threecol", "select text, num |> select * search 'search'").removeTrivialSelects
+    val expected = analyze(tf, "threecol", "select text, num |> select text, num search 'search'")
+
+    analysis.statement must be (isomorphicTo(expected.statement))
+  }
+
+  test("remove trivial selects - search with rewrite not permitted, more subtly") {
+    val tf = tableFinder(
+      (0, "threecol") -> D("text" -> TestText, "num" -> TestNumber, "num2" -> TestNumber)
+    )
+
+    // Can't rewrite here because "search" in the third stage cares
+    // about the whole input schema, so the fact that `select
+    // text,num2,num` reorders the input columns is important.
+    val analysis = analyze(tf, "threecol", "select text, num2, num |> select * search 'search'").removeTrivialSelects
+    val expected = analyze(tf, "threecol", "select text, num2, num |> select text, num2, num search 'search'")
 
     analysis.statement must be (isomorphicTo(expected.statement))
   }


### PR DESCRIPTION
Before it would consider removing a trivial select only if it were the _only_ input dataset to a query.  Now it will do for all trivial-select inputs even in the presence of joins.