### PR TITLE
Un-privatize the UnparsedFoundTables fields

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/UnparsedFoundTables.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/UnparsedFoundTables.scala
@@ -10,10 +10,10 @@ import com.socrata.soql.parsing.AbstractParser
 import com.socrata.soql.analyzer2
 
 class UnparsedFoundTables[MT <: MetaTypes] private[analyzer2] (
-  private[analyzer2] val tableMap: UnparsedTableMap[MT],
-  private[analyzer2] val initialScope: types.ResourceNameScope[MT],
-  private[analyzer2] val initialQuery: UnparsedFoundTables.Query[MT],
-  private[analyzer2] val parserParameters: EncodableParameters
+  val tableMap: UnparsedTableMap[MT],
+  val initialScope: types.ResourceNameScope[MT],
+  val initialQuery: UnparsedFoundTables.Query[MT],
+  val parserParameters: EncodableParameters
 ) extends FoundTablesLike[MT] {
   type Self[MT <: MetaTypes] = UnparsedFoundTables[MT]
 


### PR DESCRIPTION
The corresponding fields in the parsed version are already public, and especially initialQuery being public is sometimes useful