### PR TITLE
Add a column to the generated FromSingleRow selection

### DIFF
--- a/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/Sqlizer.scala
+++ b/soql-sqlizer/src/main/scala/com/socrata/soql/sqlizer/Sqlizer.scala
@@ -656,7 +656,7 @@ class Sqlizer[MT <: MetaTypes with MetaTypesExt](
           (d"(" ++ sql ++ d")", schema)
 
         case FromSingleRow(_label, _alias) =>
-          (d"(SELECT)", OrderedMap.empty)
+          (d"(SELECT 1)", OrderedMap.empty)
 
         case FromCTE(cteLabel, _label, _basedOn, _rn, _cn, _alias) =>
           (namespace.cteLabel(cteLabel), availableSchemas.potential(cteLabel))


### PR DESCRIPTION
We already ensure there's at least one selected column in cases where we're just not selecting anything, but this case was missed.