### PR TITLE
EN-66000: Infrastructure for generalized convert-to-text

### DIFF
--- a/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/Rep.scala
+++ b/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/Rep.scala
@@ -40,6 +40,12 @@ trait Rep[MT <: MetaTypes with MetaTypesExt] extends ExpressionUniverse[MT] {
   def nullLiteral(e: NullLiteral): ExprSql[MT]
   def literal(value: LiteralValue): ExprSql[MT] // type of literal will be appropriate for this rep
 
+  // Wrap a sqlized expression in whatever is required to turn it into
+  // a human-friendly form in a "default" way (e.g., for cast-to-text
+  // or being passed to `||`).  Returns `None` if this type cannot be
+  // cast to text on this database.
+  def convertToText(e: ExprSql[MT]): Option[ExprSql[MT]]
+
   // "physical" vs "expanded" because of providenced columns; for most
   // column types these will be the same, but provedenced columns add
   // one synthetic column to the "expanded" representation.  MOST USER

--- a/soql-sqlizer/src/test/scala/com/socrata/soql/sqlizer/TestRepProvider.scala
+++ b/soql-sqlizer/src/test/scala/com/socrata/soql/sqlizer/TestRepProvider.scala
@@ -36,6 +36,8 @@ class TestRepProvider(
         Set(rawId.provenance)
       }
 
+      override def convertToText(e: ExprSql) = None
+
       override def literal(e: LiteralValue) = {
         val rawId = e.value.asInstanceOf[TestID]
 
@@ -77,6 +79,8 @@ class TestRepProvider(
         exprSqlFactory(mkTextLiteral(s), e)
       }
 
+      override def convertToText(e: ExprSql) = Some(e)
+
       override protected def doExtractFrom(rs: ResultSet, dbCol: Int): CV = {
         ???
       }
@@ -89,6 +93,11 @@ class TestRepProvider(
       override def literal(e: LiteralValue) = {
         val TestNumber(n) = e.value
         exprSqlFactory(Doc(n.toString) +#+ d"::" +#+ sqlType, e)
+      }
+
+      override def convertToText(e: ExprSql) = {
+        val converted = d"(" ++ e.compressed.sql ++ d") :: text"
+        Some(exprSqlFactory(converted, e.expr))
       }
 
       override protected def doExtractFrom(rs: ResultSet, dbCol: Int): CV = {
@@ -105,6 +114,8 @@ class TestRepProvider(
         exprSqlFactory(if(b) d"true" else d"false", e)
       }
 
+      override def convertToText(e: ExprSql) = None
+
       override protected def doExtractFrom(rs: ResultSet, dbCol: Int): CV = {
         ???
       }
@@ -117,6 +128,8 @@ class TestRepProvider(
     TestCompound -> new CompoundColumnRep(TestCompound) {
       override def nullLiteral(e: NullLiteral) =
         exprSqlFactory(Seq(d"null :: text", d"null :: numeric"), e)
+
+      override def convertToText(e: ExprSql) = None
 
       override def physicalColumnCount = 2
 

--- a/soql-types/src/main/scala/com/socrata/soql/types/obfuscation/CryptProvider.scala
+++ b/soql-types/src/main/scala/com/socrata/soql/types/obfuscation/CryptProvider.scala
@@ -5,8 +5,9 @@ import java.security.SecureRandom
 import org.bouncycastle.crypto.params.KeyParameter
 import org.bouncycastle.crypto.engines.BlowfishEngine
 
-class CryptProvider(key: Array[Byte]) {
-  private val keyParam = new KeyParameter(key)
+class CryptProvider(keyMaterial: Array[Byte]) {
+  def key = java.util.Arrays.copyOf(keyMaterial, keyMaterial.length)
+  private val keyParam = new KeyParameter(keyMaterial)
 
   lazy val encryptor = locally {
     val bf = new BlowfishEngine


### PR DESCRIPTION
For use in places where values get (sometimes implicitly) converted to text.