### PR TITLE
Rework CombinedTables' notion of unique columns

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveUnique.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveUnique.scala
@@ -12,7 +12,10 @@ class PreserveUnique[MT <: MetaTypes] private (provider: LabelProvider) extends 
   def rewriteStatement(stmt: Statement, wantColumns: Boolean): Statement = {
     stmt match {
       case ct@CombinedTables(op, left, right) =>
-        // combined tables cannot guarantee unique columns exist
+        // combined tables cannot guarantee unique columns exist.
+        // More specifically, we cannot change left & right in a way
+        // that passes through unselected unique columns without
+        // potentially changing the results of the query.
         ct
 
       case cte@CTE(defLabel, defAlias, defQuery, matHint, useQuery) =>


### PR DESCRIPTION
Specifically, teach CombinedTables#unique about the meanings of table funcs, and un-teach ImposeOrdering about them.  This greatly simplifies ImposeOrderings.