### PR TITLE
Use the CJSON reps for UserParameters

### DIFF
--- a/soql-types/src/main/scala/com/socrata/soql/types/cjson.scala
+++ b/soql-types/src/main/scala/com/socrata/soql/types/cjson.scala
@@ -18,6 +18,9 @@ trait CJsonReadRep[+T] {
       }
     }
 
+  final def fromJValueRequired(v: JValue): Either[DecodeError, T] =
+    fromJValueImpl(v)
+
   protected def fromJValueImpl(v: JValue): Either[DecodeError, T]
 }
 


### PR DESCRIPTION
Reduces code duplication, especially for the timestamp types.

And, importantly, makes it so that a "number" parameter will accept either an actual JSON number or a string-containing-a-number in the value field, which increases consistency with ingress.