### PR TITLE
Add a "remove system columns" rewrite pass

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/Pass.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/Pass.scala
@@ -62,6 +62,7 @@ object Pass {
   case class LimitIfUnlimited(limit: NonNegativeBigInt) extends Pass
   case object RemoveTrivialJoins extends Pass
   case object RemoveSyntheticColumns extends Pass
+  case object RemoveSystemColumns extends Pass
 
   private[rewrite] def passBuilder[T >: Pass <: AnyRef](builder: SimpleHierarchyCodecBuilder[T]): SimpleHierarchyCodecBuilder[T] =
     builder
@@ -79,6 +80,7 @@ object Pass {
       .branch[LimitIfUnlimited]("limit_if_unlimited")(AutomaticJsonEncodeBuilder[LimitIfUnlimited], AutomaticJsonDecodeBuilder[LimitIfUnlimited], implicitly)
       .singleton("remove_trivial_joins", RemoveTrivialJoins)
       .singleton("remove_synthetic_columns", RemoveSyntheticColumns)
+      .singleton("remove_system_columns", RemoveSystemColumns)
 
   implicit val jCodec = passBuilder(AnyPass.codecBase[Pass]).build
 
@@ -99,6 +101,7 @@ object Pass {
         case 11 => LimitIfUnlimited(buffer.read[NonNegativeBigInt]())
         case 12 => RemoveTrivialJoins
         case 13 => RemoveSyntheticColumns
+        case 14 => RemoveSystemColumns
         case other => fail(s"Unknown rewrite pass type $other")
       }
 
@@ -131,6 +134,8 @@ object Pass {
           buffer.write(12)
         case RemoveSyntheticColumns =>
           buffer.write(13)
+        case RemoveSystemColumns =>
+          buffer.write(14)
       }
     }
   }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/RemoveOutputColumns.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/RemoveOutputColumns.scala
@@ -1,0 +1,70 @@
+package com.socrata.soql.analyzer2.rewrite
+
+import com.socrata.soql.analyzer2
+import com.socrata.soql.analyzer2._
+import com.socrata.soql.collection._
+
+private[rewrite] class RemoveOutputColumns[MT <: MetaTypes] (labelProvider: LabelProvider, toRemove: Statement.SchemaEntry[MT] => Boolean) extends StatementUniverse[MT] {
+  def rewriteStatement(stmt: Statement): Statement =
+    stmt match {
+      case ct@CombinedTables(_op, _left, _right) =>
+        if(ct.schema.values.exists(toRemove)) {
+          val newFrom = FromStatement(ct, labelProvider.tableLabel(), None, None)
+          Select(
+            Distinctiveness.Indistinct(),
+            OrderedMap() ++ ct.schema.iterator.flatMap { case (k, v) =>
+              if(toRemove(v)) {
+                None
+              } else {
+                Some(labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](newFrom.label, k, v.typ)(AtomicPositionInfo.Synthetic), v.name, v.hint, isSynthetic = v.isSynthetic))
+              }
+            },
+            newFrom,
+            None, Nil, None, Nil, None, None, None, Set.empty
+          )
+        } else {
+          ct
+        }
+
+      case cte@CTE(_defLabel, _defAlias, _defQuery, _matHint, useQuery) =>
+        cte.copy(useQuery = rewriteStatement(useQuery))
+
+      case v@Values(_, _) =>
+        v
+
+      case select@Select(Distinctiveness.Indistinct() | Distinctiveness.On(_), selectList, _from, _where, _groupBy, _having, _orderBy, _limit, _offset, _search, _hint) =>
+        select.copy(selectList = OrderedMap() ++ selectList.iterator.filterNot { case (k, _) => toRemove(select.schema(k)) })
+
+      case select@Select(Distinctiveness.FullyDistinct(), selectList, _from, _where, _groupBy, _having, orderBy, _limit, _offset, _search, _hint) =>
+        if(select.schema.values.exists(toRemove)) {
+          val newFrom = FromStatement(select, labelProvider.tableLabel(), None, None)
+          Select(
+            Distinctiveness.Indistinct(),
+            OrderedMap() ++ select.schema.iterator.flatMap { case (k, v) =>
+              if(toRemove(v)) {
+                None
+              } else {
+                Some(labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](newFrom.label, k, v.typ)(AtomicPositionInfo.Synthetic), v.name, v.hint, isSynthetic = v.isSynthetic))
+              }
+            },
+            newFrom,
+            None, Nil, None,
+            orderBy.map { originalOrderBy =>
+              val (selectedColumn, selectedExpr) = selectList.iterator.find { case (k, v) =>
+                v.expr == originalOrderBy.expr
+              }.getOrElse {
+                throw new Exception("Have a fully DISTINCT query with an ORDER BY which is not selected?")
+              }
+              OrderBy(
+                VirtualColumn(newFrom.label, selectedColumn, selectedExpr.typ)(AtomicPositionInfo.Synthetic),
+                ascending = originalOrderBy.ascending,
+                nullLast = originalOrderBy.nullLast
+              )
+            },
+            None, None, None, Set.empty
+          )
+        } else {
+          select
+        }
+    }
+}

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/RemoveSyntheticColumns.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/RemoveSyntheticColumns.scala
@@ -1,87 +1,8 @@
 package com.socrata.soql.analyzer2.rewrite
 
