### PR TITLE
Better "no such column" error.

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Levenshtein.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Levenshtein.scala
@@ -1,0 +1,60 @@
+// This is adapted/ ported from the levenshtein distance
+// implementation in commons-text, which like this library is licensed
+// under Apache-2.0.
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.socrata.soql.analyzer2
+
+private[analyzer2] object Levenshtein {
+  def apply(a: String, b: String): Int = {
+    if (a.length == 0) {
+      return b.length
+    }
+    if (b.length == 0) {
+      return a.length
+    }
+    val (left, right) = if(a.length <= b.length) {
+      (a, b)
+    } else {
+      (b, a)
+    }
+    val n = left.length
+    val m = right.length
+
+    val p = new Array[Int](n + 1);
+    for(i <- 0 until p.length) {
+      p(i) = i
+    }
+
+    for(j <- 1 to m) {
+      var upperLeft = p(0);
+      val rightJ = right.charAt(j - 1);
+      p(0) = j;
+
+      for(i <- 1 to n) {
+        val upper = p(i);
+        val cost = if(left.charAt(i - 1) == rightJ) 0 else 1;
+        // minimum of cell to the left+1, to the top+1, diagonally left and up +cost
+        p(i) = Math.min(Math.min(p(i - 1) + 1, p(i) + 1), upperLeft + cost);
+        upperLeft = upper;
+      }
+    }
+    return p(n);
+  }
+}

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -436,8 +436,8 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
           case SE.DuplicateAlias(name, pos) =>
             error(Error.AliasAnalysisError.DuplicateAlias(Source.nonSynthetic(scopedResourceName, pos), name))
           case nsc@SE.NoSuchColumn(name, pos) =>
-            val qual = nsc.asInstanceOf[SE.NoSuchColumn.RealNoSuchColumn].qualifier // ew
-            error(Error.TypecheckError.NoSuchColumn(Source.nonSynthetic(scopedResourceName, pos), qual.map(_.substring(1)).map(ResourceName(_)), name))
+            val qual = nsc.asInstanceOf[SE.NoSuchColumn.RealNoSuchColumn].qualifier.map(_.substring(1)).map(ResourceName(_)) // ew
+            error(Error.TypecheckError.NoSuchColumn(Source.nonSynthetic(scopedResourceName, pos), qual, name, Util.possibilitiesFor(enclosingEnv, Iterator.empty, qual, name)))
           case SE.NoSuchTable(_, _) =>
             throw new Exception("Alias analysis doesn't actually throw NoSuchTable")
         }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Typechecker.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Typechecker.scala
