### PR TITLE
Recognize phone, url, and textified boolean literals as LiteralValues

### DIFF
--- a/soql-types/src/main/scala/com/socrata/soql/types/SoQLType.scala
+++ b/soql-types/src/main/scala/com/socrata/soql/types/SoQLType.scala
@@ -785,18 +785,19 @@ case object SoQLPhone extends SoQLType("phone") {
   // Phone number can take almost anything.  But it does not take :, {, } to avoid confusion with phone type and json
   val phoneRx = "((?i)Home|Cell|Work|Fax|Other)?(: ?)?([^:{}]+)?".r
 
-  def isPossible(s: String): Boolean = {
+  def parsePhone(s: String): Option[SoQLPhone] =
     s match {
-      case phoneRx(pt, sep, pn) =>
-        Option(pt).nonEmpty || Option(pn).nonEmpty
+      case phoneRx(pt, sep, pn) if Option(pt).nonEmpty || Option(pn).nonEmpty =>
+        Some(SoQLPhone(Option(pt).map(_.toLowerCase.capitalize), Option(pn)))
       case _ =>
         try {
-          JsonUtil.parseJson[SoQLPhone](s).isRight
+          JsonUtil.parseJson[SoQLPhone](s).toOption
         } catch {
-          case ex: JsonReaderException => false
+          case ex: JsonReaderException => None
         }
     }
-  }
+
+  def isPossible(s: String): Boolean = parsePhone(s).isDefined
 
   def isPossible(s: CaseInsensitiveString): Boolean = isPossible(s.getString)
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.14.3"
+ThisBuild / version := "4.14.4"


### PR DESCRIPTION
Rather than quasi-magical casts that the sqlizer knows about