### PR TITLE
Old-analyzer/new-analyzer compatibility around joined column aliases

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/SoQLAnalyzer.scala
@@ -445,7 +445,7 @@ class SoQLAnalyzer[Type, Value](typeInfo: TypeInfo[Type, Value],
     val aliasAnalysis = AliasAnalysis(query.selection, query.from)(ctxWithJoins.schemas)
     val t1 = System.nanoTime()
     val typedAliases = aliasAnalysis.evaluationOrder.foldLeft(Map.empty[ColumnName, Expr]) { (acc, alias) =>
-      acc + (alias -> typechecker(aliasAnalysis.expressions(alias), acc, query.from))
+      acc + (alias -> typechecker(aliasAnalysis.expressions(alias).expr, acc, query.from))
     }
 
     val typecheck = typechecker(_ : Expression, typedAliases, query.from)

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -639,6 +639,8 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
         // A bit of old-analyzer compatibility here: In OA, you cannot
         // refer to a qualified column reference by its output name
         // unless that output name was explicitly given to it.
+        //
+        // There are views that depend on this behavior.
         def isQualifiedColumnReference = expression.expr match {
           case ast.ColumnOrAliasRef(Some(_), _) => true
           case _ => false

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLError.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLError.scala
@@ -827,7 +827,7 @@ object SoQLAnalyzerError {
             .append(err.name)
             .append("'")
           if(err.qualifier.isEmpty) {
-            msg.append("  (Note: joined columns must be fully qualified)")
+            msg.append(" (Note: joined columns must be fully qualified)")
           }
           result(Fields(err.qualifier, err.name), msg.toString, err.source)
         }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLError.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLError.scala
@@ -820,8 +820,17 @@ object SoQLAnalyzerError {
 
       implicit def encode[RNS: JsonEncode] = new SoQLErrorEncode[NoSuchColumn[RNS]] {
         override val code = tag
-        def encode(err: NoSuchColumn[RNS]) =
-          result(Fields(err.qualifier, err.name), s"No such column `${err.qualifier.fold("")("@" + _ + ".")}${err.name}'", err.source)
+        def encode(err: NoSuchColumn[RNS]) = {
+          val msg = new StringBuilder
+          msg.append("No such column `")
+            .append(err.qualifier.fold("")("@" + _ + "."))
+            .append(err.name)
+            .append("'")
+          if(err.qualifier.isEmpty) {
+            msg.append("  (Note: joined columns must be fully qualified)")
+          }
+          result(Fields(err.qualifier, err.name), msg.toString, err.source)
+        }
       }
 
       implicit def decode[RNS: JsonDecode] = new SoQLErrorDecode[NoSuchColumn[RNS]] {

--- a/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/SoQLAnalyzerTest.scala
@@ -811,12 +811,11 @@ SELECT visits, @x2.zx
   }
 
   test("no_chain_merge work in join subanalysis") {
-    val analysis1 = analyzer.analyzeFullQueryBinary(
-      """SELECT name_first,name_last |>
-           SELECT name_last JOIN (SELECT name_last FROM @aaaa-aaaa |> select name_last) as a1 ON name_last = @a1.name_last""")
-    val analysis2 = analyzer.analyzeFullQueryBinary("""SELECT name_last JOIN (SELECT name_last FROM @aaaa-aaaa) as a1 ON name_last = @a1.name_last""")
-    val merged = SoQLAnalysis.merge(TestFunctions.And.monomorphic.get, analysis1)
-    merged must equal (analysis2)
+    val analysis = analyzer.analyzeFullQueryBinary(
+      """SELECT hint(no_chain_merge) name_first,name_last |>
+           SELECT name_last JOIN (SELECT name_last FROM @aaaa-aaaa |> SELECT hint(no_chain_merge) distinct name_last) as a1 ON name_last = @a1.name_last""")
+    val merged = SoQLAnalysis.merge(TestFunctions.And.monomorphic.get, analysis)
+    merged must equal (analysis)
   }
 
   test("Cannot reference a non-explicitly-aliased foreign column") {


### PR DESCRIPTION
In the OA, you weren't allowed to reference semi-explicitly aliased foreign columns in other parts of the query, more or less accidentally. The NA allowed it.  This change makes the NA behavior closer to the OA behavior here.