@@ -156,7 +156,7 @@ class Typechecker[MT <: MetaTypes](
             Right(Seq(prechecked.reReference(Source.nonSynthetic(sourceName, col.position))))
           case None =>
             env.lookup(name) match {
-              case None => Left(NoSuchColumn(Source.nonSynthetic(sourceName, col.position), None, name))
+              case None => Left(NoSuchColumn(Source.nonSynthetic(sourceName, col.position), None, name, Util.possibilitiesFor(env, namedExprs.keysIterator, None, name)))
               case Some(Environment.LookupResult.Virtual(table, column, typ)) =>
                 Right(Seq(VirtualColumn(table, column, typ)(new AtomicPositionInfo(Source.nonSynthetic(sourceName, col.position)))))
               case Some(Environment.LookupResult.Physical(tableName, tableLabel, column, typ)) =>
@@ -166,7 +166,7 @@ class Typechecker[MT <: MetaTypes](
       case col@ast.ColumnOrAliasRef(Some(qual), name) =>
         val trueQual = ResourceName(qual.substring(TableName.PrefixIndex))
         env.lookup(trueQual, name) match {
-          case None => Left(NoSuchColumn(Source.nonSynthetic(sourceName, col.position), Some(trueQual), name))
+          case None => Left(NoSuchColumn(Source.nonSynthetic(sourceName, col.position), Some(trueQual), name, Util.possibilitiesFor(env, namedExprs.keysIterator, Some(trueQual), name)))
           case Some(Environment.LookupResult.Virtual(table, column, typ)) =>
             Right(Seq(VirtualColumn(table, column, typ)(new AtomicPositionInfo(Source.nonSynthetic(sourceName, col.position)))))
           case Some(Environment.LookupResult.Physical(tableName, tableLabel, column, typ)) =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Util.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Util.scala
@@ -1,8 +1,10 @@
 package com.socrata.soql.analyzer2
 
 import com.socrata.soql.ast
-import com.socrata.soql.environment.{ResourceName, ScopedResourceName, TableName}
+import com.socrata.soql.environment.{ColumnName, ResourceName, ScopedResourceName, TableName}
 import com.socrata.soql.{BinaryTree, Leaf, Compound}
+
+import SoQLAnalyzerError.TypecheckError.NoSuchColumn
 
 private[analyzer2] object Util {
   def walkParsed[MT <: MetaTypes](acc: Set[types.ScopedResourceName[MT]], scope: types.ResourceNameScope[MT], parsed: BinaryTree[ast.Select]): Set[types.ScopedResourceName[MT]] =
@@ -30,4 +32,27 @@ private[analyzer2] object Util {
     val prefixedName = TableName.SodaFountainPrefix + name.caseFolded
     TableName.reservedNames.contains(prefixedName)
   }
+
+  private def closeEnough(a: String, b: String): Boolean =
+    Levenshtein(a, b) < 3
+
+  private def closeEnough(a: Option[String], b: Option[String]): Boolean =
+    (a, b) match {
+      case (None, None) => true
+      case (Some(a), Some(b)) => closeEnough(a, b)
+      case _ => false
+    }
+
+  def possibilitiesFor(env: Environment[_], additionalNames: Iterator[ColumnName], qual: Option[ResourceName], name: ColumnName): Seq[NoSuchColumn.ColumnCandidate] = {
+    val candidates =
+      for {
+        (tableName, columnName) <- additionalNames.map((None, _)) ++ env.contents
+        if closeEnough(qual.map(_.caseFolded), tableName.map(_.caseFolded)) || // qualifiers match, or
+           (qual.isEmpty && tableName.isDefined)                               // the user provided no qualifier but the candidate has one
+        if closeEnough(columnName.caseFolded, name.caseFolded)
+      } yield NoSuchColumn.ColumnCandidate(tableName, columnName)
+
+    candidates.toVector.distinct
+  }
+
 }

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
@@ -29,7 +29,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     val Right(start) = tf.findTables(0, "select @bleh.whatever from @single_row", Map.empty)
     analyzer(start, UserParameters.empty) match {
       case Right(_) => fail("Expected an error")
-      case Left(SoQLAnalyzerError.TypecheckError.NoSuchColumn(Source.Anonymous(Pos(1, 8)), qualifier, name)) =>
+      case Left(SoQLAnalyzerError.TypecheckError.NoSuchColumn(Source.Anonymous(Pos(1, 8)), qualifier, name, _)) =>
         qualifier must be (Some(rn("bleh")))
         name must be (cn("whatever"))
       case Left(err) =>
@@ -756,7 +756,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
       analyze(tf, "aaaa-aaaa", "select @bbbb-bbbb.x join @bbbb-bbbb on true where x = 5")(new OnFail {
         override def onAnalyzerError(e: SoQLAnalyzerError[Int]): Nothing = {
           e match {
-            case SoQLAnalyzerError.TypecheckError.NoSuchColumn(Source.Anonymous(Pos(1, 51)), None, c) if c == cn("x") =>
+            case SoQLAnalyzerError.TypecheckError.NoSuchColumn(Source.Anonymous(Pos(1, 51)), None, c, _) if c == cn("x") =>
               expected(0)
             case _ =>
               super.onAnalyzerError(e)
@@ -1357,7 +1357,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
 
     val Right(ft) = tf.findTables(0, rn("ds1"), "select @ds3.gnus + num as t join @ds2 on t = @ds2.world join @ds3 on true", Map.empty)
-    val Left(SoQLAnalyzerError.TypecheckError.NoSuchColumn(_, None, badColName)) = analyzer(ft, UserParameters.empty)
+    val Left(SoQLAnalyzerError.TypecheckError.NoSuchColumn(_, None, badColName, _)) = analyzer(ft, UserParameters.empty)
     badColName must equal(cn("t"))
   }
 }


### PR DESCRIPTION
When we can't find a column, go through the names that are available and if it's "close enough" as measured by Levenshtein distance plus a heuristic around qualifier-absence, report it as a possibility.