### PR TITLE
Improve query plans in postgresql by using COPY

### DIFF
--- a/soql-sqlizer/src/test/scala/com/socrata/soql/sqlizer/TestRepProvider.scala
+++ b/soql-sqlizer/src/test/scala/com/socrata/soql/sqlizer/TestRepProvider.scala
@@ -1,5 +1,7 @@
 package com.socrata.soql.sqlizer
 
+import scala.{collection => sc}
+
 import java.sql.ResultSet
 
 import com.rojoma.json.v3.ast.JString
@@ -69,6 +71,14 @@ class TestRepProvider(
         ???
       }
 
+      override protected def doExtractExpandedFromCsv(row: sc.Seq[Option[String]], dbCol: Int): CV = {
+        ???
+      }
+
+      override protected def doExtractCompressedFromCsv(value: Option[String]): CV = {
+        ???
+      }
+
       override def ingressRep(tableName: DatabaseTableName, label: ColumnLabel) = {
         ???
       }
@@ -82,6 +92,10 @@ class TestRepProvider(
       override def convertToText(e: ExprSql) = Some(e)
 
       override protected def doExtractFrom(rs: ResultSet, dbCol: Int): CV = {
+        ???
+      }
+
+      override protected def doExtractFromCsv(value: Option[String]): CV = {
         ???
       }
 
@@ -104,6 +118,10 @@ class TestRepProvider(
         ???
       }
 
+      override protected def doExtractFromCsv(value: Option[String]): CV = {
+        ???
+      }
+
       override def ingressRep(tableName: DatabaseTableName, label: ColumnLabel) = {
         ???
       }
@@ -117,6 +135,10 @@ class TestRepProvider(
       override def convertToText(e: ExprSql) = None
 
       override protected def doExtractFrom(rs: ResultSet, dbCol: Int): CV = {
+        ???
+      }
+
+      override protected def doExtractFromCsv(value: Option[String]): CV = {
         ???
       }
 
@@ -184,6 +206,14 @@ class TestRepProvider(
       }
 
       override protected def doExtractCompressed(rs: ResultSet, dbCol: Int): CV = {
+        ???
+      }
+
+      override protected def doExtractExpandedFromCsv(row: sc.Seq[Option[String]], dbCol: Int): CV = {
+        ???
+      }
+
+      override protected def doExtractCompressedFromCsv(value: Option[String]): CV = {
         ???
       }
 


### PR DESCRIPTION
When using a cursor, pg does not want to use parallel query plans.  So, in order to preserve streaming, instead we'll COPY out results.  This means teaching the reps to be able to parse results out of CSVs as well as from result sets.

I don't entirely like this; it's putting too much pg specific code in here (for that matter, even taking a ResultSet before was pretty overly-specific for what the Sqlizer wants to be).  I think I want to refactor this so that either:

* Sqlizer is a class with an abstract ResultExtractor type which can be implemented per-secondary
* Sqlizer doesn't return a ResultExtractor at all, just schema information.

..but that can wait until later.