### PR TITLE
Add a "remove order by" rewrite pass

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/Pass.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/Pass.scala
@@ -21,6 +21,7 @@ object Pass {
   case object UseSelectListReferences extends Pass
   case class Page(size: BigInt, offset: BigInt) extends Pass
   case class AddLimitOffset(limit: Option[BigInt], offset: Option[BigInt]) extends Pass
+  case object RemoveOrderBy extends Pass
 
   private class SingletonCodec[T](value: T) extends JsonEncode[T] with JsonDecode[T] {
     def encode(t: T) = JObject.canonicalEmpty
@@ -48,6 +49,7 @@ object Pass {
     .singleton("use_select_list_references", UseSelectListReferences)
     .branch[Page]("page")(AutomaticJsonEncodeBuilder[Page], AutomaticJsonDecodeBuilder[Page], implicitly)
     .branch[AddLimitOffset]("add_limit_offset")(AutomaticJsonEncodeBuilder[AddLimitOffset], AutomaticJsonDecodeBuilder[AddLimitOffset], implicitly)
+    .singleton("remove_order_by", RemoveOrderBy)
     .build
 
   implicit object serialize extends Readable[Pass] with Writable[Pass] {
@@ -63,6 +65,7 @@ object Pass {
         case 7 => UseSelectListReferences
         case 8 => Page(buffer.read[BigInt](), buffer.read[BigInt]())
         case 9 => AddLimitOffset(buffer.read[Option[BigInt]](), buffer.read[Option[BigInt]]())
+        case 10 => RemoveOrderBy
         case other => fail(s"Unknown rewrite pass type $other")
       }
 
@@ -84,6 +87,7 @@ object Pass {
           buffer.write(9)
           buffer.write(lim)
           buffer.write(off)
+        case RemoveOrderBy => buffer.write(10)
       }
     }
   }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/RemoveUnusedOrderBy.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/RemoveUnusedOrderBy.scala
@@ -51,7 +51,7 @@ class RemoveUnusedOrderBy[MT <: MetaTypes] private () extends StatementUniverse[
 /** Attempt to preserve ordering from inner queries to outer ones.
   * SelectListReferences must not be present (this is unchecked!!). */
 object RemoveUnusedOrderBy {
-  def apply[MT <: MetaTypes](stmt: Statement[MT]): Statement[MT] = {
-    new RemoveUnusedOrderBy[MT]().rewriteStatement(stmt, true)
+  def apply[MT <: MetaTypes](stmt: Statement[MT], preserveTopLevelOrdering: Boolean = true): Statement[MT] = {
+    new RemoveUnusedOrderBy[MT]().rewriteStatement(stmt, preserveTopLevelOrdering)
   }
 }


### PR DESCRIPTION
This is like "remove unused order by" (same code even) except that it doesn't consider the top-level query's order as being "used".