### PR TITLE
Add a concept of ad-hoc rollup rewrite rules

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rollup/AdHocRewriter.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rollup/AdHocRewriter.scala
@@ -1,0 +1,16 @@
+package com.socrata.soql.analyzer2.rollup
+
+import com.socrata.soql.analyzer2._
+
+trait AdHocRewriter[MT <: MetaTypes] extends StatementUniverse[MT] {
+  // Rewrite a given expression into alternate candidate expressions.
+  // This is called if the rewriter hasn't seen any other way to
+  // handle mapping an expression onto a rollup.
+  def apply(e: Expr): Seq[Expr]
+}
+
+object AdHocRewriter {
+  def noop[MT <: MetaTypes] = new AdHocRewriter[MT] {
+    override def apply(e: Expr) = Nil
+  }
+}

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rollup/RollupExact.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rollup/RollupExact.scala
@@ -13,6 +13,7 @@ object RollupExact {
 
 class RollupExact[MT <: MetaTypes](
   semigroupRewriter: SemigroupRewriter[MT],
+  adHocRewriter: AdHocRewriter[MT],
   functionSubset: FunctionSubset[MT],
   functionSplitter: FunctionSplitter[MT],
   splitAnd: SplitAnd[MT],
@@ -732,6 +733,11 @@ class RollupExact[MT <: MetaTypes](
       }.toMap
 
     def rewrite(sExpr: Expr, needsMerge: Boolean = false): Option[Expr] =
+      doNonAdHocRewrite(sExpr, needsMerge = needsMerge) orElse {
+        adHocRewriter(sExpr).findMap(doNonAdHocRewrite(_, needsMerge))
+      }
+
+    private def doNonAdHocRewrite(sExpr: Expr, needsMerge: Boolean): Option[Expr] =
       rewriteSimple(sExpr, needsMerge).orElse { rewriteCompound(sExpr, needsMerge) }
 
     // This exists specifically to handle the case of "avg" but in

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/TestFunctions.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/TestFunctions.scala
@@ -63,6 +63,7 @@ object TestFunctions {
   // the former)
   val BottomDWord = mf("bottom_dword", FunctionName("bottom_dword"), Seq(TestNumber), Seq.empty, TestNumber)
   val BottomByte = mf("bottom_byte", FunctionName("bottom_byte"), Seq(TestNumber), Seq.empty, TestNumber)
+  val BitAnd = mf("bitand", FunctionName("bitand"), Seq(TestNumber, TestNumber), Seq.empty, TestNumber)
 
   val castIdentitiesByType = OrderedMap() ++ TestType.typesByName.iterator.map { case (n, t) =>
     t -> mf(n.caseFolded + "::" + n.caseFolded, SpecialFunctions.Cast(n), Seq(t), Seq.empty, t)

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/TestType.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/TestType.scala
@@ -99,7 +99,7 @@ object TestBoolean extends TestType("boolean", isOrdered = true) {
   def apply(b: Boolean) = if(b) canonicalTrue else canonicalFalse
 }
 
-case class TestNumber(num: Int) extends TestValue {
+case class TestNumber(num: Long) extends TestValue {
   def typ = TestNumber
   def doc = Doc(num)
 }

--- a/soql-stdlib/src/main/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLAdHocRewriter.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLAdHocRewriter.scala
@@ -1,0 +1,75 @@
+package com.socrata.soql.stdlib.analyzer2.rollup
+
+import org.joda.time.LocalDateTime
+
+import com.socrata.soql.analyzer2._
+import com.socrata.soql.analyzer2.rollup.AdHocRewriter
+import com.socrata.soql.functions.{MonomorphicFunction, SoQLFunctions}
+import com.socrata.soql.types._
+
+class SoQLAdHocRewriter[MT <: MetaTypes with ({type ColumnType = SoQLType; type ColumnValue = SoQLValue})]
+    extends AdHocRewriter[MT]
+{
+  private val LtTime = MonomorphicFunction(SoQLFunctions.Lt, Map("a" -> SoQLFloatingTimestamp))
+  private val LteTime = MonomorphicFunction(SoQLFunctions.Lte, Map("a" -> SoQLFloatingTimestamp))
+  private val GteTime = MonomorphicFunction(SoQLFunctions.Gte, Map("a" -> SoQLFloatingTimestamp))
+  private val GtTime = MonomorphicFunction(SoQLFunctions.Gt, Map("a" -> SoQLFloatingTimestamp))
+
+  private val DateTruncYMD = SoQLFunctions.FloatingTimeStampTruncYmd.monomorphic.get
+  private val DateTruncYM = SoQLFunctions.FloatingTimeStampTruncYm.monomorphic.get
+  private val DateTruncY = SoQLFunctions.FloatingTimeStampTruncY.monomorphic.get
+
+  override def apply(e: Expr): Seq[Expr] =
+    e match {
+      // some_timestamp_expr < pre-truncated literal timestamp
+      // is the same as truncate(some_timestamp_expr) < that same literal
+      // Ditto for >=
+      // Because a single timestamp literal can be simultaneously
+      // "truncated" to different degrees (ymd, ym, y), we'll generate
+      // one such candidate for each such potential truncation
+      case fc@FunctionCall(LtTime | GteTime, Seq(lhs, rhs@LiteralValue(SoQLFloatingTimestamp(timestamp)))) if timestamp.getMillisOfDay == 0 && !lhs.isInstanceOf[LiteralValue] =>
+        val result = Vector.newBuilder[Expr]
+
+        def addYear(expr: Expr): Unit = {
+          if(timestamp.getDayOfMonth == 1 && timestamp.getMonthOfYear == 1) {
+            result += FunctionCall(fc.function, Seq(FunctionCall[MT](DateTruncY, Seq(expr))(FuncallPositionInfo.None), rhs))(fc.position)
+          }
+        }
+
+        def addMonth(expr: Expr): Unit = {
+          if(timestamp.getDayOfMonth == 1) {
+            result += FunctionCall(fc.function, Seq(FunctionCall[MT](DateTruncYM, Seq(expr))(FuncallPositionInfo.None), rhs))(fc.position)
+          }
+        }
+
+        lhs match {
+          case FunctionCall(DateTruncYMD, Seq(realLhs)) =>
+            addMonth(realLhs)
+            addYear(realLhs)
+
+          case FunctionCall(DateTruncYM, Seq(realLhs)) =>
+            addYear(realLhs)
+
+          case FunctionCall(DateTruncY, _) =>
+            // nothing; we can't truncate further
+
+          case _ =>
+            result += FunctionCall(fc.function, Seq(FunctionCall[MT](DateTruncYMD, Seq(lhs))(FuncallPositionInfo.None), rhs))(fc.position)
+            addMonth(lhs)
+            addYear(lhs)
+        }
+
+        result.result()
+
+      // rewrite "'y-m-d' <= x" to "x >= 'y-m-d'" to reuse the above
+      case fc@FunctionCall(LteTime, Seq(lhs@LiteralValue(_), rhs)) =>
+        apply(FunctionCall[MT](GteTime, Seq(rhs, lhs))(fc.position))
+
+      // rewrite "'y-m-d' > x" to "x < 'y-m-d'" to reuse the above
+      case fc@FunctionCall(GtTime, Seq(lhs@LiteralValue(_), rhs)) =>
+        apply(FunctionCall[MT](LtTime, Seq(rhs, lhs))(fc.position))
+
+      case _ =>
+        Nil
+    }
+}

--- a/soql-stdlib/src/main/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLRollupExact.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLRollupExact.scala
@@ -6,4 +6,4 @@ import com.socrata.soql.types.{SoQLType, SoQLValue}
 
 class SoQLRollupExact[MT <: MetaTypes with ({type ColumnType = SoQLType; type ColumnValue = SoQLValue})](
   stringifier: Stringifier[MT]
-) extends RollupExact[MT](new SoQLSemigroupRewriter[MT], new SoQLFunctionSubset[MT], new SoQLFunctionSplitter[MT], new SoQLSplitAnd[MT], stringifier)
+) extends RollupExact[MT](new SoQLSemigroupRewriter[MT], new SoQLAdHocRewriter[MT], new SoQLFunctionSubset[MT], new SoQLFunctionSplitter[MT], new SoQLSplitAnd[MT], stringifier)

--- a/soql-stdlib/src/test/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLAdHocRewriterTest.scala
+++ b/soql-stdlib/src/test/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLAdHocRewriterTest.scala
@@ -1,0 +1,71 @@
+package com.socrata.soql.stdlib.analyzer2.rollup
+
+import java.math.{BigDecimal => JBigDecimal}
+
+import org.scalatest.{FunSuite, MustMatchers}
+
+import com.socrata.soql.analyzer2._
+import com.socrata.soql.analyzer2.mocktablefinder._
+import com.socrata.soql.environment.Provenance
+import com.socrata.soql.functions.{SoQLFunctions, MonomorphicFunction, SoQLTypeInfo, SoQLFunctionInfo}
+import com.socrata.soql.types._
+
+class SoQLAdHocRewriterTest extends FunSuite with MustMatchers {
+  import SoQLTypeInfo.hasType
+
+  trait MT extends MetaTypes {
+    type ColumnType = SoQLType
+    type ColumnValue = SoQLValue
+    type ResourceNameScope = Int
+    type DatabaseTableNameImpl = String
+    type DatabaseColumnNameImpl = String
+  }
+
+  val rewriter = new SoQLAdHocRewriter[MT]
+
+  def analyze(expr: String) = {
+    val tf = MockTableFinder[MT](
+      (0, "rollup") -> D("floating_timestamp" -> SoQLFloatingTimestamp)
+    )
+    val q = s"select $expr from @rollup"
+    val Right(ft) = tf.findTables(0, q, Map.empty)
+    val analyzer = new SoQLAnalyzer[MT](
+      SoQLTypeInfo,
+      SoQLFunctionInfo,
+      new ToProvenance[String] {
+        override def toProvenance(dtn: DatabaseTableName[String]) = Provenance(dtn.name)
+      })
+    val Right(analysis) = analyzer(ft, UserParameters.empty)
+    analysis.statement.asInstanceOf[Select[MT]].selectList.valuesIterator.next().expr
+  }
+
+  private val c1 =
+    PhysicalColumn[MT](
+      AutoTableLabel.forTest(1),
+      DatabaseTableName("rollup"),
+      DatabaseColumnName("c1"),
+      SoQLNumber
+    )(AtomicPositionInfo.None)
+
+  test("limited by literals's truncatedness") {
+    rewriter(analyze("floating_timestamp < '2001-01-02'")) must equal (Seq(analyze("date_trunc_ymd(floating_timestamp) < '2001-01-02'")))
+    rewriter(analyze("floating_timestamp < '2001-02-01'")) must equal (Seq(analyze("date_trunc_ymd(floating_timestamp) < '2001-02-01'"), analyze("date_trunc_ym(floating_timestamp) < '2001-02-01'")))
+    rewriter(analyze("floating_timestamp < '2001-01-01'")) must equal (Seq(analyze("date_trunc_ymd(floating_timestamp) < '2001-01-01'"), analyze("date_trunc_ym(floating_timestamp) < '2001-01-01'"), analyze("date_trunc_y(floating_timestamp) < '2001-01-01'")))
+
+    rewriter(analyze("floating_timestamp >= '2001-01-02'")) must equal (Seq(analyze("date_trunc_ymd(floating_timestamp) >= '2001-01-02'")))
+    rewriter(analyze("floating_timestamp >= '2001-02-01'")) must equal (Seq(analyze("date_trunc_ymd(floating_timestamp) >= '2001-02-01'"), analyze("date_trunc_ym(floating_timestamp) >= '2001-02-01'")))
+    rewriter(analyze("floating_timestamp >= '2001-01-01'")) must equal (Seq(analyze("date_trunc_ymd(floating_timestamp) >= '2001-01-01'"), analyze("date_trunc_ym(floating_timestamp) >= '2001-01-01'"), analyze("date_trunc_y(floating_timestamp) >= '2001-01-01'")))
+  }
+
+  test("limited by expr's truncatedness") {
+    rewriter(analyze("date_trunc_ymd(floating_timestamp) < '2001-01-01'")) must equal (Seq(analyze("date_trunc_ym(floating_timestamp) < '2001-01-01'"), analyze("date_trunc_y(floating_timestamp) < '2001-01-01'")))
+    rewriter(analyze("date_trunc_ym(floating_timestamp) < '2001-01-01'")) must equal (Seq(analyze("date_trunc_y(floating_timestamp) < '2001-01-01'")))
+
+    rewriter(analyze("date_trunc_ymd(floating_timestamp) >= '2001-01-01'")) must equal (Seq(analyze("date_trunc_ym(floating_timestamp) >= '2001-01-01'"), analyze("date_trunc_y(floating_timestamp) >= '2001-01-01'")))
+    rewriter(analyze("date_trunc_ym(floating_timestamp) >= '2001-01-01'")) must equal (Seq(analyze("date_trunc_y(floating_timestamp) >= '2001-01-01'")))
+  }
+
+  test("limited by both") {
+    rewriter(analyze("date_trunc_ymd(floating_timestamp) < '2001-02-01'")) must equal (Seq(analyze("date_trunc_ym(floating_timestamp) < '2001-02-01'")))
+  }
+}


### PR DESCRIPTION
And implement it for comparing a possibly-truncated timestamp to a pre-truncated literal.  This implements it for comparison operators but _not_ for BETWEEN (even though the old-rollup matcher _does_ do BETWEEN) because `x BETWEEN y AND z` is `y <= x AND x <= z`, and that upper bound can't correctly be rewritten in this way)