-import com.socrata.soql.analyzer2
 import com.socrata.soql.analyzer2._
-import com.socrata.soql.collection._
 
-class RemoveSyntheticColumns[MT <: MetaTypes] private (labelProvider: LabelProvider) extends StatementUniverse[MT] {
-  def rewriteStatement(stmt: Statement): Statement =
-    stmt match {
-      case ct@CombinedTables(_op, _left, _right) =>
-        if(ct.schema.values.exists(_.isSynthetic)) {
-          // there shouldn't ever actually be any synthetic columns to
-          // remove here, so this is "just in case".  We'll add a new
-          // wrapper select that drops the columns, rather than trying
-          // to rewrite left and right in an equivalent way.  Note we
-          // don't care about preserving our own labels, as this is
-          // the output schema for the analysis.
-
-          val newFrom = FromStatement(ct, labelProvider.tableLabel(), None, None)
-          Select(
-            Distinctiveness.Indistinct(),
-            OrderedMap() ++ ct.schema.iterator.flatMap { case (k, v) =>
-              if(v.isSynthetic) {
-                None
-              } else {
-                Some(labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](newFrom.label, k, v.typ)(AtomicPositionInfo.Synthetic), v.name, v.hint, isSynthetic = false))
-              }
-            },
-            newFrom,
-            None, Nil, None, Nil, None, None, None, Set.empty
-          )
-        } else {
-          ct
-        }
-
-      case cte@CTE(_defLabel, _defAlias, _defQuery, _matHint, useQuery) =>
-        cte.copy(useQuery = rewriteStatement(useQuery))
-
-      case v@Values(_, _) =>
-        v
-
-      case select@Select(Distinctiveness.Indistinct() | Distinctiveness.On(_), selectList, _from, _where, _groupBy, _having, _orderBy, _limit, _offset, _search, _hint) =>
-        select.copy(selectList = OrderedMap() ++ selectList.iterator.filterNot { case (k, _) => select.schema(k).isSynthetic })
-
-      case select@Select(Distinctiveness.FullyDistinct(), selectList, _from, _where, _groupBy, _having, orderBy, _limit, _offset, _search, _hint) =>
-        if(select.schema.values.exists(_.isSynthetic)) {
-          // This also sholdn't ever happen, but we can treat it much
-          // the same way we treat combined tables (i.e., wrapping it
-          // in a SELECT that drops the undesired columns), with the
-          // wrinkle that we have to preserve ordering - but in this
-          // case any ORDER BY clauses must also be selected, so we
-          // can just ORDER BY the output columns of the inner select.
-
-          val newFrom = FromStatement(select, labelProvider.tableLabel(), None, None)
-          Select(
-            Distinctiveness.Indistinct(),
-            OrderedMap() ++ select.schema.iterator.flatMap { case (k, v) =>
-              if(v.isSynthetic) {
-                None
-              } else {
-                Some(labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](newFrom.label, k, v.typ)(AtomicPositionInfo.Synthetic), v.name, v.hint, isSynthetic = false))
-              }
-            },
-            newFrom,
-            None, Nil, None,
-            orderBy.map { originalOrderBy =>
-              val (selectedColumn, selectedExpr) = selectList.iterator.find { case (k, v) =>
-                v.expr == originalOrderBy.expr
-              }.getOrElse {
-                throw new Exception("Have a fully DISTINCT query with an ORDER BY which is not selected?")
-              }
-              OrderBy(
-                VirtualColumn(newFrom.label, selectedColumn, selectedExpr.typ)(AtomicPositionInfo.Synthetic),
-                ascending = originalOrderBy.ascending,
-                nullLast = originalOrderBy.nullLast
-              )
-            },
-            None, None, None, Set.empty
-          )
-        } else {
-          select
-        }
-    }
-}
+class RemoveSyntheticColumns[MT <: MetaTypes] private (labelProvider: LabelProvider) extends RemoveOutputColumns[MT](labelProvider, _.isSynthetic)
 
 object RemoveSyntheticColumns {
   def apply[MT <: MetaTypes](labelProvider: LabelProvider, stmt: Statement[MT]): Statement[MT] = {

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/RemoveSystemColumns.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/RemoveSystemColumns.scala
@@ -1,0 +1,11 @@
+package com.socrata.soql.analyzer2.rewrite
+
+import com.socrata.soql.analyzer2._
+
+class RemoveSystemColumns[MT <: MetaTypes] private (labelProvider: LabelProvider) extends RemoveOutputColumns[MT](labelProvider, _.name.isSystem)
+
+object RemoveSystemColumns {
+  def apply[MT <: MetaTypes](labelProvider: LabelProvider, stmt: Statement[MT]): Statement[MT] = {
+    new RemoveSystemColumns[MT](labelProvider).rewriteStatement(stmt)
+  }
+}

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalysisTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalysisTest.scala
@@ -1438,4 +1438,41 @@ select * where first = 'Tom'
     val expectedAnalysis = analyze(tf, "table", "select text where num > 5")
     analysis.removeSyntheticColumns.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
+
+  test("remove system columns - dataset") {
+    val tf = tableFinder(
+      (0, "table") -> D(
+        ":id" -> TestNumber,
+        "text" -> TestText,
+        "num" -> TestNumber
+      ),
+    )
+
+    val analysis = AnalysisBuilder.saved(tf, "table").finishAnalysis
+
+    // just a sanity check
+    analysis.statement must be (isomorphicTo(analyze(tf, "table", "select :id, text, num").statement))
+
+    val expectedAnalysis = analyze(tf, "table", "select text, num")
+    analysis.removeSystemColumns.statement must be (isomorphicTo(expectedAnalysis.statement))
+  }
+
+  test("remove system columns - query") {
+    val tf = tableFinder(
+      (0, "table") -> D(
+        ":id" -> TestNumber,
+        "text" -> TestText,
+        "num" -> TestNumber
+      ),
+      (0, "query") -> Q(0, "table", "select :id, text")
+    )
+
+    val analysis = AnalysisBuilder.saved(tf, "query").finishAnalysis
+
+    // just a sanity check
+    analysis.statement must be (isomorphicTo(analyze(tf, "table", "select :id, text").statement))
+
+    val expectedAnalysis = analyze(tf, "table", "select text")
+    analysis.removeSystemColumns.statement must be (isomorphicTo(expectedAnalysis.statement))
+  }
 }

--- a/soql-environment/src/main/scala/com/socrata/soql/environment/ColumnName.scala
+++ b/soql-environment/src/main/scala/com/socrata/soql/environment/ColumnName.scala
@@ -4,6 +4,8 @@ import com.rojoma.json.v3.util.{WrapperJsonCodec, WrapperFieldCodec}
 
 final class ColumnName(name: String) extends AbstractName[ColumnName](name) {
   protected def hashCodeSeed = 0x342a3466
+
+  def isSystem = name.startsWith(":")
 }
 
 object ColumnName extends (String => ColumnName) {


### PR DESCRIPTION
Much like "remove synthetic columns", this exists as a rewrite pass so that a subsequent "remove unused columns" pass can do a deeper rewrite.

This factors out the common functionality between those two operations into a common "remove output columns according to a predicate" helper.