### PR TITLE
EN-60580: Change how function docs are represented

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val root = (project in file(".")).
   settings(BuildSettings.buildSettings ++ Seq(publishArtifact := false)).
-  aggregate (soqlEnvironment, soqlParser, soqlSerialize, soqlAnalyzer, soqlTypes, soqlStdlib, soqlToy, soqlPack, soqlUtils)
+  aggregate (soqlEnvironment, soqlParser, soqlSerialize, soqlAnalyzer, soqlTypes, soqlStdlib, soqlToy, soqlPack, soqlUtils, soqlDocs)
 
 lazy val soqlEnvironment = (project in file("soql-environment")).
   settings(SoqlEnvironment.settings)

--- a/project/SoqlDocs.scala
+++ b/project/SoqlDocs.scala
@@ -6,7 +6,9 @@ object SoqlDocs {
     name := "soql-docs",
     publish/skip := true,
     libraryDependencies ++= Seq(
+      "org.slf4j" % "slf4j-simple" % BuildSettings.slf4jVersion,
       "com.rojoma" %% "rojoma-json-v3" % "3.13.0",
+      "com.rojoma" %% "simple-arm-v2" % "2.3.3",
     )
   )
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/functions/Function.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/functions/Function.scala
@@ -30,8 +30,7 @@ case class Function[+Type](identity: String,
                            result: TypeLike[Type],
                            isAggregate: Boolean,
                            needsWindow: Boolean,
-                           doc: String,
-                           examples: Seq[Example])  {
+                           doc: Function.Doc)  {
 
   val minArity = parameters.length
   def isVariadic = repeated.nonEmpty
@@ -83,4 +82,20 @@ case class Function[+Type](identity: String,
 
   override final def hashCode = System.identityHashCode(this)
   override final def equals(that: Any) = this eq that.asInstanceOf[AnyRef]
+}
+
+object Function {
+  case class Doc(
+    description: String,
+    examples: Seq[Example],
+    status: Doc.Status = Doc.Normal
+  )
+  object Doc {
+    sealed abstract class Status
+    case object Normal extends Status
+    case object Deprecated extends Status
+    case object Hidden extends Status
+
+    val empty = Doc("", Nil, Hidden)
+  }
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/functions/MonomorphicFunction.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/functions/MonomorphicFunction.scala
@@ -9,7 +9,7 @@ import com.socrata.soql.environment.FunctionName
 import com.socrata.soql.typechecker.FunctionInfo
 
 case class MonomorphicFunction[+Type](function: Function[Type], bindings: Map[String, Type]) {
-  def this(identity: String, name: FunctionName, parameters: Seq[Type], repeated: Seq[Type], result: Type, isAggregate: Boolean = false, needsWindow: Boolean = false)(documentation: String, examples: Example*) =
+  def this(identity: String, name: FunctionName, parameters: Seq[Type], repeated: Seq[Type], result: Type, isAggregate: Boolean = false, needsWindow: Boolean = false)(doc: Function.Doc) =
     this(Function(
       identity,
       name,
@@ -19,8 +19,7 @@ case class MonomorphicFunction[+Type](function: Function[Type], bindings: Map[St
       FixedType(result),
       isAggregate,
       needsWindow,
-      documentation,
-      examples
+      doc
     ), Map.empty)
 
   val bindingsLessWildcards = bindings.keySet.diff(function.wildcards)

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/TestFunctions.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/TestFunctions.scala
@@ -20,9 +20,9 @@ object TestFunctions {
 
   // helpers to guide type inference (specifically forces TestType to be inferred)
   private def mf(identity: String, name: FunctionName, params: Seq[TestType], varargs: Seq[TestType], result: TestType, isAggregate: Boolean = false, needsWindow: Boolean = false) =
-    new MonomorphicFunction(identity, name, params, varargs, result, isAggregate = isAggregate, needsWindow = needsWindow)("").function
+    new MonomorphicFunction(identity, name, params, varargs, result, isAggregate = isAggregate, needsWindow = needsWindow)(Function.Doc.empty).function
   private def f(identity: String, name: FunctionName, constraints: Map[String, CovariantSet[TestType]], params: Seq[TypeLike[TestType]], varargs: Seq[TypeLike[TestType]], result: TypeLike[TestType], isAggregate: Boolean = false, needsWindow: Boolean = false) =
-    Function(identity, name, constraints, params, varargs, result, isAggregate = isAggregate, needsWindow = needsWindow, "", Seq())
+    Function(identity, name, constraints, params, varargs, result, isAggregate = isAggregate, needsWindow = needsWindow, Function.Doc.empty)
 
   val Case = f("case", FunctionName("case"),
     Map("a" -> AllTypes),

--- a/soql-analyzer/src/test/scala/com/socrata/soql/types/TestFunctions.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/types/TestFunctions.scala
@@ -22,9 +22,9 @@ object TestFunctions {
 
   // helpers to guide type inference (specifically forces TestType to be inferred)
   private def mf(identity: String, name: FunctionName, params: Seq[TestType], varargs: Seq[TestType], result: TestType, isAggregate: Boolean = false, needsWindow: Boolean = false) =
-    new MonomorphicFunction(identity, name, params, varargs, result, isAggregate = isAggregate, needsWindow = needsWindow)("").function
+    new MonomorphicFunction(identity, name, params, varargs, result, isAggregate = isAggregate, needsWindow = needsWindow)(Function.Doc.empty).function
   private def f(identity: String, name: FunctionName, constraints: Map[String, CovariantSet[TestType]], params: Seq[TypeLike[TestType]], varargs: Seq[TypeLike[TestType]], result: TypeLike[TestType], isAggregate: Boolean = false, needsWindow: Boolean = false) =
-    Function(identity, name, constraints, params, varargs, result, isAggregate = isAggregate, needsWindow = needsWindow, "", Seq())
+    Function(identity, name, constraints, params, varargs, result, isAggregate = isAggregate, needsWindow = needsWindow, Function.Doc.empty)
 
   val TextToLocation = mf("text to location", SpecialFunctions.Cast(TestLocation.name), Seq(TestText), Seq.empty, TestLocation)
 

--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -30,7 +30,7 @@ object SoQLFunctions {
     result: SoQLType,
     isAggregate: Boolean = false,
     needsWindow: Boolean = false)(doc: String, examples: Example*) =
-    new MonomorphicFunction(identity, name, params, varargs, result, isAggregate = isAggregate, needsWindow = needsWindow)(doc, examples:_*).function
+    new MonomorphicFunction(identity, name, params, varargs, result, isAggregate = isAggregate, needsWindow = needsWindow)(Function.Doc(doc, examples, Function.Doc.Normal)).function
   private def f(
     identity: String,
     name: FunctionName,
@@ -41,7 +41,7 @@ object SoQLFunctions {
     isAggregate: Boolean = false,
     needsWindow: Boolean = false
   )(doc: String, examples: Example*) =
-    Function(identity, name, constraints, params, varargs, result, isAggregate = isAggregate, needsWindow = needsWindow, doc, examples)
+    Function(identity, name, constraints, params, varargs, result, isAggregate = isAggregate, needsWindow = needsWindow, Function.Doc(doc, examples, Function.Doc.Normal))
   private def field(source: SoQLType, field: String, result: SoQLType) =
     mf(
       source.name.name + "_" + field,
@@ -194,15 +194,18 @@ object SoQLFunctions {
     FixedType(SoQLMultiPolygon),
     isAggregate = false,
     needsWindow = false,
-    """
-    Return the minimum convex geometry that encloses all of the geometries within a set
+    Function.Doc(
+      """
+      Return the minimum convex geometry that encloses all of the geometries within a set
 
-    The convex_hull(...) generates a polygon that represents the minimum convex geometry that
-    can encompass a geometry. All of the points in the geometry will either represent vertexes
-    of that polygon, or will be enclosed within it, much like if you were to take a rubber
-    band and snap it around the geometry's points.
-    """,
-    Seq()
+      The convex_hull(...) generates a polygon that represents the minimum convex geometry that
+      can encompass a geometry. All of the points in the geometry will either represent vertexes
+      of that polygon, or will be enclosed within it, much like if you were to take a rubber
+      band and snap it around the geometry's points.
+      """,
+      Nil,
+      Function.Doc.Normal
+    )
   )
   val Intersects = f("intersects", FunctionName("intersects"), Map("a" -> GeospatialLike, "b" -> GeospatialLike),
     Seq(VariableType("a"), VariableType("b")), Seq.empty, FixedType(SoQLBoolean))(


### PR DESCRIPTION
* It's now a single aggregate object instead of a pair of fields
* This aggregate object also has a normal/deprecated/hidden status field
* Fix the SoQLDocs subproject (and make sure it's actually built in a normal build to prevent bitrot)

This will probably be a mildly disruptive change, though _most_ things neither build nor destructure Functions so it shouldn't be too bad.