### PR TITLE
Take parsimony into account when typechecking

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Expression.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Expression.scala
@@ -28,6 +28,7 @@ sealed abstract class Expr[MT <: MetaTypes] extends Product with LabelUniverse[M
   val position: PositionInfo
 
   val size: Int
+  val distinctTypes: Set[CT]
 
   def isAggregated: Boolean
   def isWindowed: Boolean
@@ -116,6 +117,8 @@ object Expr {
 
 sealed abstract class AtomicExpr[MT <: MetaTypes] extends Expr[MT] with Product { this: HashedExpr =>
   type Self[MT <: MetaTypes] <: AtomicExpr[MT]
+
+  lazy val distinctTypes = Set(typ)
 
   override val position: AtomicPositionInfo
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Typechecker.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Typechecker.scala
@@ -76,8 +76,10 @@ class Typechecker[MT <: MetaTypes](
 
     for { e <- exprs } {
       acc.get(e.typ) match {
-        case Some(e2) if e2.size <= e.size =>
+        case Some(e2) if e2.size < e.size =>
           // the smaller (or at least most-preferred) is already chosen
+        case Some(e2) if e2.size == e.size && e2.distinctTypes.size <= e.distinctTypes.size =>
+          // the most parsimonious (or at least most-preferred) is already chosen
         case Some(_) | None =>
           acc += e.typ -> e
       }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/AggregateFunctionCall.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/AggregateFunctionCall.scala
@@ -53,6 +53,10 @@ trait AggregateFunctionCallImpl[MT <: MetaTypes] { this: AggregateFunctionCall[M
         false
     }
 
+  lazy val distinctTypes =
+    args.foldLeft(Set(typ)) { (acc, arg) => acc ++ arg.distinctTypes } ++
+      filter.foldLeft(Set.empty[CT]) { (acc, f) => acc ++ f.distinctTypes }
+
   private[analyzer2] def doRewriteDatabaseNames[MT2 <: MetaTypes](state: RewriteDatabaseNamesState[MT2]): Self[MT2] =
     AggregateFunctionCall(
       function = state.changesOnlyLabels.convertCTOnly(function),

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/FunctionCall.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/FunctionCall.scala
@@ -40,6 +40,9 @@ trait FunctionCallImpl[MT <: MetaTypes] { this: FunctionCall[MT] =>
         false
     }
 
+  lazy val distinctTypes =
+    args.foldLeft(Set(typ)) { (acc, arg) => acc ++ arg.distinctTypes }
+
   private[analyzer2] def doRewriteDatabaseNames[MT2 <: MetaTypes](state: RewriteDatabaseNamesState[MT2]) =
     this.copy(
       function = state.changesOnlyLabels.convertCTOnly(function),

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/WindowedFunctionCall.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/expression/WindowedFunctionCall.scala
@@ -67,6 +67,12 @@ trait WindowedFunctionCallImpl[MT <: MetaTypes] { this: WindowedFunctionCall[MT]
         false
     }
 
+  lazy val distinctTypes =
+    args.foldLeft(Set(typ)) { (acc, arg) => acc ++ arg.distinctTypes } ++
+      filter.foldLeft(Set.empty[CT]) { (acc, f) => acc ++ f.distinctTypes } ++
+      partitionBy.foldLeft(Set.empty[CT]) { (acc, pb) => acc ++ pb.distinctTypes } ++
+      orderBy.foldLeft(Set.empty[CT]) { (acc, ob) => acc ++ ob.expr.distinctTypes }
+
   private[analyzer2] def doRewriteDatabaseNames[MT2 <: MetaTypes](state: RewriteDatabaseNamesState[MT2]) =
     copy[MT2](
       function = state.changesOnlyLabels.convertCTOnly(function),


### PR DESCRIPTION
Specifically because of the cast-null-to-some-type case: `LiteralNull(text) :: text` and `LiteralNull(something_else) :: text` are the same _size_ but the former is more _parsimonious_ and should be preferred.