### PR TITLE
Catch invalid limits and offsets in rewrite passes earlier

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalysis.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalysis.scala
@@ -1,6 +1,6 @@
 package com.socrata.soql.analyzer2
 
-import com.socrata.soql.analyzer2.rewrite.{Pass, RewritePassHelpers}
+import com.socrata.soql.analyzer2.rewrite.{Pass, RewritePassHelpers, NonNegativeBigInt}
 import com.socrata.soql.environment.Provenance
 import com.socrata.soql.functions.MonomorphicFunction
 import com.socrata.soql.serialize.{ReadBuffer, WriteBuffer, Readable, Writable}
@@ -207,13 +207,13 @@ class SoQLAnalysis[MT <: MetaTypes] private (
     * imposeOrdering before doing this to ensure the paging is
     * meaningful.  Pages are zero-based (i.e., they're an offset
     * rather than a page number). */
-  def page(pageSize: BigInt, pageOffset: BigInt) = {
+  def page(pageSize: NonNegativeBigInt, pageOffset: NonNegativeBigInt) = {
     addLimitOffset(Some(pageSize), Some(pageOffset * pageSize))
   }
 
   /** Update limit/offset.  You might want to imposeOrdering before
     * doing this to ensure the bounds are meaningful. */
-  def addLimitOffset(limit: Option[BigInt], offset: Option[BigInt]) = {
+  def addLimitOffset(limit: Option[NonNegativeBigInt], offset: Option[NonNegativeBigInt]) = {
     val nlp = labelProvider.clone()
     copy(
       labelProvider = nlp,
@@ -224,7 +224,7 @@ class SoQLAnalysis[MT <: MetaTypes] private (
   /** Add a limit to the query if none exists.  You might want to
     * imposeOrdering before doing this to ensure the bounds are
     * meaningful. */
-  def limitIfUnlimited(limit: BigInt) = {
+  def limitIfUnlimited(limit: NonNegativeBigInt) = {
     val nlp = labelProvider.clone()
     copy(
       labelProvider = nlp,

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/AddLimitOffset.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/AddLimitOffset.scala
@@ -36,16 +36,11 @@ class AddLimitOffset[MT <: MetaTypes] private (labelProvider: LabelProvider) ext
 }
 
 object AddLimitOffset {
-  private val zero = BigInt(0)
-
-  def apply[MT <: MetaTypes](labelProvider: LabelProvider, statement: Statement[MT], limit: Option[BigInt], offset: Option[BigInt]): Statement[MT] = {
+  def apply[MT <: MetaTypes](labelProvider: LabelProvider, statement: Statement[MT], limit: Option[NonNegativeBigInt], offset: Option[NonNegativeBigInt]): Statement[MT] = {
     if(limit.isEmpty && offset.isEmpty) {
       statement
     } else {
-      require(limit.getOrElse(zero) >= zero)
-      require(offset.getOrElse(zero) >= zero)
-
-      new AddLimitOffset(labelProvider).rewriteStatement(statement, limit, offset)
+      new AddLimitOffset(labelProvider).rewriteStatement(statement, limit.map(_.underlying), offset.map(_.underlying))
     }
   }
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/LimitIfUnlimited.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/LimitIfUnlimited.scala
@@ -63,11 +63,7 @@ class LimitIfUnlimited[MT <: MetaTypes] private (labelProvider: LabelProvider) e
 }
 
 object LimitIfUnlimited {
-  private val zero = BigInt(0)
-
-  def apply[MT <: MetaTypes](labelProvider: LabelProvider, statement: Statement[MT], limit: BigInt): Statement[MT] = {
-    require(limit >= zero)
-
-    new LimitIfUnlimited(labelProvider).rewriteStatement(statement, limit)
+  def apply[MT <: MetaTypes](labelProvider: LabelProvider, statement: Statement[MT], limit: NonNegativeBigInt): Statement[MT] = {
+    new LimitIfUnlimited(labelProvider).rewriteStatement(statement, limit.underlying)
   }
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/NonNegativeBigInt.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/NonNegativeBigInt.scala
@@ -1,0 +1,38 @@
+package com.socrata.soql.analyzer2.rewrite
+
+import com.rojoma.json.v3.ast.JValue
+import com.rojoma.json.v3.codec.{JsonEncode, JsonDecode, DecodeError}
+
+import com.socrata.soql.serialize.{ReadBuffer, WriteBuffer, Readable, Writable}
+
+class NonNegativeBigInt private (val underlying: BigInt) {
+  def +(that: NonNegativeBigInt) = new NonNegativeBigInt(this.underlying + that.underlying)
+  def *(that: NonNegativeBigInt) = new NonNegativeBigInt(this.underlying * that.underlying)
+}
+
+object NonNegativeBigInt {
+  private val zero = BigInt(0)
+
+  implicit object jcodec extends JsonEncode[NonNegativeBigInt] with JsonDecode[NonNegativeBigInt] {
+    override def encode(x: NonNegativeBigInt) = JsonEncode.toJValue(x.underlying)
+    override def decode(v: JValue) =
+      JsonDecode.fromJValue[BigInt](v).flatMap { b =>
+        if(b >= zero) Right(new NonNegativeBigInt(b))
+        else Left(DecodeError.InvalidValue(v))
+      }
+  }
+
+  implicit object serialize extends Readable[NonNegativeBigInt] with Writable[NonNegativeBigInt] {
+    override def readFrom(buf: ReadBuffer): NonNegativeBigInt = {
+      val b = buf.read[BigInt]()
+      if(b >= zero) new NonNegativeBigInt(b)
+      else fail("Found negative bigint")
+    }
+    override def writeTo(buf: WriteBuffer, bi: NonNegativeBigInt): Unit =
+      buf.write(bi.underlying)
+  }
+
+  def apply(bi: BigInt): Option[NonNegativeBigInt] =
+    if(bi >= zero) Some(new NonNegativeBigInt(bi))
+    else None
+}

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/Pass.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/Pass.scala
@@ -18,10 +18,10 @@ object Pass {
   case object RemoveUnusedColumns extends Pass
   case object RemoveUnusedOrderBy extends Pass
   case object UseSelectListReferences extends Pass
-  case class Page(size: BigInt, offset: BigInt) extends Pass
-  case class AddLimitOffset(limit: Option[BigInt], offset: Option[BigInt]) extends Pass
+  case class Page(size: NonNegativeBigInt, offset: NonNegativeBigInt) extends Pass
+  case class AddLimitOffset(limit: Option[NonNegativeBigInt], offset: Option[NonNegativeBigInt]) extends Pass
   case object RemoveOrderBy extends Pass
-  case class LimitIfUnlimited(limit: BigInt) extends Pass
+  case class LimitIfUnlimited(limit: NonNegativeBigInt) extends Pass
 
   implicit val jCodec = SimpleHierarchyCodecBuilder[Pass](InternalTag("pass"))
     .singleton("inline_trivial_parameters", InlineTrivialParameters)
@@ -49,10 +49,10 @@ object Pass {
         case 5 => RemoveUnusedColumns
         case 6 => RemoveUnusedOrderBy
         case 7 => UseSelectListReferences
-        case 8 => Page(buffer.read[BigInt](), buffer.read[BigInt]())
-        case 9 => AddLimitOffset(buffer.read[Option[BigInt]](), buffer.read[Option[BigInt]]())
+        case 8 => Page(buffer.read[NonNegativeBigInt](), buffer.read[NonNegativeBigInt]())
+        case 9 => AddLimitOffset(buffer.read[Option[NonNegativeBigInt]](), buffer.read[Option[NonNegativeBigInt]]())
         case 10 => RemoveOrderBy
-        case 11 => LimitIfUnlimited(buffer.read[BigInt]())
+        case 11 => LimitIfUnlimited(buffer.read[NonNegativeBigInt]())
         case other => fail(s"Unknown rewrite pass type $other")
       }
 

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalysisTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalysisTest.scala
@@ -704,7 +704,7 @@ select b, n |> select n join @udf(b) as @udf on true
 
     val analysis = analyze(tf, "(select * from @a) union (select * from @b)")
     val expectedAnalysis = analyze(tf, "((select * from @a) union (select * from @b)) |> select * limit 25 offset 50")
-    analysis.addLimitOffset(limit = Some(25), offset = Some(50)).statement must be (isomorphicTo(expectedAnalysis.statement))
+    analysis.addLimitOffset(limit = Some(nnbi(25)), offset = Some(nnbi(50))).statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
   test("addLimitOffset - no limit/offset initially") {
@@ -714,7 +714,7 @@ select b, n |> select n join @udf(b) as @udf on true
 
     val analysis = analyze(tf, "twocol", "select text, num*num")
     val expectedAnalysis = analyze(tf, "twocol", "select text, num*num limit 25 offset 50")
-    analysis.addLimitOffset(limit = Some(25), offset = Some(50)).statement must be (isomorphicTo(expectedAnalysis.statement))
+    analysis.addLimitOffset(limit = Some(nnbi(25)), offset = Some(nnbi(50))).statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
 
@@ -725,7 +725,7 @@ select b, n |> select n join @udf(b) as @udf on true
 
     val analysis = analyze(tf, "twocol", "select text, num*num limit 100 offset 100")
     val expectedAnalysis = analyze(tf, "twocol", "select text, num*num limit 25 offset 150")
-    analysis.addLimitOffset(limit = Some(25), offset = Some(50)).statement must be (isomorphicTo(expectedAnalysis.statement))
+    analysis.addLimitOffset(limit = Some(nnbi(25)), offset = Some(nnbi(50))).statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
   test("addLimitOffset - overlaps the end of initial limit/offset") {
@@ -735,7 +735,7 @@ select b, n |> select n join @udf(b) as @udf on true
 
     val analysis = analyze(tf, "twocol", "select text, num*num limit 100 offset 100")
     val expectedAnalysis = analyze(tf, "twocol", "select text, num*num limit 50 offset 150")
-    analysis.addLimitOffset(limit = Some(500), offset = Some(50)).statement must be (isomorphicTo(expectedAnalysis.statement))
+    analysis.addLimitOffset(limit = Some(nnbi(500)), offset = Some(nnbi(50))).statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
   test("addLimitOffset - overlaps the end of initial limit/offset with no new limit provided") {
@@ -745,7 +745,7 @@ select b, n |> select n join @udf(b) as @udf on true
 
     val analysis = analyze(tf, "twocol", "select text, num*num limit 100 offset 100")
     val expectedAnalysis = analyze(tf, "twocol", "select text, num*num limit 50 offset 150")
-    analysis.addLimitOffset(limit = None, offset = Some(50)).statement must be (isomorphicTo(expectedAnalysis.statement))
+    analysis.addLimitOffset(limit = None, offset = Some(nnbi(50))).statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
   test("addLimitOffset - passes the end of initial limit/offset") {
@@ -755,7 +755,7 @@ select b, n |> select n join @udf(b) as @udf on true
 
     val analysis = analyze(tf, "twocol", "select text, num*num limit 100 offset 100")
     val expectedAnalysis = analyze(tf, "twocol", "select text, num*num limit 0 offset 200") // Note the offset will not pass the end of the original chunk
-    analysis.addLimitOffset(limit = Some(500), offset = Some(500)).statement must be (isomorphicTo(expectedAnalysis.statement))
+    analysis.addLimitOffset(limit = Some(nnbi(500)), offset = Some(nnbi(500))).statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
   test("addLimitOffset - passes the end of initial limit/offset with no new limit provided") {
@@ -765,7 +765,7 @@ select b, n |> select n join @udf(b) as @udf on true
 
     val analysis = analyze(tf, "twocol", "select text, num*num limit 100 offset 100")
     val expectedAnalysis = analyze(tf, "twocol", "select text, num*num limit 0 offset 200") // Note the offset will not pass the end of the original chunk
-    analysis.addLimitOffset(limit = None, offset = Some(500)).statement must be (isomorphicTo(expectedAnalysis.statement))
+    analysis.addLimitOffset(limit = None, offset = Some(nnbi(500))).statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
   test("inline parameters - all complex") {
@@ -1102,7 +1102,7 @@ select * where first = 'Tom'
     val tf = tableFinder(
       (0, "twocol") -> D("text" -> TestText, "num" -> TestNumber)
     )
-    val analysis = analyzeSaved(tf, "twocol").limitIfUnlimited(5)
+    val analysis = analyzeSaved(tf, "twocol").limitIfUnlimited(nnbi(5))
     val expectedAnalysis = analyze(tf, "twocol", "select * limit 5")
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
@@ -1111,7 +1111,7 @@ select * where first = 'Tom'
     val tf = tableFinder(
       (0, "twocol") -> D("text" -> TestText, "num" -> TestNumber)
     )
-    val analysis = analyze(tf, "twocol", "select *").limitIfUnlimited(5)
+    val analysis = analyze(tf, "twocol", "select *").limitIfUnlimited(nnbi(5))
     val expectedAnalysis = analyze(tf, "twocol", "select * limit 5")
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
@@ -1120,7 +1120,7 @@ select * where first = 'Tom'
     val tf = tableFinder(
       (0, "twocol") -> D("text" -> TestText, "num" -> TestNumber)
     )
-    val analysis = analyze(tf, "twocol", "select * limit 10").limitIfUnlimited(5)
+    val analysis = analyze(tf, "twocol", "select * limit 10").limitIfUnlimited(nnbi(5))
     val expectedAnalysis = analyze(tf, "twocol", "select * limit 10")
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
@@ -1130,7 +1130,7 @@ select * where first = 'Tom'
       (0, "twocol1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "twocol2") -> D("text" -> TestText, "num" -> TestNumber)
     )
-    val analysis = analyze(tf, "(select * from @twocol1) union (select * from @twocol2)").limitIfUnlimited(5)
+    val analysis = analyze(tf, "(select * from @twocol1) union (select * from @twocol2)").limitIfUnlimited(nnbi(5))
     val expectedAnalysis = analyze(tf, "(select * from @twocol1) union (select * from @twocol2) |> select * limit 5")
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
@@ -1140,7 +1140,7 @@ select * where first = 'Tom'
       (0, "twocol1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "twocol2") -> D("text" -> TestText, "num" -> TestNumber)
     )
-    val analysis = analyze(tf, "(select * from @twocol1 limit 10) union (select * from @twocol2)").limitIfUnlimited(5)
+    val analysis = analyze(tf, "(select * from @twocol1 limit 10) union (select * from @twocol2)").limitIfUnlimited(nnbi(5))
     val expectedAnalysis = analyze(tf, "(select * from @twocol1 limit 10) union (select * from @twocol2) |> select * limit 5")
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
@@ -1150,7 +1150,7 @@ select * where first = 'Tom'
       (0, "twocol1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "twocol2") -> D("text" -> TestText, "num" -> TestNumber)
     )
-    val analysis = analyze(tf, "(select * from @twocol1) union (select * from @twocol2 limit 10)").limitIfUnlimited(5)
+    val analysis = analyze(tf, "(select * from @twocol1) union (select * from @twocol2 limit 10)").limitIfUnlimited(nnbi(5))
     val expectedAnalysis = analyze(tf, "(select * from @twocol1) union (select * from @twocol2 limit 10) |> select * limit 5")
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
@@ -1160,7 +1160,7 @@ select * where first = 'Tom'
       (0, "twocol1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "twocol2") -> D("text" -> TestText, "num" -> TestNumber)
     )
-    val analysis = analyze(tf, "(select * from @twocol1 limit 20) union (select * from @twocol2 limit 10)").limitIfUnlimited(5)
+    val analysis = analyze(tf, "(select * from @twocol1 limit 20) union (select * from @twocol2 limit 10)").limitIfUnlimited(nnbi(5))
     val expectedAnalysis = analyze(tf, "(select * from @twocol1 limit 20) union (select * from @twocol2 limit 10)")
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
@@ -1170,7 +1170,7 @@ select * where first = 'Tom'
       (0, "twocol1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "twocol2") -> D("text" -> TestText, "num" -> TestNumber)
     )
-    val analysis = analyze(tf, "(select * from @twocol1) intersect (select * from @twocol2)").limitIfUnlimited(5)
+    val analysis = analyze(tf, "(select * from @twocol1) intersect (select * from @twocol2)").limitIfUnlimited(nnbi(5))
     val expectedAnalysis = analyze(tf, "(select * from @twocol1) intersect (select * from @twocol2) |> select * limit 5")
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
@@ -1180,7 +1180,7 @@ select * where first = 'Tom'
       (0, "twocol1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "twocol2") -> D("text" -> TestText, "num" -> TestNumber)
     )
-    val analysis = analyze(tf, "(select * from @twocol1 limit 10) intersect (select * from @twocol2)").limitIfUnlimited(5)
+    val analysis = analyze(tf, "(select * from @twocol1 limit 10) intersect (select * from @twocol2)").limitIfUnlimited(nnbi(5))
     val expectedAnalysis = analyze(tf, "(select * from @twocol1 limit 10) intersect (select * from @twocol2)")
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
@@ -1190,7 +1190,7 @@ select * where first = 'Tom'
       (0, "twocol1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "twocol2") -> D("text" -> TestText, "num" -> TestNumber)
     )
-    val analysis = analyze(tf, "(select * from @twocol1) intersect (select * from @twocol2 limit 10)").limitIfUnlimited(5)
+    val analysis = analyze(tf, "(select * from @twocol1) intersect (select * from @twocol2 limit 10)").limitIfUnlimited(nnbi(5))
     val expectedAnalysis = analyze(tf, "(select * from @twocol1) intersect (select * from @twocol2 limit 10)")
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
@@ -1200,7 +1200,7 @@ select * where first = 'Tom'
       (0, "twocol1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "twocol2") -> D("text" -> TestText, "num" -> TestNumber)
     )
-    val analysis = analyze(tf, "(select * from @twocol1 limit 20) intersect (select * from @twocol2 limit 10)").limitIfUnlimited(5)
+    val analysis = analyze(tf, "(select * from @twocol1 limit 20) intersect (select * from @twocol2 limit 10)").limitIfUnlimited(nnbi(5))
     val expectedAnalysis = analyze(tf, "(select * from @twocol1 limit 20) union (select * from @twocol2 limit 10)")
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
@@ -1210,7 +1210,7 @@ select * where first = 'Tom'
       (0, "twocol1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "twocol2") -> D("text" -> TestText, "num" -> TestNumber)
     )
-    val analysis = analyze(tf, "(select * from @twocol1) minus (select * from @twocol2)").limitIfUnlimited(5)
+    val analysis = analyze(tf, "(select * from @twocol1) minus (select * from @twocol2)").limitIfUnlimited(nnbi(5))
     val expectedAnalysis = analyze(tf, "(select * from @twocol1) minus (select * from @twocol2) |> select * limit 5")
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
@@ -1220,7 +1220,7 @@ select * where first = 'Tom'
       (0, "twocol1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "twocol2") -> D("text" -> TestText, "num" -> TestNumber)
     )
-    val analysis = analyze(tf, "(select * from @twocol1 limit 10) minus (select * from @twocol2)").limitIfUnlimited(5)
+    val analysis = analyze(tf, "(select * from @twocol1 limit 10) minus (select * from @twocol2)").limitIfUnlimited(nnbi(5))
     val expectedAnalysis = analyze(tf, "(select * from @twocol1 limit 10) minus (select * from @twocol2)")
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
@@ -1230,7 +1230,7 @@ select * where first = 'Tom'
       (0, "twocol1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "twocol2") -> D("text" -> TestText, "num" -> TestNumber)
     )
-    val analysis = analyze(tf, "(select * from @twocol1) minus (select * from @twocol2 limit 10)").limitIfUnlimited(5)
+    val analysis = analyze(tf, "(select * from @twocol1) minus (select * from @twocol2 limit 10)").limitIfUnlimited(nnbi(5))
     val expectedAnalysis = analyze(tf, "(select * from @twocol1) minus (select * from @twocol2 limit 10) |> select * limit 5")
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
@@ -1240,7 +1240,7 @@ select * where first = 'Tom'
       (0, "twocol1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "twocol2") -> D("text" -> TestText, "num" -> TestNumber)
     )
-    val analysis = analyze(tf, "(select * from @twocol1 limit 20) minus (select * from @twocol2 limit 10)").limitIfUnlimited(5)
+    val analysis = analyze(tf, "(select * from @twocol1 limit 20) minus (select * from @twocol2 limit 10)").limitIfUnlimited(nnbi(5))
     val expectedAnalysis = analyze(tf, "(select * from @twocol1 limit 20) union (select * from @twocol2 limit 10)")
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/TestHelper.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/TestHelper.scala
@@ -5,6 +5,7 @@ import org.scalatest.matchers.{BeMatcher, MatchResult}
 
 import com.socrata.soql.ast
 import com.socrata.soql.environment.{ColumnName, ResourceName, HoleName, Provenance}
+import com.socrata.soql.analyzer2.rewrite.NonNegativeBigInt
 
 import mocktablefinder._
 
@@ -39,6 +40,10 @@ trait TestHelper { this: Assertions =>
   def dcn(n: String) = DatabaseColumnName(n)
   def dtn(n: String) = DatabaseTableName(n)
   def canon(n: String) = CanonicalName(n)
+
+  def nnbi(x: Int) = NonNegativeBigInt(x).getOrElse {
+    throw new Exception("tried to use a negative value to construct a non-negative bigint")
+  }
 
   def xtest(s: String)(f: => Any): Unit = {}
 


### PR DESCRIPTION
Specifically, don't allow someone to create a rewrite pass with an invalid limit or offset in the first place, rather than crashing with a "requirement failed" message when given such an invalid value.  This'll let us return a "bad request" when deserializing a Pass fails rather than crashing later.