### PR TITLE
Refactor the sqlizer

### DIFF
--- a/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/ExprSqlizer.scala
+++ b/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/ExprSqlizer.scala
@@ -3,76 +3,84 @@ package com.socrata.soql.sqlizer
 import com.socrata.soql.analyzer2._
 import com.socrata.prettyprint.prelude._
 
-class ExprSqlizer[MT <: MetaTypes with MetaTypesExt](
-  sqlizer: Sqlizer[MT],
-  availableSchemas: Map[AutoTableLabel, Map[types.ColumnLabel[MT], AugmentedType[MT]]],
-  selectListIndices: IndexedSeq[SelectListIndex],
-  dynamicContext: Sqlizer.DynamicContext[MT]
-) extends StatementUniverse[MT] {
-  import sqlizer.funcallSqlizer
-  import sqlizer.exprSqlFactory
-
-  private val repFor = dynamicContext.repFor
-
-  def sqlizeOrderBy(e: OrderBy): OrderBySql[MT] = {
-    if(repFor(e.expr.typ).isProvenanced) {
-      if(!dynamicContext.provTracker(e.expr).isPlural) {
-        // all provenance values in a physical column will be the
-        // same; eliminate them from the sqlizer so that the pg
-        // optimizer doesn't have to.
-        val result = sqlize(e.expr)
-        val Seq(_provenance, value) = result.sqls
-        OrderBySql(exprSqlFactory(value, e.expr), ascending = e.ascending, nullLast = e.nullLast)
-      } else {
-        OrderBySql(sqlize(e.expr), ascending = e.ascending, nullLast = e.nullLast)
-      }
-    } else {
-      // We'll compress into a json array it because we don't want
-      // ORDER BY's null positioning to be inconsistent depending on
-      // whether or not it's expanded
-      OrderBySql(sqlize(e.expr).compressed, ascending = e.ascending, nullLast = e.nullLast)
-    }
+object ExprSqlizer {
+  trait Contexted[MT <: MetaTypes with MetaTypesExt] extends SqlizerUniverse[MT] {
+    def sqlizeOrderBy(e: OrderBy): OrderBySql
+    def sqlize(e: Expr): ExprSql
   }
+}
 
-  def sqlize(e: Expr): ExprSql[MT] =
-    e match {
-      case pc@PhysicalColumn(tbl, _tableName, col, typ) =>
-        val trueType = availableSchemas(tbl)(col)
-        assert(trueType.typ == typ)
-        assert(trueType.isExpanded)
-        repFor(typ).physicalColumnRef(pc)
-      case vc@VirtualColumn(tbl, col, typ) =>
-        val trueType = availableSchemas(tbl)(col)
-        assert(trueType.typ == typ)
-        repFor(typ).virtualColumnRef(vc, isExpanded = trueType.isExpanded)
-      case nl@NullLiteral(typ) =>
-        repFor(typ).nullLiteral(nl)
-      case lit@LiteralValue(v) =>
-        repFor(lit.typ).literal(lit)
-      case SelectListReference(n, _isAggregated, _isWindowed, typ) =>
-        val SelectListIndex(startingPhysicalColumn, isExpanded) = selectListIndices(n-1)
-        if(isExpanded) {
-          exprSqlFactory(Doc(startingPhysicalColumn.toString), e)
+
+class ExprSqlizer[MT <: MetaTypes with MetaTypesExt](
+  funcallSqlizer: FuncallSqlizer[MT],
+  exprSqlFactory: ExprSqlFactory[MT]
+) extends SqlizerUniverse[MT] {
+  def withContext(
+    availableSchemas: AvailableSchemas,
+    selectListIndices: IndexedSeq[SelectListIndex],
+    sqlizerCtx: Sqlizer.DynamicContext[MT]
+  ): ExprSqlizer.Contexted[MT] =
+    new ExprSqlizer.Contexted[MT] {
+      override def sqlizeOrderBy(e: OrderBy): OrderBySql = {
+        if(sqlizerCtx.repFor(e.expr.typ).isProvenanced) {
+          if(!sqlizerCtx.provTracker(e.expr).isPlural) {
+            // all provenance values in a physical column will be the
+            // same; eliminate them from the sqlizer so that the pg
+            // optimizer doesn't have to.
+            val result = sqlize(e.expr)
+            val Seq(_provenance, value) = result.sqls
+            OrderBySql(exprSqlFactory(value, e.expr), ascending = e.ascending, nullLast = e.nullLast)
+          } else {
+            OrderBySql(sqlize(e.expr), ascending = e.ascending, nullLast = e.nullLast)
+          }
         } else {
-          exprSqlFactory(
-            (0 until repFor(typ).expandedColumnCount).map { offset =>
-              Doc((startingPhysicalColumn + offset).toString)
-            },
-            e
-          )
+          // We'll compress into a json array it because we don't want
+          // ORDER BY's null positioning to be inconsistent depending on
+          // whether or not it's expanded
+          OrderBySql(sqlize(e.expr).compressed, ascending = e.ascending, nullLast = e.nullLast)
         }
-      case fc@FunctionCall(_func, args) =>
-        funcallSqlizer.sqlizeOrdinaryFunction(fc, args.map(sqlize), dynamicContext)
-      case afc@AggregateFunctionCall(_func, args, _distinct, filter) =>
-        funcallSqlizer.sqlizeAggregateFunction(afc, args.map(sqlize), filter.map(sqlize), dynamicContext)
-      case wfc@WindowedFunctionCall(_func, args, filter, partitionBy, orderBy, _frame) =>
-        funcallSqlizer.sqlizeWindowedFunction(
-          wfc,
-          args.map(sqlize),
-          filter.map(sqlize),
-          partitionBy.map(sqlize),
-          orderBy.map(sqlizeOrderBy),
-          dynamicContext
-        )
+      }
+
+      override def sqlize(e: Expr): ExprSql =
+        e match {
+          case pc@PhysicalColumn(tbl, _tableName, col, typ) =>
+            val trueType = availableSchemas(tbl)(col)
+            assert(trueType.typ == typ)
+            assert(trueType.isExpanded)
+            sqlizerCtx.repFor(typ).physicalColumnRef(pc)
+          case vc@VirtualColumn(tbl, col, typ) =>
+            val trueType = availableSchemas(tbl)(col)
+            assert(trueType.typ == typ)
+            sqlizerCtx.repFor(typ).virtualColumnRef(vc, isExpanded = trueType.isExpanded)
+          case nl@NullLiteral(typ) =>
+            sqlizerCtx.repFor(typ).nullLiteral(nl)
+          case lit@LiteralValue(v) =>
+            sqlizerCtx.repFor(lit.typ).literal(lit)
+          case SelectListReference(n, _isAggregated, _isWindowed, typ) =>
+            val SelectListIndex(startingPhysicalColumn, isExpanded) = selectListIndices(n-1)
+            if(isExpanded) {
+              exprSqlFactory(Doc(startingPhysicalColumn.toString), e)
+            } else {
+              exprSqlFactory(
+                (0 until sqlizerCtx.repFor(typ).expandedColumnCount).map { offset =>
+                  Doc((startingPhysicalColumn + offset).toString)
+                },
+                e
+              )
+            }
+          case fc@FunctionCall(_func, args) =>
+            funcallSqlizer.sqlizeOrdinaryFunction(fc, args.map(sqlize), sqlizerCtx)
+          case afc@AggregateFunctionCall(_func, args, _distinct, filter) =>
+            funcallSqlizer.sqlizeAggregateFunction(afc, args.map(sqlize), filter.map(sqlize), sqlizerCtx)
+          case wfc@WindowedFunctionCall(_func, args, filter, partitionBy, orderBy, _frame) =>
+            funcallSqlizer.sqlizeWindowedFunction(
+              wfc,
+              args.map(sqlize),
+              filter.map(sqlize),
+              partitionBy.map(sqlize),
+              orderBy.map(sqlizeOrderBy),
+              sqlizerCtx
+            )
+        }
     }
 }

--- a/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/GensymProvider.scala
+++ b/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/GensymProvider.scala
@@ -1,0 +1,12 @@
+package com.socrata.soql.sqlizer
+
+import com.socrata.prettyprint.prelude._
+
+class GensymProvider(namespaces: SqlNamespaces[_]) {
+  private var counter = 0L
+
+  def next(): Doc[Nothing] = {
+    counter += 1
+    d"${namespaces.gensymPrefix}${counter}"
+  }
+}

--- a/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/SqlNamespaces.scala
+++ b/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/SqlNamespaces.scala
@@ -4,17 +4,6 @@ import com.socrata.soql.analyzer2._
 import com.socrata.prettyprint.prelude._
 
 trait SqlNamespaces[MT <: MetaTypes] extends LabelUniverse[MT] {
-  private var counter = 0L
-
-  // Returns an identifier that is guaranteed not to conflict with any
-  // other identifier that this query could use.
-  def gensym(): Doc[Nothing] = {
-    counter += 1
-    d"$gensymPrefix$counter"
-  }
-
-  protected def gensymPrefix: String
-
   // Turns an AutoTableLabel into a table name that is guaranteed to
   // not conflict with any real table.
   def tableLabel(table: AutoTableLabel): Doc[Nothing] =
@@ -25,24 +14,39 @@ trait SqlNamespaces[MT <: MetaTypes] extends LabelUniverse[MT] {
   // Otherwise it returns the (base of) the physical column(s) which
   // make up that logical column.
   def columnBase(label: ColumnLabel): Doc[Nothing] =
+    Doc(rawColumnBase(label))
+
+  def rawColumnBase(label: ColumnLabel): String =
     label match {
-      case dcn: DatabaseColumnName => databaseColumnBase(dcn)
-      case acl: AutoColumnLabel => Doc(rawAutoColumnBase(acl))
+      case dcn: DatabaseColumnName => rawDatabaseColumnBase(dcn)
+      case acl: AutoColumnLabel => rawAutoColumnBase(acl)
     }
 
-  def databaseTableName(dtn: DatabaseTableName): Doc[Nothing]
-  def databaseColumnBase(dcn: DatabaseColumnName): Doc[Nothing]
+  def databaseTableName(dtn: DatabaseTableName): Doc[Nothing] = Doc(rawDatabaseTableName(dtn))
+  def databaseColumnBase(dcn: DatabaseColumnName): Doc[Nothing] = Doc(rawDatabaseColumnBase(dcn))
+  def autoColumnBase(acl: AutoColumnLabel): Doc[Nothing] = Doc(rawAutoColumnBase(acl))
+
   def rawAutoColumnBase(acl: AutoColumnLabel): String = s"$autoColumnPrefix${acl.name}"
 
   def indexName(dtn: DatabaseTableName, col: ColumnLabel): Doc[Nothing] =
-    Doc(idxPrefix) ++ d"_" ++ databaseTableName(dtn) ++ d"_" ++ columnBase(col)
+    Doc(rawIndexName(dtn, col))
+
+  def rawIndexName(dtn: DatabaseTableName, col: ColumnLabel): String =
+    idxPrefix + "_" + rawDatabaseTableName(dtn) + "_" + rawColumnBase(col)
 
   def indexName(dtn: DatabaseTableName, col: ColumnLabel, subcol: String): Doc[Nothing] =
-    indexName(dtn, col) ++ d"_" ++ Doc(subcol)
+    Doc(rawIndexName(dtn, col, subcol))
+
+  def rawIndexName(dtn: DatabaseTableName, col: ColumnLabel, subcol: String): String =
+    rawIndexName(dtn, col) + "_" + subcol
 
   protected def idxPrefix: String
 
   protected def autoTablePrefix: String
 
   protected def autoColumnPrefix: String
+
+  def rawDatabaseTableName(dtn: DatabaseTableName): String
+  def rawDatabaseColumnBase(dcn: DatabaseColumnName): String
+  def gensymPrefix: String
 }

--- a/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/SqlizerUniverse.scala
+++ b/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/SqlizerUniverse.scala
@@ -1,6 +1,7 @@
 package com.socrata.soql.sqlizer
 
 import com.socrata.soql.analyzer2._
+import com.socrata.soql.collection.OrderedMap
 import com.socrata.prettyprint
 
 import com.socrata.soql.sqlizer
@@ -23,4 +24,7 @@ trait SqlizerUniverse[MT <: MetaTypes with MetaTypesExt] extends StatementUniver
   type ExtraContext = MT#ExtraContext
   type ExtraContextResult = MT#ExtraContextResult
   type ExprSqlFactory = sqlizer.ExprSqlFactory[MT]
+
+  type AugmentedSchema = sqlizer.AugmentedSchema[MT]
+  type AvailableSchemas = sqlizer.AvailableSchemas[MT]
 }

--- a/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/package.scala
+++ b/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/package.scala
@@ -3,6 +3,8 @@ package com.socrata.soql
 import scala.collection.compat._
 
 import com.socrata.prettyprint.prelude._
+import com.socrata.soql.analyzer2._
+import com.socrata.soql.collection.OrderedMap
 
 package object sqlizer {
   implicit class AugmentSeq[T](private val underlying: Seq[Doc[T]]) extends AnyVal {
@@ -47,4 +49,7 @@ package object sqlizer {
       }
     }
   }
+
+  type AugmentedSchema[MT <: MetaTypes with MetaTypesExt] = OrderedMap[types.ColumnLabel[MT], AugmentedType[MT]]
+  type AvailableSchemas[MT <: MetaTypes with MetaTypesExt] = Map[AutoTableLabel, AugmentedSchema[MT]]
 }


### PR DESCRIPTION
* Separate more cleanly query-specific parts of the parameters and the non-query-specific parts
* and also make SqlNamespace stateless (gensyms are now separate)
* Which means we can create a sqlizer once at startup and reuse it over and over
* Unfortunately the Rep provide is still pretty query-specific, but it's the only piece.