### PR TITLE
More functions!

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/NamedExpr.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/NamedExpr.scala
@@ -11,6 +11,8 @@ case class NamedExpr[MT <: MetaTypes](expr: Expr[MT], name: ColumnName, hint: Op
 
   private[analyzer2] def doRelabel(state: RelabelState) =
     copy(expr = expr.doRelabel(state))
+
+  def typ = expr.typ
 }
 
 object NamedExpr {

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rollup/RollupExact.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rollup/RollupExact.scala
@@ -511,11 +511,15 @@ class RollupExact[MT <: MetaTypes](
     }
 
     val groupBySubset =
-      select.groupBy.forall { sGroupBy =>
-        candidate.groupBy.exists { cGroupBy =>
-          sGroupBy.isIsomorphic(cGroupBy, rewriteInTerms.isoState)
-        } || candidate.groupBy.exists { cGroupBy =>
-          functionSubset(sGroupBy, cGroupBy, rewriteInTerms.isoState).isDefined
+      select.groupBy.iterator.map { e =>
+        e +: adHocRewriter(e)
+      }.forall { sGroupByPossibilities =>
+        sGroupByPossibilities.exists { sGroupBy =>
+          candidate.groupBy.exists { cGroupBy =>
+            sGroupBy.isIsomorphic(cGroupBy, rewriteInTerms.isoState)
+          } || candidate.groupBy.exists { cGroupBy =>
+            functionSubset(sGroupBy, cGroupBy, rewriteInTerms.isoState).isDefined
+          }
         }
       }
     if(!groupBySubset) {

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rollup/RollupExact.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rollup/RollupExact.scala
@@ -819,7 +819,7 @@ class RollupExact[MT <: MetaTypes](
           functionSubset(sExpr, ne.expr, isoState).map((label, ne, _))
         }
       ) match {
-        case Some((selectedColumn, NamedExpr(rollupExpr@AggregateFunctionCall(func, args, false, None), _name, _hint, _isSynthetic), functionExtract)) if rollupContext.isCoarseningGroup =>
+        case Some((selectedColumn, rollupExpr@NamedExpr(AggregateFunctionCall(func, args, false, None), _name, _hint, _isSynthetic), functionExtract)) if rollupContext.isCoarseningGroup =>
           assert(rollupExpr.typ == sExpr.typ)
           semigroupRewriter(func).map { merger =>
             functionExtract(merger(PhysicalColumn[MT](newFrom.label, newFrom.tableName, columnLabelMap(selectedColumn), rollupExpr.typ)(sExpr.position.asAtomic)))
@@ -830,9 +830,10 @@ class RollupExact[MT <: MetaTypes](
         case Some((selectedColumn, NamedExpr(_ : WindowedFunctionCall, _name, _hint, _isSynthetic), _)) if rollupContext.isCoarseningGroup =>
           log.debug("can't rewrite, windowed function call")
           None
-        case Some((selectedColumn, ne, functionExtract)) =>
-          assert(ne.expr.typ == sExpr.typ)
-          Some(functionExtract(PhysicalColumn[MT](newFrom.label, newFrom.tableName, columnLabelMap(selectedColumn), sExpr.typ)(sExpr.position.asAtomic)))
+        case Some((selectedColumn, rollupExpr, functionExtract)) =>
+          val result = functionExtract(PhysicalColumn[MT](newFrom.label, newFrom.tableName, columnLabelMap(selectedColumn), rollupExpr.typ)(sExpr.position.asAtomic))
+          assert(result.typ == sExpr.typ)
+          Some(result)
         case None =>
           sExpr match {
             case lit: LiteralValue => Some(lit)

--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -612,6 +612,66 @@ object SoQLFunctions {
   val FloatingTimeStampTruncY = mf("floating timestamp trunc year", FunctionName("date_trunc_y"), Seq(SoQLFloatingTimestamp), Seq.empty, SoQLFloatingTimestamp)(
     "Truncate a date at the year threshold"
   )
+  val DateTruncYm = mf("date trunc month", FunctionName("date_trunc_ym"), Seq(SoQLDate), Seq.empty, SoQLDate)(
+    "Truncate a date at the year/month threshold"
+  )
+  val DateTruncY = mf("date trunc year", FunctionName("date_trunc_y"), Seq(SoQLDate), Seq.empty, SoQLDate)(
+    "Truncate a date at the year threshold"
+  )
+
+  val FloatingTimestampYearField = field(SoQLFloatingTimestamp, "year", SoQLNumber)
+  val FloatingTimestampMonthField = field(SoQLFloatingTimestamp, "month", SoQLNumber)
+  val FloatingTimestampDayField = field(SoQLFloatingTimestamp, "day", SoQLNumber)
+  val FloatingTimestampDayOfWeekField = field(SoQLFloatingTimestamp, "dow", SoQLNumber)
+  val FloatingTimestampWeekOfYearField = field(SoQLFloatingTimestamp, "woy", SoQLNumber)
+  val FloatingTimestampIsoYearField = field(SoQLFloatingTimestamp, "isoyear", SoQLNumber)
+  val DateYearField = field(SoQLDate, "year", SoQLNumber)
+  val DateMonthField = field(SoQLDate, "month", SoQLNumber)
+  val DateDayField = field(SoQLDate, "day", SoQLNumber)
+  val DateDayOfWeekField = field(SoQLDate, "dow", SoQLNumber)
+  val DateWeekOfYearField = field(SoQLDate, "woy", SoQLNumber)
+  val DateIsoYearField = field(SoQLDate, "isoyear", SoQLNumber)
+  val FloatingTimestampHourField = field(SoQLFloatingTimestamp, "hour", SoQLNumber)
+  val FloatingTimestampMinuteField = field(SoQLFloatingTimestamp, "minute", SoQLNumber)
+  val FloatingTimestampSecondField = field(SoQLFloatingTimestamp, "second", SoQLNumber)
+  val TimeHourField = field(SoQLTime, "hour", SoQLNumber)
+  val TimeMinuteField = field(SoQLTime, "minute", SoQLNumber)
+  val TimeSecondField = field(SoQLTime, "second", SoQLNumber)
+  val FloatingTimestampDateField = field(SoQLFloatingTimestamp, "date", SoQLDate)
+  val FloatingTimestampTimeField = field(SoQLFloatingTimestamp, "time", SoQLTime)
+
+  val DateTimeAdd = mf("date time add", SpecialFunctions.Operator("+"), Seq(SoQLDate, SoQLTime), Seq.empty, SoQLFloatingTimestamp)(
+    "Add a time to a date, producing a timestamp"
+  )
+  val TimeDateAdd = mf("time date add", SpecialFunctions.Operator("+"), Seq(SoQLTime, SoQLDate), Seq.empty, SoQLFloatingTimestamp)(
+    "Add a time to a date, producing a timestamp"
+  )
+
+  val TimeIntervalAdd = mf("time interval add", SpecialFunctions.Operator("+"), Seq(SoQLTime, SoQLInterval), Seq.empty, SoQLTime)(
+    "Add an interval to a time, producing a new time"
+  )
+  val IntervalTimeAdd = mf("interval time add", SpecialFunctions.Operator("+"), Seq(SoQLInterval, SoQLTime), Seq.empty, SoQLTime)(
+    "Add an interval to a time, producing a new time"
+  )
+  val TimeIntervalSub = mf("time interval sub", SpecialFunctions.Operator("-"), Seq(SoQLTime, SoQLInterval), Seq.empty, SoQLTime)(
+    "Subtract an interval from a time, producing a new time"
+  )
+  val TimeTimeSub = mf("time time sub", SpecialFunctions.Operator("+"), Seq(SoQLTime, SoQLTime), Seq.empty, SoQLInterval)(
+    "Subtract a time from a time, producing an interval"
+  )
+
+  val DateIntervalAdd = mf("date interval add", SpecialFunctions.Operator("+"), Seq(SoQLDate, SoQLInterval), Seq.empty, SoQLFloatingTimestamp)(
+    "Add an interval to a date, producing a new timestamp"
+  )
+  val IntervalDateAdd = mf("interval date add", SpecialFunctions.Operator("+"), Seq(SoQLInterval, SoQLDate), Seq.empty, SoQLFloatingTimestamp)(
+    "Add an interval to a date, producing a new timestamp"
+  )
+  val DateIntervalSub = mf("date interval sub", SpecialFunctions.Operator("-"), Seq(SoQLDate, SoQLInterval), Seq.empty, SoQLFloatingTimestamp)(
+    "Subtract an interval from a date, producing a new timestamp"
+  )
+  val DateDateSub = mf("date date sub", SpecialFunctions.Operator("-"), Seq(SoQLDate, SoQLDate), Seq.empty, SoQLNumber)(
+    "Subtract two dates, returning the difference in number of days"
+  )
 
   val FloatingTimeStampExtractY = mf("floating timestamp extract year", FunctionName("date_extract_y"), Seq(SoQLFloatingTimestamp), Seq.empty, SoQLNumber)(
     "Extract the year as an integer"
@@ -674,6 +734,11 @@ object SoQLFunctions {
     NoDocs
   )
 
+  // This does the same as subtracting two dates; it exists for symmetry with floating_timestamp
+  val DateDiffD = mf("date diff in days", FunctionName("date_diff_d"), Seq(SoQLDate, SoQLDate), Seq.empty, SoQLNumber)(
+    NoDocs
+  )
+
   val EpochSeconds = mf("epoch_seconds", FunctionName("epoch_seconds"), Seq(SoQLFixedTimestamp), Seq.empty, SoQLNumber)(
     "Returns the number of seconds since the start of 1 January 1970 GMT.  Note that this includes millisecond precision"
   )
@@ -699,6 +764,22 @@ object SoQLFunctions {
     "Return the current date and time as a fixed timestamp displayed in Coordinated Universal Time (UTC+00:00).",
     Example("Get the current datetime (displayed as UTC+00:00)", "get_utc_date()", ""),
     Example("Get records of last month converted into US/Pacific time", "floating_date_column between date_trunc_ym(to_floating_timestamp(get_utc_date(), 'US/Pacific')) - 'P1M' and date_trunc_ym(to_floating_timestamp(get_utc_date(), 'US/Pacific')) - 'PT1S'", "")
+  )
+
+  val FixedTimestampToText = mf("fixed timestamp to text", SpecialFunctions.Cast(SoQLText.name), Seq(SoQLFixedTimestamp), Seq.empty, SoQLText)(
+    "Convert a fixed_timestamp to an ISO8601 string"
+  )
+  val FloatingTimestampToText = mf("floating timestamp to text", SpecialFunctions.Cast(SoQLText.name), Seq(SoQLFloatingTimestamp), Seq.empty, SoQLText)(
+    "Convert a floating_timestamp to an ISO8601 string"
+  )
+  val DateToText = mf("date to text", SpecialFunctions.Cast(SoQLText.name), Seq(SoQLDate), Seq.empty, SoQLText)(
+    "Convert a date to an ISO8601 string"
+  )
+  val TimeToText = mf("time to text", SpecialFunctions.Cast(SoQLText.name), Seq(SoQLTime), Seq.empty, SoQLText)(
+    "Convert a date to an ISO8601 string"
+  )
+  val IntervalToText = mf("interval to text", SpecialFunctions.Cast(SoQLText.name), Seq(SoQLInterval), Seq.empty, SoQLText)(
+    "Convert an inteval to an ISO8601 string"
   )
 
   val castIdentitiesByType = OrderedMap() ++ SoQLType.typesByName.iterator.map { case (n, t) =>
@@ -836,6 +917,13 @@ object SoQLFunctions {
   val TextToRowVersion = mf("text to rowver", SpecialFunctions.Cast(SoQLVersion.name), Seq(SoQLText), Seq.empty, SoQLVersion)(
     NoDocs
   ).hidden // required by the old-sqlizer (not a real function, requires a string literal); not necessary in the new
+
+  val RowIdentifierToText = mf("rid to text", SpecialFunctions.Cast(SoQLText.name), Seq(SoQLID), Seq.empty, SoQLText)(
+    NoDocs
+  ).hidden
+  val RowVersionToText = mf("rowver to text", SpecialFunctions.Cast(SoQLText.name), Seq(SoQLVersion), Seq.empty, SoQLText)(
+    NoDocs
+  ).hidden
 
   val Iif = f("iif", FunctionName("iif"), Map.empty,
     Seq(FixedType(SoQLBoolean), VariableType("a"), VariableType("a")),

--- a/soql-stdlib/src/main/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLFunctionSubset.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLFunctionSubset.scala
@@ -11,13 +11,44 @@ class SoQLFunctionSubset[MT <: MetaTypes with ({type ColumnType = SoQLType; type
   private val monomorphicMap = locally {
     import SoQLFunctions._
     Seq(
-      (FloatingTimeStampTruncY, FloatingTimeStampTruncYmd),
+      // out of a YMD timestamp truncation, we can further truncate
       (FloatingTimeStampTruncYm, FloatingTimeStampTruncYmd),
+      (FloatingTimeStampTruncY, FloatingTimeStampTruncYmd),
+      // .. or extract one of the date-related fields
+      (FloatingTimestampDateField, FloatingTimeStampTruncYmd),
+      (FloatingTimestampYearField, FloatingTimeStampTruncYmd),
+      (FloatingTimeStampExtractY, FloatingTimeStampTruncYmd),
+      (FloatingTimestampMonthField, FloatingTimeStampTruncYmd),
+      (FloatingTimeStampExtractM, FloatingTimeStampTruncYmd),
+      (FloatingTimestampDayField, FloatingTimeStampTruncYmd),
+      (FloatingTimeStampExtractD, FloatingTimeStampTruncYmd),
+      (FloatingTimestampDayOfWeekField, FloatingTimeStampTruncYmd),
+      (FloatingTimeStampExtractDow, FloatingTimeStampTruncYmd),
+      (FloatingTimestampWeekOfYearField, FloatingTimeStampTruncYmd),
+      (FloatingTimeStampExtractWoy, FloatingTimeStampTruncYmd),
+      (FloatingTimestampIsoYearField, FloatingTimeStampTruncYmd),
+      (FloatingTimestampExtractIsoY, FloatingTimeStampTruncYmd),
+      // out of a YM timestamp truncation, we can further truncate
       (FloatingTimeStampTruncY, FloatingTimeStampTruncYm),
+      // .. or extract one of the fields
+      (FloatingTimestampYearField, FloatingTimeStampTruncYm),
+      (FloatingTimeStampExtractY, FloatingTimeStampTruncYmd),
+      (FloatingTimestampMonthField, FloatingTimeStampTruncYm),
+      (FloatingTimeStampExtractM, FloatingTimeStampTruncYmd),
+      // Out of a Y timestamp truncation, we can extract the year field
+      (FloatingTimestampYearField, FloatingTimeStampTruncY),
+      (FloatingTimeStampExtractY, FloatingTimeStampTruncYmd),
+      // Out of a YM date truncation, we can further truncate
+      (DateTruncY, DateTruncYm),
+      // ... or extract one of the fields
+      (DateYearField, DateTruncYm),
+      (DateMonthField, DateTruncYm),
+      // Out of a Y date truncation, we ca extract the year field
+      (DateYearField, DateTruncY),
+      // datez_trunc functions return _fixed_ timestamps...
       (FixedTimeStampZTruncY, FixedTimeStampZTruncYmd),
       (FixedTimeStampZTruncYm, FixedTimeStampZTruncYmd),
-      (FixedTimeStampZTruncY, FixedTimeStampZTruncYm),
-      (DateTruncY, DateTruncYm),
+      (FixedTimeStampZTruncY, FixedTimeStampZTruncYm)
     ).map { case (a, b) =>
         (a.monomorphic.get.function.identity, b.monomorphic.get.function.identity) -> a.monomorphic.get
     }.toMap

--- a/soql-stdlib/src/main/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLFunctionSubset.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLFunctionSubset.scala
@@ -17,6 +17,7 @@ class SoQLFunctionSubset[MT <: MetaTypes with ({type ColumnType = SoQLType; type
       (FixedTimeStampZTruncY, FixedTimeStampZTruncYmd),
       (FixedTimeStampZTruncYm, FixedTimeStampZTruncYmd),
       (FixedTimeStampZTruncY, FixedTimeStampZTruncYm),
+      (DateTruncY, DateTruncYm),
     ).map { case (a, b) =>
         (a.monomorphic.get.function.identity, b.monomorphic.get.function.identity) -> a.monomorphic.get
     }.toMap

--- a/soql-stdlib/src/test/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLAdHocRewriterTest.scala
+++ b/soql-stdlib/src/test/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLAdHocRewriterTest.scala
@@ -10,33 +10,25 @@ import com.socrata.soql.environment.Provenance
 import com.socrata.soql.functions.{SoQLFunctions, MonomorphicFunction, SoQLTypeInfo, SoQLFunctionInfo}
 import com.socrata.soql.types._
 
-class SoQLAdHocRewriterTest extends FunSuite with MustMatchers {
+class SoQLAdHocRewriterTest extends FunSuite with MustMatchers with SoQLRollupTestHelper {
   import SoQLTypeInfo.hasType
-
-  trait MT extends MetaTypes {
-    type ColumnType = SoQLType
-    type ColumnValue = SoQLValue
-    type ResourceNameScope = Int
-    type DatabaseTableNameImpl = String
-    type DatabaseColumnNameImpl = String
-  }
 
   val rewriter = new SoQLAdHocRewriter[MT]
 
   def analyze(expr: String) = {
     val tf = MockTableFinder[MT](
-      (0, "rollup") -> D("floating_timestamp" -> SoQLFloatingTimestamp)
+      (0, "rollup") -> D("floating_timestamp" -> SoQLFloatingTimestamp, "fixed_timestamp" -> SoQLFixedTimestamp)
     )
     val q = s"select $expr from @rollup"
     val Right(ft) = tf.findTables(0, q, Map.empty)
     val analyzer = new SoQLAnalyzer[MT](
       SoQLTypeInfo.soqlTypeInfo2,
       SoQLFunctionInfo,
-      new ToProvenance[String] {
-        override def toProvenance(dtn: DatabaseTableName[String]) = Provenance(dtn.name)
+      new ToProvenance {
+        override def toProvenance(dtn: DatabaseTableName) = Provenance(dtn.name)
       })
     val Right(analysis) = analyzer(ft, UserParameters.empty)
-    analysis.statement.asInstanceOf[Select[MT]].selectList.valuesIterator.next().expr
+    analysis.statement.asInstanceOf[Select].selectList.valuesIterator.next().expr
   }
 
   private val c1 =
@@ -67,5 +59,34 @@ class SoQLAdHocRewriterTest extends FunSuite with MustMatchers {
 
   test("limited by both") {
     rewriter(analyze("date_trunc_ymd(floating_timestamp) < '2001-02-01'")) must equal (Seq(analyze("date_trunc_ym(floating_timestamp) < '2001-02-01'")))
+  }
+
+  test("trunc at zone") {
+    rewriter(analyze("date_trunc_ymd(fixed_timestamp, 'zone me!')")) must equal (Seq(analyze("date_trunc_ymd(to_floating_timestamp(fixed_timestamp, 'zone me!'))")))
+    rewriter(analyze("date_trunc_ym(fixed_timestamp, 'zone me!')")) must equal (Seq(analyze("date_trunc_ym(to_floating_timestamp(fixed_timestamp, 'zone me!'))")))
+    rewriter(analyze("date_trunc_y(fixed_timestamp, 'zone me!')")) must equal (Seq(analyze("date_trunc_y(to_floating_timestamp(fixed_timestamp, 'zone me!'))")))
+  }
+
+  test("trunc of converted timestamp") {
+    rewriter(analyze("date_trunc_ymd(to_floating_timestamp(fixed_timestamp, 'zone me!'))")) must equal (Seq(analyze("date_trunc_ymd(fixed_timestamp, 'zone me!')")))
+    rewriter(analyze("date_trunc_ym(to_floating_timestamp(fixed_timestamp, 'zone me!'))")) must equal (Seq(analyze("date_trunc_ym(fixed_timestamp, 'zone me!')")))
+    rewriter(analyze("date_trunc_y(to_floating_timestamp(fixed_timestamp, 'zone me!'))")) must equal (Seq(analyze("date_trunc_y(fixed_timestamp, 'zone me!')")))
+  }
+
+  test("timestamp trunc does not loop") {
+    val tf = MockTableFinder[MT](
+      (0, "dataset") -> D("fixed_timestamp" -> SoQLFixedTimestamp, "number" -> SoQLNumber),
+      (1, "rollup") -> D("c1" -> SoQLFloatingTimestamp, "c2" -> SoQLNumber).withPrimaryKey("c1")
+    )
+
+    val analysis = analyze(tf, "select date_trunc_y(fixed_timestamp, 'US/Pacific') as y, sum(number) from @dataset group by y")
+    val rollup = SoQLRollupInfo(1, "rollup", tf, "select date_trunc_ymd(to_floating_timestamp(fixed_timestamp, 'US/Pacific')) as y, sum(number) from @dataset group by y")
+    val Some(result) = rollupExact(analysis.statement.asInstanceOf[Select], rollup, analysis.labelProvider)
+
+    locally {
+      val Right(expectedRollupFT) = tf.findTables(1, "select date_trunc_y(c1) as y, sum(c2) from @rollup group by y", Map.empty)
+      val Right(expectedRollupAnalysis) = analyzer(expectedRollupFT, UserParameters.empty)
+      result must be (isomorphicTo(expectedRollupAnalysis.statement))
+    }
   }
 }

--- a/soql-stdlib/src/test/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLFunctionSplitterTest.scala
+++ b/soql-stdlib/src/test/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLFunctionSplitterTest.scala
@@ -1,0 +1,30 @@
+package com.socrata.soql.stdlib.analyzer2.rollup
+
+import org.scalatest.{FunSuite, MustMatchers}
+
+import com.socrata.soql.analyzer2._
+import com.socrata.soql.analyzer2.mocktablefinder._
+import com.socrata.soql.analyzer2.rollup.RollupInfo
+import com.socrata.soql.environment.{Provenance, ResourceName, ScopedResourceName}
+import com.socrata.soql.functions.{SoQLFunctions, MonomorphicFunction, SoQLTypeInfo, SoQLFunctionInfo}
+import com.socrata.soql.types._
+import com.socrata.soql.types.obfuscation.CryptProvider
+
+class SoQLFunctionSplitterTest extends SoQLRollupTestHelper {
+  xtest("avg") {
+    val tf = MockTableFinder[MT](
+      (0, "dataset") -> D("text" -> SoQLText, "number" -> SoQLNumber),
+      (1, "rollup") -> D("c1" -> SoQLText, "c2" -> SoQLNumber, "c3" -> SoQLNumber).withPrimaryKey("c1")
+    )
+
+    val analysis = analyze(tf, "select avg(number) from @dataset")
+    val rollup = SoQLRollupInfo(1, "rollup", tf, "select text, sum(number), count(number) from @dataset group by text")
+    val Some(result) = rewriter(analysis.statement.asInstanceOf[Select], rollup, analysis.labelProvider)
+
+    locally {
+      val Right(expectedRollupFT) = tf.findTables(1, "select sum(c2)/coalesce(sum(c3), 0) from @rollup", Map.empty)
+      val Right(expectedRollupAnalysis) = analyzer(expectedRollupFT, UserParameters.empty)
+      result must be (isomorphicTo(expectedRollupAnalysis.statement))
+    }
+  }
+}

--- a/soql-stdlib/src/test/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLFunctionSplitterTest.scala
+++ b/soql-stdlib/src/test/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLFunctionSplitterTest.scala
@@ -11,7 +11,7 @@ import com.socrata.soql.types._
 import com.socrata.soql.types.obfuscation.CryptProvider
 
 class SoQLFunctionSplitterTest extends SoQLRollupTestHelper {
-  xtest("avg") {
+  test("avg") {
     val tf = MockTableFinder[MT](
       (0, "dataset") -> D("text" -> SoQLText, "number" -> SoQLNumber),
       (1, "rollup") -> D("c1" -> SoQLText, "c2" -> SoQLNumber, "c3" -> SoQLNumber).withPrimaryKey("c1")
@@ -19,7 +19,7 @@ class SoQLFunctionSplitterTest extends SoQLRollupTestHelper {
 
     val analysis = analyze(tf, "select avg(number) from @dataset")
     val rollup = SoQLRollupInfo(1, "rollup", tf, "select text, sum(number), count(number) from @dataset group by text")
-    val Some(result) = rewriter(analysis.statement.asInstanceOf[Select], rollup, analysis.labelProvider)
+    val Some(result) = rollupExact(analysis.statement.asInstanceOf[Select], rollup, analysis.labelProvider)
 
     locally {
       val Right(expectedRollupFT) = tf.findTables(1, "select sum(c2)/coalesce(sum(c3), 0) from @rollup", Map.empty)

--- a/soql-stdlib/src/test/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLFunctionSubsetTest.scala
+++ b/soql-stdlib/src/test/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLFunctionSubsetTest.scala
@@ -19,7 +19,7 @@ class SoQLFunctionSubsetTest extends SoQLRollupTestHelper {
 
     val analysis = analyze(tf, "select date_trunc_ym(floating_timestamp) as month, sum(number) from @dataset group by month")
     val rollup = SoQLRollupInfo(1, "rollup", tf, "select date_trunc_ymd(floating_timestamp) as date, sum(number) from @dataset group by date")
-    val Some(result) = rewriter(analysis.statement.asInstanceOf[Select], rollup, analysis.labelProvider)
+    val Some(result) = rollupExact(analysis.statement.asInstanceOf[Select], rollup, analysis.labelProvider)
 
     locally {
       val Right(expectedRollupFT) = tf.findTables(1, "select date_trunc_ym(c1) as y, sum(c2) from @rollup group by y", Map.empty)
@@ -36,7 +36,7 @@ class SoQLFunctionSubsetTest extends SoQLRollupTestHelper {
 
     val analysis = analyze(tf, "select date_trunc_y(floating_timestamp) as month, sum(number) from @dataset group by month")
     val rollup = SoQLRollupInfo(1, "rollup", tf, "select date_trunc_ymd(floating_timestamp) as date, sum(number) from @dataset group by date")
-    val Some(result) = rewriter(analysis.statement.asInstanceOf[Select], rollup, analysis.labelProvider)
+    val Some(result) = rollupExact(analysis.statement.asInstanceOf[Select], rollup, analysis.labelProvider)
 
     locally {
       val Right(expectedRollupFT) = tf.findTables(1, "select date_trunc_y(c1) as y, sum(c2) from @rollup group by y", Map.empty)
@@ -53,7 +53,7 @@ class SoQLFunctionSubsetTest extends SoQLRollupTestHelper {
 
     val analysis = analyze(tf, "select floating_timestamp.date as date, sum(number) from @dataset group by date")
     val rollup = SoQLRollupInfo(1, "rollup", tf, "select date_trunc_ymd(floating_timestamp) as date, sum(number) from @dataset group by date")
-    val Some(result) = rewriter(analysis.statement.asInstanceOf[Select], rollup, analysis.labelProvider)
+    val Some(result) = rollupExact(analysis.statement.asInstanceOf[Select], rollup, analysis.labelProvider)
 
     locally {
       val Right(expectedRollupFT) = tf.findTables(1, "select c1.date as date, sum(c2) from @rollup group by date", Map.empty)
@@ -70,7 +70,7 @@ class SoQLFunctionSubsetTest extends SoQLRollupTestHelper {
 
     val analysis = analyze(tf, "select datez_trunc_y(fixed_timestamp) as year, sum(number) from @dataset group by year")
     val rollup = SoQLRollupInfo(1, "rollup", tf, "select datez_trunc_ym(fixed_timestamp) as month, sum(number) from @dataset group by month")
-    val Some(result) = rewriter(analysis.statement.asInstanceOf[Select], rollup, analysis.labelProvider)
+    val Some(result) = rollupExact(analysis.statement.asInstanceOf[Select], rollup, analysis.labelProvider)
 
     locally {
       val Right(expectedRollupFT) = tf.findTables(1, "select datez_trunc_y(c1) as y, sum(c2) from @rollup group by y", Map.empty)

--- a/soql-stdlib/src/test/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLFunctionSubsetTest.scala
+++ b/soql-stdlib/src/test/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLFunctionSubsetTest.scala
@@ -1,0 +1,81 @@
+package com.socrata.soql.stdlib.analyzer2.rollup
+
+import org.scalatest.{FunSuite, MustMatchers}
+
+import com.socrata.soql.analyzer2._
+import com.socrata.soql.analyzer2.mocktablefinder._
+import com.socrata.soql.analyzer2.rollup.RollupInfo
+import com.socrata.soql.environment.{Provenance, ResourceName, ScopedResourceName}
+import com.socrata.soql.functions.{SoQLFunctions, MonomorphicFunction, SoQLTypeInfo, SoQLFunctionInfo}
+import com.socrata.soql.types._
+import com.socrata.soql.types.obfuscation.CryptProvider
+
+class SoQLFunctionSubsetTest extends SoQLRollupTestHelper {
+  test("ymd -> ym subset") {
+    val tf = MockTableFinder[MT](
+      (0, "dataset") -> D("floating_timestamp" -> SoQLFloatingTimestamp, "number" -> SoQLNumber),
+      (1, "rollup") -> D("c1" -> SoQLFloatingTimestamp, "c2" -> SoQLNumber).withPrimaryKey("c1")
+    )
+
+    val analysis = analyze(tf, "select date_trunc_ym(floating_timestamp) as month, sum(number) from @dataset group by month")
+    val rollup = SoQLRollupInfo(1, "rollup", tf, "select date_trunc_ymd(floating_timestamp) as date, sum(number) from @dataset group by date")
+    val Some(result) = rewriter(analysis.statement.asInstanceOf[Select], rollup, analysis.labelProvider)
+
+    locally {
+      val Right(expectedRollupFT) = tf.findTables(1, "select date_trunc_ym(c1) as y, sum(c2) from @rollup group by y", Map.empty)
+      val Right(expectedRollupAnalysis) = analyzer(expectedRollupFT, UserParameters.empty)
+      result must be (isomorphicTo(expectedRollupAnalysis.statement))
+    }
+  }
+
+  test("ymd -> y subset") {
+    val tf = MockTableFinder[MT](
+      (0, "dataset") -> D("floating_timestamp" -> SoQLFloatingTimestamp, "number" -> SoQLNumber),
+      (1, "rollup") -> D("c1" -> SoQLFloatingTimestamp, "c2" -> SoQLNumber).withPrimaryKey("c1")
+    )
+
+    val analysis = analyze(tf, "select date_trunc_y(floating_timestamp) as month, sum(number) from @dataset group by month")
+    val rollup = SoQLRollupInfo(1, "rollup", tf, "select date_trunc_ymd(floating_timestamp) as date, sum(number) from @dataset group by date")
+    val Some(result) = rewriter(analysis.statement.asInstanceOf[Select], rollup, analysis.labelProvider)
+
+    locally {
+      val Right(expectedRollupFT) = tf.findTables(1, "select date_trunc_y(c1) as y, sum(c2) from @rollup group by y", Map.empty)
+      val Right(expectedRollupAnalysis) = analyzer(expectedRollupFT, UserParameters.empty)
+      result must be (isomorphicTo(expectedRollupAnalysis.statement))
+    }
+  }
+
+  test("ymd -> date subset") {
+    val tf = MockTableFinder[MT](
+      (0, "dataset") -> D("floating_timestamp" -> SoQLFloatingTimestamp, "number" -> SoQLNumber),
+      (1, "rollup") -> D("c1" -> SoQLFloatingTimestamp, "c2" -> SoQLNumber).withPrimaryKey("c1")
+    )
+
+    val analysis = analyze(tf, "select floating_timestamp.date as date, sum(number) from @dataset group by date")
+    val rollup = SoQLRollupInfo(1, "rollup", tf, "select date_trunc_ymd(floating_timestamp) as date, sum(number) from @dataset group by date")
+    val Some(result) = rewriter(analysis.statement.asInstanceOf[Select], rollup, analysis.labelProvider)
+
+    locally {
+      val Right(expectedRollupFT) = tf.findTables(1, "select c1.date as date, sum(c2) from @rollup group by date", Map.empty)
+      val Right(expectedRollupAnalysis) = analyzer(expectedRollupFT, UserParameters.empty)
+      result must be (isomorphicTo(expectedRollupAnalysis.statement))
+    }
+  }
+
+  test("datez subset") {
+    val tf = MockTableFinder[MT](
+      (0, "dataset") -> D("fixed_timestamp" -> SoQLFixedTimestamp, "number" -> SoQLNumber),
+      (1, "rollup") -> D("c1" -> SoQLFixedTimestamp, "c2" -> SoQLNumber).withPrimaryKey("c1")
+    )
+
+    val analysis = analyze(tf, "select datez_trunc_y(fixed_timestamp) as year, sum(number) from @dataset group by year")
+    val rollup = SoQLRollupInfo(1, "rollup", tf, "select datez_trunc_ym(fixed_timestamp) as month, sum(number) from @dataset group by month")
+    val Some(result) = rewriter(analysis.statement.asInstanceOf[Select], rollup, analysis.labelProvider)
+
+    locally {
+      val Right(expectedRollupFT) = tf.findTables(1, "select datez_trunc_y(c1) as y, sum(c2) from @rollup group by y", Map.empty)
+      val Right(expectedRollupAnalysis) = analyzer(expectedRollupFT, UserParameters.empty)
+      result must be (isomorphicTo(expectedRollupAnalysis.statement))
+    }
+  }
+}

--- a/soql-stdlib/src/test/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLRollupTestHelper.scala
+++ b/soql-stdlib/src/test/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLRollupTestHelper.scala
@@ -1,0 +1,82 @@
+package com.socrata.soql.stdlib.analyzer2.rollup
+
+import java.math.{BigDecimal => JBigDecimal}
+
+import org.scalatest.{FunSuite, MustMatchers}
+import org.scalatest.matchers.{BeMatcher, MatchResult}
+
+import com.socrata.soql.analyzer2._
+import com.socrata.soql.analyzer2.mocktablefinder._
+import com.socrata.soql.analyzer2.rollup.RollupInfo
+import com.socrata.soql.environment.{Provenance, ResourceName, ScopedResourceName}
+import com.socrata.soql.functions.{SoQLFunctions, MonomorphicFunction, SoQLTypeInfo, SoQLFunctionInfo}
+import com.socrata.soql.types._
+import com.socrata.soql.types.obfuscation.CryptProvider
+
+object SoQLRollupTestHelper {
+  trait MT extends MetaTypes {
+    type ColumnType = SoQLType
+    type ColumnValue = SoQLValue
+    type ResourceNameScope = Int
+    type DatabaseTableNameImpl = String
+    type DatabaseColumnNameImpl = String
+  }
+}
+
+trait SoQLRollupTestHelper extends FunSuite with MustMatchers with StatementUniverse[SoQLRollupTestHelper.MT] {
+  import SoQLTypeInfo.hasType
+
+  type MT = SoQLRollupTestHelper.MT
+
+  implicit object cvDoc extends HasDoc[CV] {
+    def docOf(cv: CV) = cv.doc(CryptProvider.zeros)
+  }
+
+  def xtest[T](s: String)(f: => T): Unit = {}
+
+  class IsomorphicToMatcher(right: Statement) extends BeMatcher[Statement] {
+    def apply(left: Statement) =
+      MatchResult(
+        left.isIsomorphic(right),
+        left.debugStr + "\nwas not isomorphic to\n" + right.debugStr,
+        left.debugStr + "\nwas isomorphic to\n" + right.debugStr
+      )
+  }
+
+  def isomorphicTo(right: Statement) = new IsomorphicToMatcher(right)
+
+  val analyzer = new SoQLAnalyzer[MT](
+    SoQLTypeInfo.soqlTypeInfo2,
+    SoQLFunctionInfo,
+    new ToProvenance {
+      override def toProvenance(dtn: DatabaseTableName) = Provenance(dtn.name)
+    })
+
+  val rewriter = new SoQLRollupExact[MT](Stringifier.simple)
+
+  class SoQLRollupInfo(
+    val id: Int,
+    val statement: Statement,
+    val resourceName: types.ScopedResourceName[MT],
+    val databaseName: types.DatabaseTableName[MT]
+  ) extends RollupInfo[MT, Int] {
+    override def databaseColumnNameOfIndex(i: Int) = DatabaseColumnName(s"c${i+1}")
+  }
+
+  object SoQLRollupInfo {
+    def apply(id: Int, name: String, tf: TableFinder[MT], soql: String): SoQLRollupInfo = {
+      val Right(foundTables) = tf.findTables(0, soql, Map.empty)
+      val analysis = analyzer(foundTables, UserParameters.empty) match {
+        case Right(a) => a
+        case Left(e) => fail(e.toString)
+      }
+      new SoQLRollupInfo(id, analysis.statement, ScopedResourceName(0, ResourceName(name)), DatabaseTableName(name))
+    }
+  }
+
+  def analyze(tf: TableFinder[MT], q: String) = {
+    val Right(ft) = tf.findTables(0, q, Map.empty)
+    val Right(analysis) = analyzer(ft, UserParameters.empty)
+    analysis
+  }
+}

--- a/soql-stdlib/src/test/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLRollupTestHelper.scala
+++ b/soql-stdlib/src/test/scala/com/socrata/soql/stdlib/analyzer2/rollup/SoQLRollupTestHelper.scala
@@ -52,7 +52,7 @@ trait SoQLRollupTestHelper extends FunSuite with MustMatchers with StatementUniv
       override def toProvenance(dtn: DatabaseTableName) = Provenance(dtn.name)
     })
 
-  val rewriter = new SoQLRollupExact[MT](Stringifier.simple)
+  val rollupExact = new SoQLRollupExact[MT](Stringifier.simple)
 
   class SoQLRollupInfo(
     val id: Int,

--- a/soql-types/src/main/scala/com/socrata/soql/types/SoQLType.scala
+++ b/soql-types/src/main/scala/com/socrata/soql/types/SoQLType.scala
@@ -662,7 +662,7 @@ case class SoQLDate(value: LocalDate) extends SoQLValue {
     buffer.write(typ.StringRep(value))
   }
 }
-case object SoQLDate extends SoQLType("date") with NonObfuscatedType {
+case object SoQLDate extends SoQLType("datestamp") with NonObfuscatedType {
   type Self = SoQLDate
 
   val cjsonRep: CJsonRep[SoQLDate, SoQLValue] = new SoQLValueCJsonRep[SoQLDate] {


### PR DESCRIPTION
* Field-syntax access for parts of floating_timestamps, dates, and times
** including fieldlike access to "date" and "time" parts of timestamps
* Add a time to a date to get a floating_timestamp
* Add or subtract an interval to a time to get a new time
* Subtract two times to get an interval
* Add an interval to a date to get a floating_timestamp (not sure why
  the discrepancy, but it's what PG does)
* Subtract an interval from a date to get a floating_timestamp
* Find the difference between two dates in days
* Truncate a date at year or month
* Convert timestamps, dates, times, intervals to ISO8601 via cast-to-text
* Convert row identifiers and row versions to text via cast