### PR TITLE
Add error-to-encodederror conversion

### DIFF
--- a/soql-utils/src/main/scala/com/socrata/soql/util/EncodedError.scala
+++ b/soql-utils/src/main/scala/com/socrata/soql/util/EncodedError.scala
@@ -136,6 +136,10 @@ object GenericSoQLError {
     }
 }
 
+trait AbstractErrorEncode[T] {
+  def encodeError(err: T): EncodedError
+}
+
 trait SoQLErrorEncode[T] {
   val code: String
 
@@ -289,7 +293,7 @@ object SoQLErrorCodec {
     def toDecode: ErrorDecodes[T] =
       new ErrorDecodes(branches.map(_.mappable), codes)
 
-    def build: JsonEncode[T] with JsonDecode[T] =
+    def build: JsonEncode[T] with AbstractErrorEncode[T] with JsonDecode[T] =
       branches.reverse.foldLeft(new ErrorHierarchyCodecBuilder[T]) { (builder, branch) =>
         branch.addToCodec(builder)
       }.build

--- a/soql-utils/src/main/scala/com/socrata/soql/util/ErrorHierarchyCodecBuilder.scala
+++ b/soql-utils/src/main/scala/com/socrata/soql/util/ErrorHierarchyCodecBuilder.scala
@@ -13,11 +13,12 @@ private[util] class ErrorHierarchyCodecBuilder[Root <: AnyRef] private (enc: Err
     new ErrorHierarchyCodecBuilder[Root](enc.branch[T], dec.branch[T])
   }
 
-  def build: JsonEncode[Root] with JsonDecode[Root] = {
-    new JsonEncode[Root] with JsonDecode[Root] {
+  def build: JsonEncode[Root] with AbstractErrorEncode[Root] with JsonDecode[Root] = {
+    new JsonEncode[Root] with AbstractErrorEncode[Root] with JsonDecode[Root] {
       val e = enc.build
       val d = dec.build
       def encode(x: Root) = e.encode(x)
+      def encodeError(x: Root) = e.encodeError(x)
       def decode(x: JValue) = d.decode(x)
     }
   }

--- a/soql-utils/src/main/scala/com/socrata/soql/util/ErrorHierarchyEncodeBuilder.scala
+++ b/soql-utils/src/main/scala/com/socrata/soql/util/ErrorHierarchyEncodeBuilder.scala
@@ -6,29 +6,39 @@ import scala.reflect.ClassTag
 import com.rojoma.json.v3.ast._
 import com.rojoma.json.v3.codec._
 
-private[util] class ErrorHierarchyEncodeBuilder[Root <: AnyRef] private (subcodecs: Map[String, JsonEncode[_ <: Root]], classes: Map[Class[_], String]) {
+private[util] class ErrorHierarchyEncodeBuilder[Root <: AnyRef] private (subcodecs: Map[String, (JsonEncode[_ <: Root], AbstractErrorEncode[_ <: Root])], classes: Map[Class[_], String]) {
   def this() = this(Map.empty, Map.empty)
+
+  private def toAbstract[T](enc: SoQLErrorEncode[T]) = new AbstractErrorEncode[T] {
+    override def encodeError(err: T): EncodedError =
+      enc.encode(err)
+  }
 
   def branch[T <: Root](implicit enc: SoQLErrorEncode[T], mfst: ClassTag[T]) = {
     val name = enc.code
     val cls = mfst.runtimeClass
     if(subcodecs contains name) throw new IllegalArgumentException("Already defined a encoder for branch " + name)
     if(classes.contains(cls)) throw new IllegalArgumentException("Already defined a encoder for class " + cls)
-    new ErrorHierarchyEncodeBuilder[Root](subcodecs + (name -> SoQLErrorCodec.jsonEncode(enc)), classes + (cls -> name))
+    new ErrorHierarchyEncodeBuilder[Root](subcodecs + (name -> ((SoQLErrorCodec.jsonEncode(enc), toAbstract(enc)))), classes + (cls -> name))
   }
 
   private def encFor(x: Root) =
     classes.get(x.getClass) match {
-      case Some(name) => (name, subcodecs(name))
+      case Some(name) => subcodecs(name)
       case None => throw new IllegalArgumentException("No encoder defined for " + x.getClass)
     }
 
-  def build: JsonEncode[Root] = {
+  def build: JsonEncode[Root] with AbstractErrorEncode[Root] = {
     if(subcodecs.isEmpty) throw new IllegalStateException("No branches defined")
-    new JsonEncode[Root] {
+    new JsonEncode[Root] with AbstractErrorEncode[Root] {
       def encode(x: Root): JValue = {
-        val (name, subenc) = encFor(x)
+        val (subenc, _) = encFor(x)
         subenc.asInstanceOf[JsonEncode[Root]].encode(x)
+      }
+
+      def encodeError(x: Root): EncodedError = {
+        val (_, subenc) = encFor(x)
+        subenc.asInstanceOf[AbstractErrorEncode[Root]].encodeError(x)
       }
     }
   }


### PR DESCRIPTION
Before, the only way to do this conversion once you have collection of errors would be to serialize to JSON and then deserialize to an EncodedError.  This lets you skip the middle step and go directly to an EncodedError.