### PR TITLE
Delay typechecking of ON clauses

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -842,6 +842,8 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
       override def intoFakeRealFrom = atomicFrom
 
       override def doTypecheckOnClauses(ctx: Ctx, availableSelectList: Map[ColumnName, Expr]) =
+        // This extendEnvironment should not fail, as we already did
+        // this extension once in queryInputSchema.
         (atomicFrom, envify(ctx, extendEnvironment(ctx.enclosingEnv), NoPosition /* TODO: NEED POS INFO FROM AST */))
     }
     case class FakeJoin(joinType: JoinType, lateral: Boolean, left: FakeFrom, right: AtomicFrom, on: ast.Expression) extends FakeFrom {

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -862,8 +862,9 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
         val (realLeft, env0) = left.doTypecheckOnClauses(ctx, nextSelectList)
 
         // Because we're re-building the unitary join environment, we
-        // want to add to the exting scope rather than extending the
-        // environment here.  It has already been extended by the left.
+        // want to add a scope to th existing environment rather than
+        // adding a new sub-environment here.  It has already been
+        // extended by the leftmost part of the join.
         val env = envify(ctx, right.addToEnvironment(env0), NoPosition /* TODO: NEED POS INFO FROM AST */)
 
         val checkedOn =

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/AggregateFunctionCall.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/AggregateFunctionCall.scala
@@ -21,7 +21,7 @@ trait AggregateFunctionCallImpl[MT <: MetaTypes] { this: AggregateFunctionCall[M
 
   val size = 1 + args.iterator.map(_.size).sum + filter.fold(0)(_.size)
 
-  private[analyzer2] def columnReferences: Map[AutoTableLabel, Set[ColumnLabel]] = {
+  private[analyzer2] lazy val columnReferences: Map[AutoTableLabel, Set[ColumnLabel]] = {
     var refs =
       args.foldLeft(Map.empty[AutoTableLabel, Set[ColumnLabel]]) { (acc, arg) =>
         acc.mergeWith(arg.columnReferences)(_ ++ _)

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/FunctionCall.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/FunctionCall.scala
@@ -20,7 +20,7 @@ trait FunctionCallImpl[MT <: MetaTypes] { this: FunctionCall[MT] =>
   val isAggregated = args.exists(_.isAggregated)
   val isWindowed = args.exists(_.isWindowed)
 
-  private[analyzer2] def columnReferences: Map[AutoTableLabel, Set[ColumnLabel]] =
+  private[analyzer2] lazy val columnReferences: Map[AutoTableLabel, Set[ColumnLabel]] =
     args.foldLeft(Map.empty[AutoTableLabel, Set[ColumnLabel]]) { (acc, arg) =>
       acc.mergeWith(arg.columnReferences)(_ ++ _)
     }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/WindowedFunctionCall.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/WindowedFunctionCall.scala
@@ -22,7 +22,7 @@ trait WindowedFunctionCallImpl[MT <: MetaTypes] { this: WindowedFunctionCall[MT]
   val isAggregated = args.exists(_.isAggregated) || partitionBy.exists(_.isAggregated) || orderBy.exists(_.expr.isAggregated)
   def isWindowed = true
 
-  private[analyzer2] def columnReferences: Map[AutoTableLabel, Set[ColumnLabel]] = {
+  private[analyzer2] lazy val columnReferences: Map[AutoTableLabel, Set[ColumnLabel]] = {
     var refs =
       args.foldLeft(Map.empty[AutoTableLabel, Set[ColumnLabel]]) { (acc, arg) =>
         acc.mergeWith(arg.columnReferences)(_ ++ _)


### PR DESCRIPTION
This lets you use select list references in them, as long as the select- list column you're referencing only itself references tables that have been established at the point the ON column exists.

There's still an unfortunate thing here because it would also be nice to do this same sort of thing for LATERAL joins, but that would be a much more major restructuring, since the output of the FROM-clause's typechecking is used as the input to typechecking the select-list, so it becomes circular.  This ON clause change was easy because they don't affect the query's input schema at all, just which rows exist.