### PR TITLE
Allow sqlizer implementations more control over column namespacing

### DIFF
--- a/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/Rep.scala
+++ b/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/Rep.scala
@@ -131,7 +131,7 @@ object Rep {
 
       override def compressedDatabaseType = sqlType
 
-      override def compressedDatabaseColumn(name: ColumnLabel) = namespace.columnBase(name)
+      override def compressedDatabaseColumn(name: ColumnLabel) = namespace.columnName(name)
 
       override def compressedSubColumns(table: String, column: ColumnLabel) =
         Seq(Doc(table) ++ d"." ++ compressedDatabaseColumn(column))
@@ -201,12 +201,12 @@ object Rep {
       final override def expandedDatabaseTypes = d"text" +: physicalDatabaseTypes
 
       final override def physicalDatabaseColumns(name: ColumnLabel) =
-        Seq(namespace.columnBase(name))
+        Seq(namespace.columnName(name))
       final override def expandedDatabaseColumns(name: ColumnLabel) =
-        (namespace.columnBase(name) ++ d"_provenance") +: physicalDatabaseColumns(name)
+        (namespace.columnName(name, "provenance")) +: physicalDatabaseColumns(name)
 
       override def compressedDatabaseColumn(name: ColumnLabel) =
-        namespace.columnBase(name)
+        namespace.columnName(name)
 
       override def physicalColumnRef(col: PhysicalColumn) = {
         val dsTable = namespace.tableLabel(col.table)

--- a/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/SqlNamespaces.scala
+++ b/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/SqlNamespaces.scala
@@ -13,26 +13,37 @@ trait SqlNamespaces[MT <: MetaTypes] extends LabelUniverse[MT] {
   // that is guaranteed to not conflict with any real column.
   // Otherwise it returns the (base of) the physical column(s) which
   // make up that logical column.
-  def columnBase(label: ColumnLabel): Doc[Nothing] =
-    Doc(rawColumnBase(label))
+  def columnName(label: ColumnLabel): Doc[Nothing] =
+    Doc(rawColumn(label))
 
-  def rawColumnBase(label: ColumnLabel): String =
+  def columnName(label: ColumnLabel, suffix: String): Doc[Nothing] =
+    Doc(rawColumn(label, suffix))
+
+  def rawColumn(label: ColumnLabel): String =
     label match {
-      case dcn: DatabaseColumnName => rawDatabaseColumnBase(dcn)
-      case acl: AutoColumnLabel => rawAutoColumnBase(acl)
+      case dcn: DatabaseColumnName => rawDatabaseColumnName(dcn)
+      case acl: AutoColumnLabel => rawAutoColumn(acl)
+    }
+
+  def rawColumn(label: ColumnLabel, suffix: String): String =
+    label match {
+      case dcn: DatabaseColumnName => rawDatabaseColumnName(dcn, suffix)
+      case acl: AutoColumnLabel => rawAutoColumn(acl, suffix)
     }
 
   def databaseTableName(dtn: DatabaseTableName): Doc[Nothing] = Doc(rawDatabaseTableName(dtn))
-  def databaseColumnBase(dcn: DatabaseColumnName): Doc[Nothing] = Doc(rawDatabaseColumnBase(dcn))
-  def autoColumnBase(acl: AutoColumnLabel): Doc[Nothing] = Doc(rawAutoColumnBase(acl))
+  def databaseColumn(dcn: DatabaseColumnName): Doc[Nothing] = Doc(rawDatabaseColumnName(dcn))
+  def databaseColumn(dcn: DatabaseColumnName, suffix: String): Doc[Nothing] = Doc(rawDatabaseColumnName(dcn, suffix))
+  def autoColumn(acl: AutoColumnLabel, suffix: String = ""): Doc[Nothing] = Doc(rawAutoColumn(acl, suffix))
 
-  def rawAutoColumnBase(acl: AutoColumnLabel): String = s"$autoColumnPrefix${acl.name}"
+  def rawAutoColumn(acl: AutoColumnLabel): String = s"$autoColumnPrefix${acl.name}"
+  def rawAutoColumn(acl: AutoColumnLabel, suffix: String): String = s"$autoColumnPrefix${acl.name}_$suffix"
 
   def indexName(dtn: DatabaseTableName, col: ColumnLabel): Doc[Nothing] =
     Doc(rawIndexName(dtn, col))
 
   def rawIndexName(dtn: DatabaseTableName, col: ColumnLabel): String =
-    idxPrefix + "_" + rawDatabaseTableName(dtn) + "_" + rawColumnBase(col)
+    idxPrefix + "_" + rawDatabaseTableName(dtn) + "_" + rawColumn(col, "")
 
   def indexName(dtn: DatabaseTableName, col: ColumnLabel, subcol: String): Doc[Nothing] =
     Doc(rawIndexName(dtn, col, subcol))
@@ -47,6 +58,9 @@ trait SqlNamespaces[MT <: MetaTypes] extends LabelUniverse[MT] {
   protected def autoColumnPrefix: String
 
   def rawDatabaseTableName(dtn: DatabaseTableName): String
-  def rawDatabaseColumnBase(dcn: DatabaseColumnName): String
+  def rawDatabaseColumnName(dcn: DatabaseColumnName): String
+  // This should create a name which is the moral equivalent of
+  //   rawDatabaseColumnName(dcn) + "_" + suffix
+  def rawDatabaseColumnName(dcn: DatabaseColumnName, suffix: String): String
   def gensymPrefix: String
 }

--- a/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/SqlNamespaces.scala
+++ b/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/SqlNamespaces.scala
@@ -22,22 +22,23 @@ trait SqlNamespaces[MT <: MetaTypes] extends LabelUniverse[MT] {
   def rawColumn(label: ColumnLabel): String =
     label match {
       case dcn: DatabaseColumnName => rawDatabaseColumnName(dcn)
-      case acl: AutoColumnLabel => rawAutoColumn(acl)
+      case acl: AutoColumnLabel => rawAutoColumnName(acl)
     }
 
   def rawColumn(label: ColumnLabel, suffix: String): String =
     label match {
       case dcn: DatabaseColumnName => rawDatabaseColumnName(dcn, suffix)
-      case acl: AutoColumnLabel => rawAutoColumn(acl, suffix)
+      case acl: AutoColumnLabel => rawAutoColumnName(acl, suffix)
     }
 
   def databaseTableName(dtn: DatabaseTableName): Doc[Nothing] = Doc(rawDatabaseTableName(dtn))
   def databaseColumn(dcn: DatabaseColumnName): Doc[Nothing] = Doc(rawDatabaseColumnName(dcn))
   def databaseColumn(dcn: DatabaseColumnName, suffix: String): Doc[Nothing] = Doc(rawDatabaseColumnName(dcn, suffix))
-  def autoColumn(acl: AutoColumnLabel, suffix: String = ""): Doc[Nothing] = Doc(rawAutoColumn(acl, suffix))
+  def autoColumnName(acl: AutoColumnLabel): Doc[Nothing] = Doc(rawAutoColumnName(acl))
+  def autoColumnName(acl: AutoColumnLabel, suffix: String): Doc[Nothing] = Doc(rawAutoColumnName(acl, suffix))
 
-  def rawAutoColumn(acl: AutoColumnLabel): String = s"$autoColumnPrefix${acl.name}"
-  def rawAutoColumn(acl: AutoColumnLabel, suffix: String): String = s"$autoColumnPrefix${acl.name}_$suffix"
+  def rawAutoColumnName(acl: AutoColumnLabel): String = s"$autoColumnPrefix${acl.name}"
+  def rawAutoColumnName(acl: AutoColumnLabel, suffix: String): String = s"$autoColumnPrefix${acl.name}_$suffix"
 
   def indexName(dtn: DatabaseTableName, col: ColumnLabel): Doc[Nothing] =
     Doc(rawIndexName(dtn, col))

--- a/soql-sqlizer/src/test/scala/com/socrata/soql/sqlizer/TestHelper.scala
+++ b/soql-sqlizer/src/test/scala/com/socrata/soql/sqlizer/TestHelper.scala
@@ -54,9 +54,14 @@ object TestHelper {
       name
     }
 
-    override def rawDatabaseColumnBase(dcn: DatabaseColumnName) = {
+    override def rawDatabaseColumnName(dcn: DatabaseColumnName) = {
       val DatabaseColumnName(name) = dcn
       name
+    }
+
+    override def rawDatabaseColumnName(dcn: DatabaseColumnName, suffix: String) = {
+      val DatabaseColumnName(name) = dcn
+      name + "_" + suffix
     }
 
     override def gensymPrefix: String = "g"

--- a/soql-sqlizer/src/test/scala/com/socrata/soql/sqlizer/TestRepProvider.scala
+++ b/soql-sqlizer/src/test/scala/com/socrata/soql/sqlizer/TestRepProvider.scala
@@ -121,8 +121,7 @@ class TestRepProvider(
       override def physicalColumnCount = 2
 
       override def physicalDatabaseColumns(name: ColumnLabel) = {
-        val base = namespace.columnBase(name)
-        Seq(base ++ d"_a", base ++ d"_b")
+        Seq(namespace.columnName(name, "a"), namespace.columnName(name, "b"))
       }
 
       override def physicalDatabaseTypes = Seq(d"text", d"numeric")
@@ -139,7 +138,7 @@ class TestRepProvider(
       override def compressedDatabaseType = d"jsonb"
 
       override def compressedDatabaseColumn(name: ColumnLabel) =
-        namespace.columnBase(name)
+        namespace.columnName(name)
 
       override def literal(e: LiteralValue) = {
         val cmp@TestCompound(_, _) = e.value


### PR DESCRIPTION
Before:
* `SqlNamespaces` had an abstract method `rawDatabaseColumnBase`, which was assumed to be a thing onto which further identifierish stuff could be appended.

Now:
* `SqlNamespaces` has two methods, both named `rawDatabaseColumnName`. The one with a "suffix" parameter should create a name which should be in some sense "like" `rawDatabaseColumnName(dcn) + "_" + suffix`.