### PR TITLE
Include comments in the lexer stream

### DIFF
--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/RecursiveDescentParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/RecursiveDescentParser.scala
@@ -406,7 +406,7 @@ abstract class RecursiveDescentParser(parameters: AbstractParser.Parameters = Ab
   }
 
   protected final def parseFull[T](parser: Reader => ParseResult[T], soql: String): T = {
-    val ParseResult(end, result) = parser(new LexerReader(lexer(soql)))
+    val ParseResult(end, result) = parser(new LexerReader(lexer(soql)).withoutComments)
     if(end.first.isInstanceOf[EOF]) {
       result
     } else {

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/tokens/Tokens.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/tokens/Tokens.scala
@@ -20,6 +20,12 @@ sealed abstract class ValueToken[T] extends Token {
   override def printable = value.toString
 }
 
+// Comments - note the positions are the position of the start of the
+// comment, but the string only contains the text of the comment.
+sealed abstract class Comment extends Token
+case class LineComment(text: String) extends Comment
+case class BlockComment(text: String) extends Comment
+
 // Keywords
 case class SELECT() extends Token
 case class DISTINCT() extends Token


### PR DESCRIPTION
The parser strips them out, but this means we don't forget about them _entirely_ early on.