### PR TITLE
EN-69963: Be less lazy in `squash`

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Typechecker.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Typechecker.scala
@@ -83,7 +83,7 @@ class Typechecker[MT <: MetaTypes](
       }
     }
 
-    Right(acc.valuesIterator.toSeq)
+    Right(acc.valuesIterator.toVector)
   }
 
   private def check(expr: ast.Expression): Either[Error, Seq[Expr]] = {


### PR DESCRIPTION
Squash is used to say "here are a bunch of exprs of possibly different types; for each type, select the most preferable one.  It was producing a Stream unnecessarily which was building up into an enormous force event that overflowed the stack on long argument lists.