### PR TITLE
"Remove used columns" was too aggressive on values statements

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/RemoveUnusedColumns.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/RemoveUnusedColumns.scala
@@ -26,11 +26,11 @@ class RemoveUnusedColumns[MT <: MetaTypes] private (columnReferences: Map[types.
         (v, false)
 
       case stmt@Select(distinctiveness, selectList, from, where, groupBy, having, orderBy, limit, offset, search, hint) =>
-        val newSelectList = (myLabel, distinctiveness) match {
-          case (_, Distinctiveness.FullyDistinct()) | (None, _) =>
+        val newSelectList = (myLabel, distinctiveness, search) match {
+          case (None, _, _) | (_, Distinctiveness.FullyDistinct(), _) | (_, _, Some(_)) =>
             // need to keep all my columns
             selectList
-          case (Some(tl), _) =>
+          case (Some(tl), _, _) =>
             val wantedColumns = columnReferences.getOrElse(tl, Set.empty)
             selectList.filter { case (cl, _) => wantedColumns(cl) }
         }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Select.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Select.scala
@@ -37,6 +37,14 @@ trait SelectImpl[MT <: MetaTypes] { this: Select[MT] =>
     for(o <- orderBy) {
       refs = refs.mergeWith(o.expr.columnReferences)(_ ++ _)
     }
+    for(s <- search) {
+      // Add all our input columns
+      val allInputColumns = from.schema.
+        foldLeft(Map.empty[AutoTableLabel, Set[ColumnLabel]]) { (acc, schemaEnt) =>
+          acc + (schemaEnt.table -> (acc.getOrElse(schemaEnt.table, Set.empty) + schemaEnt.column))
+        }
+      refs = refs.mergeWith(allInputColumns)(_ ++ _)
+    }
     refs
   }
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Values.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Values.scala
@@ -24,7 +24,12 @@ trait ValuesImpl[MT <: MetaTypes] { this: Values[MT] =>
     }
 
   private[analyzer2] def columnReferences: Map[AutoTableLabel, Set[ColumnLabel]] =
-    Map.empty
+    // This _can_ have column references because of lateral joins...
+    values.iterator.foldLeft(Map.empty[AutoTableLabel, Set[ColumnLabel]]) { (acc, row) =>
+      row.iterator.foldLeft(acc) { (acc, expr) =>
+        acc.mergeWith(expr.columnReferences)(_ ++ _)
+      }
+    }
 
   private[analyzer2] def findIsomorphism(
     state: IsomorphismState,


### PR DESCRIPTION
Specifically it just always assumed that a values statement never used any columns itself, which is not necessarily true if lateral joins are involved.