### PR TITLE
EN-67656: Fix off-by-one error in Position deserializer

### DIFF
--- a/soql-json-utils/src/main/scala/com/socrata/soql/jsonutils/package.scala
+++ b/soql-json-utils/src/main/scala/com/socrata/soql/jsonutils/package.scala
@@ -36,7 +36,7 @@ package object jsonutils {
           Right(NoPosition)
         case other =>
           pattern.matches(v).map { results =>
-            SoQLPosition(row(results), col(results), text(results), col(results))
+            SoQLPosition(row(results), col(results), text(results), col(results) - 1)
           }
       }
   }


### PR DESCRIPTION
I still want to stop using Position altogether eventually (because it's weird that the JSON serialization of a SoQLPosition loses information) but this is just an off-by-one error and can be fixed.