### PR TITLE
EN-82509: Make the merger even more explicit about aggregatedness

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/Merger.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/Merger.scala
@@ -168,7 +168,7 @@ class Merger[MT <: MetaTypes](and: MonomorphicFunction[MT#ColumnType]) extends S
           ).filter(_.isAggregated == a.isAggregated)
 
         case (a@Select(_aDistinct, aSelect, aFrom, aWhere, Nil, None, aOrder, None, None, None, aHint),
-              b@Select(bDistinct, bSelect, _oldA, bWhere, Nil, None, bOrder, bLim, bOff, None, bHint)) if !b.isAggregated =>
+              b@Select(bDistinct, bSelect, _oldA, bWhere, Nil, None, bOrder, bLim, bOff, None, bHint)) if !a.isAggregated && !b.isAggregated =>
           debug("non-aggregate on non-aggregate")
           val selectList = mergeSelection(aLabel, a.selectedExprs, bSelect)
           Some(a.copy(
@@ -183,7 +183,7 @@ class Merger[MT <: MetaTypes](and: MonomorphicFunction[MT#ColumnType]) extends S
                ))
 
         case (a@Select(_aDistinct, aSelect, aFrom, aWhere, Nil, None, _aOrder, None, None, None, aHint),
-              b@Select(bDistinct, bSelect, _oldA, bWhere, bGroup, bHaving, bOrder, bLim, bOff, None, bHint)) if b.isAggregated =>
+              b@Select(bDistinct, bSelect, _oldA, bWhere, bGroup, bHaving, bOrder, bLim, bOff, None, bHint)) if !a.isAggregated && b.isAggregated =>
           debug("aggregate on non-aggregate")
           Some(Select(
                  distinctiveness = mergeDistinct(aLabel, a.selectedExprs, bDistinct),
@@ -199,7 +199,7 @@ class Merger[MT <: MetaTypes](and: MonomorphicFunction[MT#ColumnType]) extends S
                  hint = aHint ++ bHint))
 
         case (a@Select(_aDistinct, aSelect, aFrom, aWhere, aGroup, aHaving, aOrder, None, None, None, aHint),
-              b@Select(bDistinct, bSelect, _oldA, bWhere, Nil, None, bOrder, bLim, bOff, None, bHint)) if a.isAggregated =>
+              b@Select(bDistinct, bSelect, _oldA, bWhere, Nil, None, bOrder, bLim, bOff, None, bHint)) if a.isAggregated && !b.isAggregated =>
           debug("non-aggregate on aggregate")
           Some(
             Select(

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalysisTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalysisTest.scala
@@ -399,6 +399,22 @@ select a |> select a |> select a
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
+  test("merge - non-simple non-aggregate on implicit aggregate") {
+    val tf = tableFinder(
+      (0, "twocol") -> D("text" -> TestText, "num" -> TestNumber)
+    )
+
+    val analysis = analyze(tf, "twocol", """
+select count(*) |> select 2 as s order by s -- the order-by forces "non-simple"
+""")
+
+    val expectedAnalysis = analyze(tf, "twocol", """
+select count(*) |> select 2 as s order by s
+""")
+
+    analysis.merge(and).statement must be (isomorphicTo(expectedAnalysis.statement))
+  }
+
   test("remove unused columns - simple") {
     val tf = tableFinder(
       (0, "twocol") -> D("text" -> TestText, "num" -> TestNumber)


### PR DESCRIPTION
Instead of trusting an empty group by to imply it, because that's just wrong.