### PR TITLE
Add unaccent SOQL function

### DIFF
--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -556,6 +556,11 @@ object SoQLFunctions {
     "Pad on the right of a string with a character to a certain length"
   )
 
+  val Unaccent = mf("unaccent", FunctionName("unaccent"), Seq(SoQLText), Seq.empty, SoQLText)(
+    "Remove accents (diacritical marks) from a string",
+    Example("Remove accents from a geographic name", "unaccent('Sainte-Thérèse, Québec') => 'Sainte-Therese, Quebec'", "")
+  )
+
   val RowNumber = mf("row_number", FunctionName("row_number"), Seq(), Seq.empty, SoQLNumber, needsWindow = true)(
     NoDocs
   )

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "4.14.21"
+ThisBuild / version := "4.14.22"


### PR DESCRIPTION
This adds PostgreSQL's `unaccent` function for removing diacritics from a string:
```
unaccent('Sainte-Thérèse, Québec') => 'Sainte-Therese, Quebec'
```
Per [discussion with Robert M.](https://di-tylertech.slack.com/archives/C0EFEMN7N/p1697050043137879?thread_ts=1696961907.732169&cid=C0EFEMN7N), this will also require adding a migration in [socrata-platform/soql-postgres-adapter](https://github.com/socrata-platform/soql-postgres-adapter) for the unaccent extension — PR to follow.