### PR TITLE
Make expression isomorphism easier

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Expression.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Expression.scala
@@ -119,6 +119,7 @@ sealed abstract class Column[MT <: MetaTypes] extends AtomicExpr[MT] { this: Has
 
 final case class PhysicalColumn[MT <: MetaTypes](
   table: AutoTableLabel,
+  tableName: types.DatabaseTableName[MT],
   tableCanonicalName: CanonicalName,
   column: types.DatabaseColumnName[MT],
   typ: MT#ColumnType

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Expression.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Expression.scala
@@ -38,6 +38,7 @@ sealed abstract class Expr[MT <: MetaTypes] extends Product with LabelUniverse[M
 
   private[analyzer2] def reposition(p: Position): Self[MT]
 
+  final def isIsomorphic(that: Expr[MT]): Boolean = findIsomorphism(new IsomorphismState, that)
   private[analyzer2] def findIsomorphism(state: IsomorphismState, that: Expr[MT]): Boolean
   private[analyzer2] def columnReferences: Map[AutoTableLabel, Set[ColumnLabel]]
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/From.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/From.scala
@@ -43,6 +43,7 @@ sealed abstract class From[MT <: MetaTypes] extends LabelUniverse[MT] {
   private[analyzer2] def doAllTables(set: Set[DatabaseTableName]): Set[DatabaseTableName]
   private[analyzer2] def realTables: Map[AutoTableLabel, DatabaseTableName]
 
+  final def isIsomorphic(that: From[MT]): Boolean = findIsomorphism(new IsomorphismState, that)
   private[analyzer2] def findIsomorphism(state: IsomorphismState, that: From[MT]): Boolean
   private[analyzer2] def columnReferences: Map[AutoTableLabel, Set[ColumnLabel]]
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Isomorphism.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Isomorphism.scala
@@ -56,22 +56,14 @@ private[analyzer2] object IsomorphismState {
 }
 
 private[analyzer2] class IsomorphismState[MT <: MetaTypes] private (
-  tableMapLeft: Map[AutoTableLabel, types.DatabaseTableName[MT]],
-  tableMapRight: Map[AutoTableLabel, types.DatabaseTableName[MT]],
   forwardTables: scm.Map[types.AutoTableLabel[MT], types.AutoTableLabel[MT]],
   backwardTables: scm.Map[types.AutoTableLabel[MT], types.AutoTableLabel[MT]],
   forwardColumns: IsomorphismState.DMap[(Option[types.AutoTableLabel[MT]], types.ColumnLabel[MT])],
   backwardColumns: IsomorphismState.DMap[(Option[types.AutoTableLabel[MT]], types.ColumnLabel[MT])]
 ) extends LabelUniverse[MT] {
-  def this(
-    tableMapLeft: Map[AutoTableLabel, types.DatabaseTableName[MT]],
-    tableMapRight: Map[AutoTableLabel, types.DatabaseTableName[MT]]
-  ) = this(tableMapLeft, tableMapRight, new scm.HashMap, new scm.HashMap, new IsomorphismState.DMap, new IsomorphismState.DMap)
+  def this() = this(new scm.HashMap, new scm.HashMap, new IsomorphismState.DMap, new IsomorphismState.DMap)
 
   def finish = new IsomorphismState.View(forwardTables, backwardTables, forwardColumns, backwardColumns)
-
-  def physicalTableLeft(table: AutoTableLabel): DatabaseTableName = tableMapLeft(table)
-  def physicalTableRight(table: AutoTableLabel): DatabaseTableName = tableMapRight(table)
 
   def tryAssociate(tableA: AutoTableLabel, tableB: AutoTableLabel): Boolean = {
     (tableA, tableB) match {

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -169,7 +169,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
         case from: FromTable =>
           selectFromFrom(
             from.columns.map { case (label, NameEntry(name, typ)) =>
-              labelProvider.columnLabel() -> NamedExpr(PhysicalColumn[MT](from.label, from.canonicalName, label, typ)(AtomicPositionInfo.None), name, isSynthetic = false)
+              labelProvider.columnLabel() -> NamedExpr(PhysicalColumn[MT](from.label, from.tableName, from.canonicalName, label, typ)(AtomicPositionInfo.None), name, isSynthetic = false)
             },
             from
           )
@@ -238,7 +238,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
               if(desc.hiddenColumns(name)) {
                 None
               } else {
-                Some(outputLabel -> NamedExpr(PhysicalColumn[MT](from.label, from.canonicalName, dcn, typ)(AtomicPositionInfo.None), name, isSynthetic = false))
+                Some(outputLabel -> NamedExpr(PhysicalColumn[MT](from.label, from.tableName, from.canonicalName, dcn, typ)(AtomicPositionInfo.None), name, isSynthetic = false))
               }
             },
             from,
@@ -247,7 +247,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
             None,
             desc.ordering.map { case TableDescription.Ordering(dcn, ascending, nullLast) =>
               val NameEntry(_, typ) = from.columns(dcn)
-              OrderBy(PhysicalColumn[MT](from.label, from.canonicalName, dcn, typ)(AtomicPositionInfo.None), ascending = ascending, nullLast = nullLast)
+              OrderBy(PhysicalColumn[MT](from.label, from.tableName, from.canonicalName, dcn, typ)(AtomicPositionInfo.None), ascending = ascending, nullLast = nullLast)
             },
             None,
             None,
@@ -446,7 +446,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
         case j: Join => findSystemColumns(j.left)
         case FromTable(tableName, tableCanonicalName, _, _, tableLabel, columns, _) =>
           columns.collect { case (colLabel, NameEntry(name, typ)) if isSystemColumn(name) =>
-            name -> PhysicalColumn[MT](tableLabel, tableCanonicalName, colLabel, typ)(AtomicPositionInfo.None)
+            name -> PhysicalColumn[MT](tableLabel, tableName, tableCanonicalName, colLabel, typ)(AtomicPositionInfo.None)
           }
         case FromStatement(stmt, tableLabel, _, _) =>
           stmt.schema.iterator.collect { case (colLabel, Statement.SchemaEntry(name, typ, _isSynthetic)) if isSystemColumn(name) =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Statement.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Statement.scala
@@ -50,7 +50,7 @@ sealed abstract class Statement[MT <: MetaTypes] extends LabelUniverse[MT] {
   private[analyzer2] def columnReferences: Map[AutoTableLabel, Set[ColumnLabel]]
 
   def isIsomorphic(that: Statement[MT]): Boolean =
-    findIsomorphism(new IsomorphismState(this.realTables, that.realTables), None, None, that)
+    findIsomorphism(new IsomorphismState, None, None, that)
 
   private[analyzer2] def findIsomorphism(
     state: IsomorphismState,

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Typechecker.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Typechecker.scala
@@ -146,7 +146,7 @@ class Typechecker[MT <: MetaTypes](
               case Some(Environment.LookupResult.Virtual(table, column, typ)) =>
                 Right(Seq(VirtualColumn(table, column, typ)(new AtomicPositionInfo(col.position))))
               case Some(Environment.LookupResult.Physical(tableName, tableCanonicalName, tableLabel, column, typ)) =>
-                Right(Seq(PhysicalColumn[MT](tableLabel, tableCanonicalName, column, typ)(new AtomicPositionInfo(col.position))))
+                Right(Seq(PhysicalColumn[MT](tableLabel, tableName, tableCanonicalName, column, typ)(new AtomicPositionInfo(col.position))))
             }
         }
       case col@ast.ColumnOrAliasRef(Some(qual), name) =>
@@ -156,7 +156,7 @@ class Typechecker[MT <: MetaTypes](
           case Some(Environment.LookupResult.Virtual(table, column, typ)) =>
             Right(Seq(VirtualColumn(table, column, typ)(new AtomicPositionInfo(col.position))))
           case Some(Environment.LookupResult.Physical(tableName, tableCanonicalName, tableLabel, column, typ)) =>
-            Right(Seq(PhysicalColumn[MT](tableLabel, tableCanonicalName, column, typ)(new AtomicPositionInfo(col.position))))
+            Right(Seq(PhysicalColumn[MT](tableLabel, tableName, tableCanonicalName, column, typ)(new AtomicPositionInfo(col.position))))
         }
       case l: ast.Literal =>
         squash(typeInfo.potentialExprs(l, primaryTable), l.position)

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/AggregateFunctionCall.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/AggregateFunctionCall.scala
@@ -44,8 +44,10 @@ trait AggregateFunctionCallImpl[MT <: MetaTypes] { this: AggregateFunctionCall[M
       case AggregateFunctionCall(thatFunction, thatArgs, thatDistinct, thatFilter) =>
         this.function == thatFunction &&
           this.args.length == thatArgs.length &&
+          this.args.zip(thatArgs).forall { case (a, b) => a.findIsomorphism(state, b) } &&
           this.distinct == thatDistinct &&
           this.filter.isDefined == thatFilter.isDefined &&
+          this.filter.zip(thatFilter).forall { case (a, b) => a.findIsomorphism(state, b) } &&
           this.filter.zip(thatFilter).forall { case (a, b) => a.findIsomorphism(state, b) }
       case _ =>
         false

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/PhysicalColumn.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/PhysicalColumn.scala
@@ -18,7 +18,7 @@ trait PhysicalColumnImpl[MT <: MetaTypes] extends LabelUniverse[MT] { this: Phys
 
   private[analyzer2] def findIsomorphism(state: IsomorphismState, that: Expr[MT]): Boolean = {
     that match {
-      case PhysicalColumn(thatTable, thatTableCanonicalName, thatColumn, thatTyp) =>
+      case PhysicalColumn(thatTable, thatTableName, thatTableCanonicalName, thatColumn, thatTyp) =>
         this.typ == that.typ &&
           this.tableCanonicalName == thatTableCanonicalName &&
           state.physicalTableLeft(this.table) == state.physicalTableRight(thatTable) &&
@@ -31,6 +31,7 @@ trait PhysicalColumnImpl[MT <: MetaTypes] extends LabelUniverse[MT] { this: Phys
   private[analyzer2] def doRewriteDatabaseNames[MT2 <: MetaTypes](state: RewriteDatabaseNamesState[MT2]) =
     PhysicalColumn(
       table = table,
+      tableName = state.convert(tableName),
       tableCanonicalName = tableCanonicalName,
       column = state.convert(table, column),
       typ = state.changesOnlyLabels.convertCT(typ)
@@ -54,6 +55,7 @@ trait OPhysicalColumnImpl { this: PhysicalColumn.type =>
   implicit def serialize[MT <: MetaTypes](implicit writableCT : Writable[MT#ColumnType], writableDTN : Writable[MT#DatabaseTableNameImpl], writableDCN : Writable[MT#DatabaseColumnNameImpl]): Writable[PhysicalColumn[MT]] = new Writable[PhysicalColumn[MT]] {
     def writeTo(buffer: WriteBuffer, c: PhysicalColumn[MT]): Unit = {
       buffer.write(c.table)
+      buffer.write(c.tableName)
       buffer.write(c.tableCanonicalName)
       buffer.write(c.column)
       buffer.write(c.typ)
@@ -65,6 +67,7 @@ trait OPhysicalColumnImpl { this: PhysicalColumn.type =>
     def readFrom(buffer: ReadBuffer): PhysicalColumn[MT] = {
       PhysicalColumn(
         table = buffer.read[AutoTableLabel](),
+        tableName = buffer.read[DatabaseTableName](),
         tableCanonicalName = buffer.read[CanonicalName](),
         column = buffer.read[DatabaseColumnName](),
         typ = buffer.read[CT]()

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/PhysicalColumn.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/PhysicalColumn.scala
@@ -21,7 +21,7 @@ trait PhysicalColumnImpl[MT <: MetaTypes] extends LabelUniverse[MT] { this: Phys
       case PhysicalColumn(thatTable, thatTableName, thatTableCanonicalName, thatColumn, thatTyp) =>
         this.typ == that.typ &&
           this.tableCanonicalName == thatTableCanonicalName &&
-          state.physicalTableLeft(this.table) == state.physicalTableRight(thatTable) &&
+          this.tableName == thatTableName &&
           state.tryAssociate(Some(this.table), this.column, Some(thatTable), thatColumn)
       case _ =>
         false

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
@@ -25,7 +25,7 @@ trait FromTableImpl[MT <: MetaTypes] { this: FromTable[MT] =>
     )
   }.toVector
 
-  def unique = primaryKeys.to(LazyList).map(_.map { dcn => PhysicalColumn[MT](label, canonicalName, dcn, columns(dcn).typ)(AtomicPositionInfo.None) })
+  def unique = primaryKeys.to(LazyList).map(_.map { dcn => PhysicalColumn[MT](label, tableName, canonicalName, dcn, columns(dcn).typ)(AtomicPositionInfo.None) })
 
   lazy val resourceName = Some(definiteResourceName)
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Select.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Select.scala
@@ -119,8 +119,8 @@ trait SelectImpl[MT <: MetaTypes] { this: Select[MT] =>
 
   lazy val unique: LazyList[Seq[AutoColumnLabel]] = {
     val selectedColumns = selectList.iterator.collect {
-      case (columnLabel, NamedExpr(PhysicalColumn(table, tableCanonicalName, col, typ), _name, _isSynthetic)) =>
-        PhysicalColumn(table, tableCanonicalName, col, typ)(AtomicPositionInfo.None) -> columnLabel
+      case (columnLabel, NamedExpr(PhysicalColumn(table, tableName, tableCanonicalName, col, typ), _name, _isSynthetic)) =>
+        PhysicalColumn(table, tableName, tableCanonicalName, col, typ)(AtomicPositionInfo.None) -> columnLabel
       case (columnLabel, NamedExpr(VirtualColumn(table, col, typ), _name, _isSynthetic)) =>
         VirtualColumn(table, col, typ)(AtomicPositionInfo.None) -> columnLabel
     }.toMap[Column[MT], AutoColumnLabel]

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
@@ -112,7 +112,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     select.selectList must equal (
       OrderedMap(
         c(1) -> NamedExpr(
-          PhysicalColumn[TestMT](t(1), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None),
+          PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None),
           cn("t"),
           false
         ),
@@ -120,8 +120,8 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
           FunctionCall[TestMT](
             TestFunctions.Times.monomorphic.get,
             Seq(
-              PhysicalColumn[TestMT](t(1), canon("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.None),
-              PhysicalColumn[TestMT](t(1), canon("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.None)
+              PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), canon("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.None),
+              PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), canon("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.None)
             )
           )(FuncallPositionInfo.None),
           cn("num_num"),
@@ -251,8 +251,8 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
       Select[TestMT](
         Distinctiveness.Indistinct(),
         OrderedMap(
-          c(1) -> NamedExpr(PhysicalColumn[TestMT](t(1), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None), cn("text"), false),
-          c(2) -> NamedExpr(PhysicalColumn[TestMT](t(1), canon("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.None), cn("num"), false)
+          c(1) -> NamedExpr(PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None), cn("text"), false),
+          c(2) -> NamedExpr(PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), canon("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.None), cn("num"), false)
         ),
         FromTable[TestMT](
           dtn("aaaa-aaaa"),
@@ -268,7 +268,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
         ),
         None, Nil, None,
         List(
-          OrderBy(PhysicalColumn[TestMT](t(1), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None),true,true)
+          OrderBy(PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None),true,true)
         ),
         None,None,None,Set.empty
       )
@@ -299,8 +299,8 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
           Select[TestMT](
             Distinctiveness.Indistinct(),
             OrderedMap(
-              c(1) -> NamedExpr(PhysicalColumn[TestMT](t(1), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None), cn("text"),false),
-              c(2) -> NamedExpr(PhysicalColumn[TestMT](t(1), canon("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.None), cn("num"),false)
+              c(1) -> NamedExpr(PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None), cn("text"),false),
+              c(2) -> NamedExpr(PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), canon("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.None), cn("num"),false)
             ),
             FromTable[TestMT](
               dtn("aaaa-aaaa"),
@@ -316,7 +316,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
             ),
             None, Nil, None,
             List(
-              OrderBy(PhysicalColumn[TestMT](t(1), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None),true,true)
+              OrderBy(PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None),true,true)
             ),
             None,None,None,Set.empty
           ),
@@ -381,12 +381,12 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     select.selectList must equal (
       OrderedMap(
         c(4) -> NamedExpr(
-          PhysicalColumn[TestMT](t(1), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None),
+          PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None),
           cn("text"),
           false
         ),
         c(5) -> NamedExpr(
-          PhysicalColumn[TestMT](t(1), canon("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.None),
+          PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), canon("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.None),
           cn("num"),
           false
         )
@@ -440,11 +440,11 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
                         FunctionCall[TestMT](
                           MonomorphicFunction(TestFunctions.Eq, Map("a" -> TestText)),
                           Seq(
-                            PhysicalColumn[TestMT](t(3),canon("bbbb-bbbb"),dcn("user"),TestText)(AtomicPositionInfo.None),
+                            PhysicalColumn[TestMT](t(3),dtn("bbbb-bbbb"),canon("bbbb-bbbb"),dcn("user"),TestText)(AtomicPositionInfo.None),
                             VirtualColumn[TestMT](t(2),c(1),TestText)(AtomicPositionInfo.None)
                           )
                         )(FuncallPositionInfo.None),
-                        PhysicalColumn[TestMT](t(3),canon("bbbb-bbbb"),dcn("allowed"),TestBoolean)(AtomicPositionInfo.None)
+                        PhysicalColumn[TestMT](t(3),dtn("bbbb-bbbb"),canon("bbbb-bbbb"),dcn("allowed"),TestBoolean)(AtomicPositionInfo.None)
                       )
                     )(FuncallPositionInfo.None)
                   ),
@@ -481,12 +481,12 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     select.selectList must equal (
       OrderedMap(
         c(4) -> NamedExpr(
-          PhysicalColumn[TestMT](t(1), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None),
+          PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None),
           cn("text"),
           false
         ),
         c(5) -> NamedExpr(
-          PhysicalColumn[TestMT](t(1), canon("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.None),
+          PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), canon("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.None),
           cn("num"),
           false
         )
@@ -515,7 +515,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
               JoinType.Inner,
               true,
               FromStatement(
-                Values[TestMT](OrderedSet(c(1)), NonEmptySeq(NonEmptySeq(PhysicalColumn[TestMT](t(1),canon("aaaa-aaaa"),dcn("text"),TestText)(AtomicPositionInfo.None),Nil),Nil)),
+                Values[TestMT](OrderedSet(c(1)), NonEmptySeq(NonEmptySeq(PhysicalColumn[TestMT](t(1),dtn("aaaa-aaaa"),canon("aaaa-aaaa"),dcn("text"),TestText)(AtomicPositionInfo.None),Nil),Nil)),
                 t(2), None, None
               ),
               FromStatement[TestMT](
@@ -540,11 +540,11 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
                         FunctionCall[TestMT](
                           MonomorphicFunction(TestFunctions.Eq, Map("a" -> TestText)),
                           Seq(
-                            PhysicalColumn[TestMT](t(3),canon("bbbb-bbbb"),dcn("user"),TestText)(AtomicPositionInfo.None),
+                            PhysicalColumn[TestMT](t(3),dtn("bbbb-bbbb"),canon("bbbb-bbbb"),dcn("user"),TestText)(AtomicPositionInfo.None),
                             VirtualColumn[TestMT](t(2),c(1),TestText)(AtomicPositionInfo.None)
                           )
                         )(FuncallPositionInfo.None),
-                        PhysicalColumn[TestMT](t(3),canon("bbbb-bbbb"),dcn("allowed"),TestBoolean)(AtomicPositionInfo.None)
+                        PhysicalColumn[TestMT](t(3),dtn("bbbb-bbbb"),canon("bbbb-bbbb"),dcn("allowed"),TestBoolean)(AtomicPositionInfo.None)
                       )
                     )(FuncallPositionInfo.None)
                   ),
@@ -580,12 +580,12 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     select.selectList must equal (
       OrderedMap(
         c(13) -> NamedExpr(
-          PhysicalColumn[TestMT](t(1), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None),
+          PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None),
           cn("text"),
           false
         ),
         c(14) -> NamedExpr(
-          PhysicalColumn[TestMT](t(1), canon("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.None),
+          PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), canon("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.None),
           cn("num"),
           false
         )
@@ -631,7 +631,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
                           TestFunctions.castIdentitiesByType(TestBoolean).monomorphic.get,
                           Seq(LiteralValue[TestMT](TestBoolean(true))(AtomicPositionInfo.None))
                         )(FuncallPositionInfo.None),
-                        PhysicalColumn[TestMT](t(1), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None)
+                        PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), canon("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.None)
                       )
                     )
                   )


### PR DESCRIPTION
Before:
* You could only check entire Statements for equivalence, because the check needed to build up a map of table labels to database table names.

Now:
* You can check Statements, Froms, and Exprs for equivalence.
