### PR TITLE
overload reduce_precision to always return the multitype of the input

### DIFF
--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -240,9 +240,35 @@ object SoQLFunctions {
   val GeoCollectionExtractMultiPointFromPoint = mf("geo_multi_collection_mpt_mpt", FunctionName("geo_collection_extract"), Seq(SoQLMultiPoint), Seq.empty, SoQLMultiPoint)(
     NoDocs
   )
-
-  val ReducePrecision = f("reduce_precision", FunctionName("reduce_precision"), Map("a" -> GeospatialLike, "b" -> NumLike),
-    Seq(VariableType("a"), VariableType("b")), Seq.empty, VariableType("a")) (
+  // Reducing precision _can_ return multi types, so we are going to ensure they always return multitypes
+  // similar to spatial_union
+  val ReducePointPrecision = f("reducePointPrecision", FunctionName("reduce_precision"), Map("a" -> PointLike, "b" -> NumLike),
+    Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLMultiPoint)) (
+      "Reduce the precision of a given geometry, for example reduce_precision(to_point('POINT (1.234 10.675)'), 0.1) => POINT (1.2 10.6)",
+      Example("Reduce to tens place", "SELECT reduce_precision(to_point('POINT (1.234 10.675)'), 0.1)", "")
+    )
+  val ReduceLinePrecision = f("reduceLinePrecision", FunctionName("reduce_precision"), Map("a" -> LineLike, "b" -> NumLike),
+    Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLMultiLine)) (
+      "Reduce the precision of a given geometry, for example reduce_precision(to_point('POINT (1.234 10.675)'), 0.1) => POINT (1.2 10.6)",
+      Example("Reduce to tens place", "SELECT reduce_precision(to_point('POINT (1.234 10.675)'), 0.1)", "")
+    )
+  val ReducePolyPrecision = f("reducePolyPrecision", FunctionName("reduce_precision"), Map("a" -> PolygonLike, "b" -> NumLike),
+    Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLMultiPolygon)) (
+      "Reduce the precision of a given geometry, for example reduce_precision(to_point('POINT (1.234 10.675)'), 0.1) => POINT (1.2 10.6)",
+      Example("Reduce to tens place", "SELECT reduce_precision(to_point('POINT (1.234 10.675)'), 0.1)", "")
+    )
+  val ReduceMPointPrecision = f("reduceMPointPrecision", FunctionName("reduce_precision"), Map("a" -> PointLike, "b" -> NumLike),
+    Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLMultiPoint)) (
+      "Reduce the precision of a given geometry, for example reduce_precision(to_point('POINT (1.234 10.675)'), 0.1) => POINT (1.2 10.6)",
+      Example("Reduce to tens place", "SELECT reduce_precision(to_point('POINT (1.234 10.675)'), 0.1)", "")
+    )
+  val ReduceMLinePrecision = f("reduceMLinePrecision", FunctionName("reduce_precision"), Map("a" -> LineLike, "b" -> NumLike),
+    Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLMultiLine)) (
+      "Reduce the precision of a given geometry, for example reduce_precision(to_point('POINT (1.234 10.675)'), 0.1) => POINT (1.2 10.6)",
+      Example("Reduce to tens place", "SELECT reduce_precision(to_point('POINT (1.234 10.675)'), 0.1)", "")
+    )
+  val ReduceMPolyPrecision = f("reduceMPolyPrecision", FunctionName("reduce_precision"), Map("a" -> PolygonLike, "b" -> NumLike),
+    Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLMultiPolygon)) (
       "Reduce the precision of a given geometry, for example reduce_precision(to_point('POINT (1.234 10.675)'), 0.1) => POINT (1.2 10.6)",
       Example("Reduce to tens place", "SELECT reduce_precision(to_point('POINT (1.234 10.675)'), 0.1)", "")
     )

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.12.6"
+ThisBuild / version := "4.12.7"


### PR DESCRIPTION
- ST_ReducePrecision can return the multi-version of a geometry, so we have to overload the function to ensure the return type is multitype.