### PR TITLE
EN-81036: Remove PK-sets that contain hidden columns

### DIFF
--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
@@ -1418,4 +1418,19 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
 
     from.lateral must be (true)
   }
+
+  test("Hidden columns get removed from primary-key sets during analysis") {
+    val tf = tableFinder(
+      (0, "ds1") -> D(":id" -> TestNumber, "text" -> TestText, "num" -> TestNumber).withHiddenColumns("text").withPrimaryKey(":id").withPrimaryKey("text")
+    )
+
+    val Right(ft) = tf.findTables(0, rn("ds1"), "select *", Map.empty)
+    val Right(analysis) = analyzer(ft, UserParameters.empty)
+
+    val select = analysis.statement.asInstanceOf[Select[TestMT]]
+    val fromTable = select.from.asInstanceOf[FromTable[TestMT]]
+
+    fromTable.primaryKeys must be (Seq(Seq(DatabaseColumnName(":id"))))
+  }
+
 }


### PR DESCRIPTION
When we remove hidden columns from tables, we need to also consider any PK column group which contains such a column as no longer being a valid PK.  Otherwise later on we can crash when we assume that the pk list always contains lists of real column