### PR TITLE
EN-93632: Wrapping queries in the TableFinder and SoQLAnalyzer

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/FoundTablesTableFinder.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/FoundTablesTableFinder.scala
@@ -21,7 +21,7 @@ class FoundTablesTableFinder[MT <: MetaTypes](foundTables: UnparsedFoundTables[M
               },
               ds.primaryKeys,
               ds.wrappingQuery.map { wq =>
-                WrappingQuery(wq.scope, wq.soql, wq.parameters)
+                WrappingQuery(wq.scope, wq.soql)
               }
             )
             foundDataset(name, converted)
@@ -35,7 +35,7 @@ class FoundTablesTableFinder[MT <: MetaTypes](foundTables: UnparsedFoundTables[M
               q.hiddenColumns,
               q.outputColumnHints,
               q.wrappingQuery.map { wq =>
-                WrappingQuery(wq.scope, wq.soql, wq.parameters)
+                WrappingQuery(wq.scope, wq.soql)
               }
             )
             foundQuery(name, converted)
@@ -47,7 +47,7 @@ class FoundTablesTableFinder[MT <: MetaTypes](foundTables: UnparsedFoundTables[M
               tf.parameters,
               tf.hiddenColumns,
               tf.wrappingQuery.map { wq =>
-                WrappingQuery(wq.scope, wq.soql, wq.parameters)
+                WrappingQuery(wq.scope, wq.soql)
               }
             )
             foundTableFunction(name, converted)

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/FoundTablesTableFinder.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/FoundTablesTableFinder.scala
@@ -19,7 +19,10 @@ class FoundTablesTableFinder[MT <: MetaTypes](foundTables: UnparsedFoundTables[M
               ds.ordering.map { ord =>
                 Ordering(ord.column, ord.ascending, ord.nullLast)
               },
-              ds.primaryKeys
+              ds.primaryKeys,
+              ds.wrappingQuery.map { wq =>
+                WrappingQuery(wq.scope, wq.soql, wq.parameters)
+              }
             )
             foundDataset(name, converted)
           case q: UnparsedTableDescription.Query[MT] =>
@@ -30,7 +33,10 @@ class FoundTablesTableFinder[MT <: MetaTypes](foundTables: UnparsedFoundTables[M
               q.soql,
               q.parameters,
               q.hiddenColumns,
-              q.outputColumnHints
+              q.outputColumnHints,
+              q.wrappingQuery.map { wq =>
+                WrappingQuery(wq.scope, wq.soql, wq.parameters)
+              }
             )
             foundQuery(name, converted)
           case tf: UnparsedTableDescription.TableFunction[MT] =>
@@ -39,7 +45,10 @@ class FoundTablesTableFinder[MT <: MetaTypes](foundTables: UnparsedFoundTables[M
               tf.canonicalName,
               tf.soql,
               tf.parameters,
-              tf.hiddenColumns
+              tf.hiddenColumns,
+              tf.wrappingQuery.map { wq =>
+                WrappingQuery(wq.scope, wq.soql, wq.parameters)
+              }
             )
             foundTableFunction(name, converted)
         }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/From.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/From.scala
@@ -9,7 +9,7 @@ import com.rojoma.json.v3.ast.JValue
 import com.socrata.prettyprint.prelude._
 
 import com.socrata.soql.collection._
-import com.socrata.soql.environment.ResourceName
+import com.socrata.soql.environment.{ResourceName, ColumnName}
 import com.socrata.soql.functions.MonomorphicFunction
 import com.socrata.soql.serialize.{Readable, ReadBuffer, Writable, WriteBuffer}
 import com.socrata.soql.analyzer2
@@ -153,6 +153,7 @@ object From {
   case class SchemaEntry[MT <: MetaTypes](
     table: AutoTableLabel,
     column: types.ColumnLabel[MT],
+    name: ColumnName,
     typ: types.ColumnType[MT],
     hint: Option[JValue],
     isSynthetic: Boolean

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/MockTableFinder.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/MockTableFinder.scala
@@ -26,9 +26,10 @@ object OptionalBoolean {
 
 sealed abstract class Thing[+RNS, +CT] {
   def canonicalName: Option[String]
+  def withWrappingQuery[RNS2 >: RNS, CT2 >: CT](scope: RNS2, soql: String): Thing[RNS2, CT2]
 }
 
-case class MockWrappingQuery[+RNS, +CT](scope: RNS, soql: String, params: Map[String, CT])
+case class MockWrappingQuery[+RNS, +CT](scope: RNS, soql: String)
 
 case class D[+RNS, +CT](schema: (String, CT)*) extends Thing[RNS, CT] { self =>
   private var canonicalName_ : Option[String] = None
@@ -95,9 +96,13 @@ case class D[+RNS, +CT](schema: (String, CT)*) extends Thing[RNS, CT] { self =>
   }
   def outputColumnHints = outputColumnHints_
 
-  def withWrappingQuery[RNS2 >: RNS, CT2 >: CT](scope: RNS2, soql: String, params: (String, CT2)*): D[RNS2, CT2] = {
+  def withWrappingQuery[RNS2 >: RNS, CT2 >: CT](scope: RNS2, soql: String): D[RNS2, CT2] = {
+    // otherwise these can be shadowed by the subclass
+    val wqScope = scope
+    val wqSoql = soql
+
     val result = new D[RNS2, CT2](this.schema : _*) {
-      override val wrappingQuery = Some(MockWrappingQuery(scope, soql, params.toMap))
+      override val wrappingQuery = Some(MockWrappingQuery(wqScope, wqSoql))
     }
     result.copyVars(this)
     result
@@ -148,9 +153,13 @@ case class Q[+RNS, +CT](scope: RNS, parent: String, soql: String, params: (Strin
   }
   def outputColumnHints = outputColumnHints_
 
-  def withWrappingQuery[RNS2 >: RNS, CT2 >: CT](scope: RNS2, soql: String, params: (String, CT2)*): Q[RNS2, CT2] = {
+  def withWrappingQuery[RNS2 >: RNS, CT2 >: CT](scope: RNS2, soql: String): Q[RNS2, CT2] = {
+    // otherwise these can be shadowed by the subclass
+    val wqScope = scope
+    val wqSoql = soql
+
     val result = new Q[RNS2, CT2](this.scope, this.parent, this.soql, this.params : _*) {
-      override val wrappingQuery = Some(MockWrappingQuery(scope, soql, params.toMap))
+      override val wrappingQuery = Some(MockWrappingQuery(wqScope, wqSoql))
     }
     result.copyVars(this)
     result
@@ -189,9 +198,13 @@ case class U[+RNS, +CT](scope: RNS, soql: String, params: (String, CT)*) extends
   }
   def hiddenColumns = hiddenColumns_
 
-  def withWrappingQuery[RNS2 >: RNS, CT2 >: CT](scope: RNS2, soql: String, params: (String, CT2)*): U[RNS2, CT2] = {
+  def withWrappingQuery[RNS2 >: RNS, CT2 >: CT](scope: RNS2, soql: String): U[RNS2, CT2] = {
+    // otherwise these can be shadowed by the subclass
+    val wqScope = scope
+    val wqSoql = soql
+
     val result = new U[RNS2, CT2](this.scope, this.soql, this.params : _*) {
-      override val wrappingQuery = Some(MockWrappingQuery(scope, soql, params.toMap))
+      override val wrappingQuery = Some(MockWrappingQuery(wqScope, wqSoql))
     }
     result.copyVars(this)
     result
@@ -204,16 +217,16 @@ object MockTableFinder {
   def apply[MT <: MetaTypes](items: UnparsedFoundTables[MT])(implicit dtnIsString: String =:= MT#DatabaseTableNameImpl, dcnIsString: String =:= MT#DatabaseColumnNameImpl) = UnparsedTableMap.asMockTableFinder(items.tableMap)
   def apply[MT <: MetaTypes](items: FoundTables[MT])(implicit dtnIsString: String =:= MT#DatabaseTableNameImpl, dcnIsString: String =:= MT#DatabaseColumnNameImpl): MockTableFinder[MT] = this(items.asUnparsedFoundTables)
 
-  private case class JWQ[+RNS,+CT](scope: Option[RNS], soql: String, params: Map[String, CT])
+  private case class JWQ[+RNS](scope: Option[RNS], soql: String)
 
   private sealed abstract class JThing[+RNS, +CT]
-  private case class JD[+RNS, +CT](schema: Seq[(String, CT)], canonicalName: Option[String], orderings: Option[Seq[(String, Boolean, Boolean)]], hiddenColumns: Option[Seq[String]], primaryKeys: Option[Seq[Seq[String]]], wrappingQuery: Option[JWQ[RNS, CT]]) extends JThing[RNS, CT]
-  private case class JQ[+RNS,+CT](scope: Option[RNS], parent: String, soql: String, params: Map[String, CT], canonicalName: Option[String], hiddenColumns: Option[Seq[String]], wrappingQuery: Option[JWQ[RNS, CT]]) extends JThing[RNS, CT]
-  private case class JU[+RNS,+CT](scope: Option[RNS], soql: String, params: Seq[(String, CT)], canonicalName: Option[String], hiddenColumns: Option[Seq[String]], wrappingQuery: Option[JWQ[RNS, CT]]) extends JThing[RNS, CT]
+  private case class JD[+RNS, +CT](schema: Seq[(String, CT)], canonicalName: Option[String], orderings: Option[Seq[(String, Boolean, Boolean)]], hiddenColumns: Option[Seq[String]], primaryKeys: Option[Seq[Seq[String]]], wrappingQuery: Option[JWQ[RNS]]) extends JThing[RNS, CT]
+  private case class JQ[+RNS,+CT](scope: Option[RNS], parent: String, soql: String, params: Map[String, CT], canonicalName: Option[String], hiddenColumns: Option[Seq[String]], wrappingQuery: Option[JWQ[RNS]]) extends JThing[RNS, CT]
+  private case class JU[+RNS,+CT](scope: Option[RNS], soql: String, params: Seq[(String, CT)], canonicalName: Option[String], hiddenColumns: Option[Seq[String]], wrappingQuery: Option[JWQ[RNS]]) extends JThing[RNS, CT]
 
   implicit def jDecode[MT <: MetaTypes](implicit rnsFieldDecode: FieldDecode[MT#ResourceNameScope], rnsDecode: JsonDecode[MT#ResourceNameScope], ctDecode: JsonDecode[MT#ColumnType], dtnIsString: String =:= MT#DatabaseTableNameImpl, dcnIsString: String =:= MT#DatabaseColumnNameImpl): JsonDecode[MockTableFinder[MT]] =
     new JsonDecode[MockTableFinder[MT]] with MetaTypeHelper[MT] {
-      private implicit val jwqDecode = AutomaticJsonDecodeBuilder[JWQ[RNS, CT]]
+      private implicit val jwqDecode = AutomaticJsonDecodeBuilder[JWQ[RNS]]
 
       private implicit val jdDecode = AutomaticJsonDecodeBuilder[JD[RNS, CT]]
       private implicit val jqDecode = AutomaticJsonDecodeBuilder[JQ[RNS, CT]]
@@ -244,21 +257,21 @@ object MockTableFinder {
                         }.withHiddenColumns(hiddenColumns.getOrElse(Nil) : _*)
                       ) { (dataset, pk) => dataset.withPrimaryKey(pk: _*) }
                     ) { (ds, jwq) =>
-                      ds.withWrappingQuery(jwq.scope.getOrElse(rns), jwq.soql, jwq.params.toSeq : _*)
+                      ds.withWrappingQuery(jwq.scope.getOrElse(rns), jwq.soql)
                     }
                   case JQ(scopeOpt, parent, soql, params, cname, hiddenColumns, wq) =>
                     val result = Q(scopeOpt.getOrElse(rns), parent, soql, params.toSeq : _*)
                     wq.foldLeft(
                       cname.fold(result)(result.withCanonicalName).withHiddenColumns(hiddenColumns.getOrElse(Nil) : _*)
                     ) { (q, jwq) =>
-                      q.withWrappingQuery(jwq.scope.getOrElse(rns), jwq.soql, jwq.params.toSeq : _*)
+                      q.withWrappingQuery(jwq.scope.getOrElse(rns), jwq.soql)
                     }
                   case JU(scopeOpt, soql, params, cname, hiddenColumns, wq) =>
                     val result = U(scopeOpt.getOrElse(rns), soql, params : _*)
                     wq.foldLeft(
                       cname.fold(result)(result.withCanonicalName).withHiddenColumns(hiddenColumns.getOrElse(Nil) : _*)
                     ) { (u, jwq) =>
-                      u.withWrappingQuery(jwq.scope.getOrElse(rns), jwq.soql, jwq.params.toSeq : _*)
+                      u.withWrappingQuery(jwq.scope.getOrElse(rns), jwq.soql)
                     }
                 }
 
@@ -271,7 +284,7 @@ object MockTableFinder {
 
   implicit def jEncode[MT <: MetaTypes](implicit rnsFieldEncode: FieldEncode[MT#ResourceNameScope], rnsEncode: JsonEncode[MT#ResourceNameScope], ctEncode: JsonEncode[MT#ColumnType]): JsonEncode[MockTableFinder[MT]] =
     new JsonEncode[MockTableFinder[MT]] with MetaTypeHelper[MT] {
-      private implicit val jwqEncode = AutomaticJsonEncodeBuilder[JWQ[RNS, CT]]
+      private implicit val jwqEncode = AutomaticJsonEncodeBuilder[JWQ[RNS]]
 
       private implicit val jdEncode = AutomaticJsonEncodeBuilder[JD[RNS, CT]]
       private implicit val jqEncode = AutomaticJsonEncodeBuilder[JQ[RNS, CT]]
@@ -300,7 +313,7 @@ object MockTableFinder {
                         Some(d.hiddenColumns.toSeq).filter(_.nonEmpty),
                         Some(d.primaryKeys).filter(_.nonEmpty),
                         d.wrappingQuery.map { wq =>
-                          JWQ[RNS, CT](Some(wq.scope).filter(_ != rns), wq.soql, wq.params.toMap)
+                          JWQ[RNS](Some(wq.scope).filter(_ != rns), wq.soql)
                         }
                       )
                     case q@Q(scope, parent, soql, params@_*) =>
@@ -312,7 +325,7 @@ object MockTableFinder {
                         q.canonicalName.filter(_ != name),
                         Some(q.hiddenColumns.map(_.name).toSeq).filter(_.nonEmpty),
                         q.wrappingQuery.map { wq =>
-                          JWQ[RNS, CT](Some(wq.scope).filter(_ != rns), wq.soql, wq.params.toMap)
+                          JWQ[RNS](Some(wq.scope).filter(_ != rns), wq.soql)
                         }
                       )
                     case u@U(scope, soql, params@_*) =>
@@ -323,7 +336,7 @@ object MockTableFinder {
                         u.canonicalName.filter(_ != name),
                         Some(u.hiddenColumns.map(_.name).toSeq).filter(_.nonEmpty),
                         u.wrappingQuery.map { wq =>
-                          JWQ[RNS, CT](Some(wq.scope).filter(_ != rns), wq.soql, wq.params.toMap)
+                          JWQ[RNS](Some(wq.scope).filter(_ != rns), wq.soql)
                         }
                       )
                   }
@@ -339,7 +352,7 @@ object MockTableFinder {
 class MockTableFinder[MT <: MetaTypes](private val raw: OrderedMap[(MT#ResourceNameScope, String), Thing[MT#ResourceNameScope, MT#ColumnType]])(implicit dtnIsString: String =:= MT#DatabaseTableNameImpl, dcnIsString: String =:= MT#DatabaseColumnNameImpl) extends TableFinder[MT] {
 
   private def toTableFinder(wq: MockWrappingQuery[ResourceNameScope, ColumnType]): WrappingQuery =
-    WrappingQuery(wq.scope, wq.soql, wq.params.iterator.map { case (name, typ) => HoleName(name) -> typ }.toMap)
+    WrappingQuery(wq.scope, wq.soql)
 
   private val tables: Map[ScopedResourceName, FinderTableDescription] = locally {
     // canonical names need to be unique within the whole tablefinder

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/MockTableFinder.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/MockTableFinder.scala
@@ -323,12 +323,15 @@ class MockTableFinder[MT <: MetaTypes](private val raw: OrderedMap[(MT#ResourceN
         TableDescription.Query[MT](
           scope, canonicalName, parent,
           ParserUtil.parseWithoutContext(soql, parserParameters.copy(allowHoles = false)).getOrElse(throw new Exception("broken soql fixture 1")),
-          soql, params, hiddenColumns, outputColumnHints)
+          soql, params, hiddenColumns, outputColumnHints,
+          None
+        )
       case TableFunction(scope, canonicalName, soql, params, hiddenColumns) =>
         TableDescription.TableFunction[MT](
           scope, canonicalName,
           ParserUtil.parseWithoutContext(soql, parserParameters.copy(allowHoles = true)).getOrElse(throw new Exception("broken soql fixture 2")),
-          soql, params, hiddenColumns
+          soql, params, hiddenColumns,
+          None
         )
     }
   }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/MockTableFinder.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/MockTableFinder.scala
@@ -27,14 +27,21 @@ object OptionalBoolean {
 sealed abstract class Thing[+RNS, +CT] {
   def canonicalName: Option[String]
 }
-case class D[+CT](schema: (String, CT)*) extends Thing[Nothing, CT] {
+
+case class MockWrappingQuery[+RNS, +CT](scope: RNS, soql: String, params: Map[String, CT])
+
+case class D[+RNS, +CT](schema: (String, CT)*) extends Thing[RNS, CT] { self =>
   private var canonicalName_ : Option[String] = None
   private var orderings_ : List[(String, Boolean, Boolean)] = Nil
   private var hiddenColumns_ : Set[String] = Set.empty
   private var primaryKeys_ : List[Seq[String]] = Nil
   private var outputColumnHints_ : Map[ColumnName, JValue] = Map.empty
 
-  private def copyVars[CT2 >: CT](that: D[CT2]): Unit = {
+  // variance makes this field special; we can't _set_ it, we have to
+  // _override_ it.
+  val wrappingQuery : Option[MockWrappingQuery[RNS, CT]] = None
+
+  private def copyVars[RNS2 >: RNS, CT2 >: CT](that: D[RNS2, CT2]): Unit = {
     this.canonicalName_ = that.canonicalName_
     this.orderings_ = that.orderings_
     this.hiddenColumns_ = that.hiddenColumns_
@@ -42,23 +49,25 @@ case class D[+CT](schema: (String, CT)*) extends Thing[Nothing, CT] {
     this.outputColumnHints_ = that.outputColumnHints_
   }
 
-  def withCanonicalName(name: String): D[CT] = {
-    val result = D(schema: _*)
+  def withCanonicalName(name: String): D[RNS, CT] = {
+    val result = D[RNS, CT](schema: _*)
     result.copyVars(this)
     result.canonicalName_ = Some(name)
     result
   }
   def canonicalName = canonicalName_
 
-  def withOrdering(column: String, ascending: Boolean = true, nullLast: OptionalBoolean = OptionalBoolean.Unprovided): D[CT] = {
-    val result = D(schema : _*)
+  def withOrdering(column: String, ascending: Boolean = true, nullLast: OptionalBoolean = OptionalBoolean.Unprovided): D[RNS, CT] = {
+    val result = new D[RNS, CT](schema : _*) {
+      override val wrappingQuery = self.wrappingQuery
+    }
     result.copyVars(this)
     result.orderings_ = (column, ascending, nullLast.orElse(ascending)) :: orderings_
     result
   }
   def orderings: Seq[(String, Boolean, Boolean)] = orderings_.reverse
 
-  def withHiddenColumns(column: String*): D[CT] = {
+  def withHiddenColumns(column: String*): D[RNS, CT] = {
     val result = D(schema : _*)
     result.copyVars(this)
     result.hiddenColumns_ = hiddenColumns_ ++ column
@@ -66,26 +75,42 @@ case class D[+CT](schema: (String, CT)*) extends Thing[Nothing, CT] {
   }
   def hiddenColumns = hiddenColumns_
 
-  def withPrimaryKey(column: String*): D[CT] = {
-    val result = D(schema : _*)
+  def withPrimaryKey(column: String*): D[RNS, CT] = {
+    val result = new D[RNS, CT](schema : _*) {
+      override val wrappingQuery = self.wrappingQuery
+    }
     result.copyVars(this)
     result.primaryKeys_ = column :: primaryKeys_
     result
   }
   def primaryKeys = primaryKeys_.reverse
 
-  def withOutputColumnHints(hints: (String, JValue)*): D[CT] = {
-    val result = D(schema : _*)
+  def withOutputColumnHints(hints: (String, JValue)*): D[RNS, CT] = {
+    val result = new D[RNS, CT](schema : _*) {
+      override val wrappingQuery = self.wrappingQuery
+    }
     result.copyVars(this)
     result.outputColumnHints_ = outputColumnHints_ ++ hints.map { case (c, v) => ColumnName(c) -> v }
     result
   }
   def outputColumnHints = outputColumnHints_
+
+  def withWrappingQuery[RNS2 >: RNS, CT2 >: CT](scope: RNS2, soql: String, params: (String, CT2)*): D[RNS2, CT2] = {
+    val result = new D[RNS2, CT2](this.schema : _*) {
+      override val wrappingQuery = Some(MockWrappingQuery(scope, soql, params.toMap))
+    }
+    result.copyVars(this)
+    result
+  }
 }
-case class Q[+RNS, +CT](scope: RNS, parent: String, soql: String, params: (String, CT)*) extends Thing[RNS, CT] {
+case class Q[+RNS, +CT](scope: RNS, parent: String, soql: String, params: (String, CT)*) extends Thing[RNS, CT] { self =>
   private var canonicalName_ : Option[String] = None
   private var hiddenColumns_ : Set[ColumnName] = Set.empty
   private var outputColumnHints_ : Map[ColumnName, JValue] = Map.empty
+
+  // variance makes this field special; we can't _set_ it, we have to
+  // _override_ it.
+  val wrappingQuery : Option[MockWrappingQuery[RNS, CT]] = None
 
   private def copyVars[RNS2 >: RNS, CT2 >: CT](that: Q[RNS2, CT2]): Unit = {
     this.canonicalName_ = that.canonicalName_
@@ -94,7 +119,9 @@ case class Q[+RNS, +CT](scope: RNS, parent: String, soql: String, params: (Strin
   }
 
   def withCanonicalName(name: String): Q[RNS, CT] = {
-    val result = Q(scope, parent, soql, params : _*)
+    val result = new Q[RNS, CT](scope, parent, soql, params : _*) {
+      override val wrappingQuery = self.wrappingQuery
+    }
     result.copyVars(this)
     result.canonicalName_ = Some(name)
     result
@@ -102,7 +129,9 @@ case class Q[+RNS, +CT](scope: RNS, parent: String, soql: String, params: (Strin
   def canonicalName = canonicalName_
 
   def withHiddenColumns(column: String*): Q[RNS, CT] = {
-    val result = Q(scope, parent, soql, params : _*)
+    val result = new Q[RNS, CT](scope, parent, soql, params : _*) {
+      override val wrappingQuery = self.wrappingQuery
+    }
     result.copyVars(this)
     result.hiddenColumns_ = hiddenColumns_ ++ column.iterator.map(ColumnName(_))
     result
@@ -110,24 +139,40 @@ case class Q[+RNS, +CT](scope: RNS, parent: String, soql: String, params: (Strin
   def hiddenColumns = hiddenColumns_
 
   def withOutputColumnHints(hints: (String, JValue)*): Q[RNS, CT] = {
-    val result = Q(scope, parent, soql, params : _*)
+    val result = new Q[RNS, CT](this.scope, this.parent, this.soql, this.params : _*) {
+      override val wrappingQuery = self.wrappingQuery
+    }
     result.copyVars(this)
     result.outputColumnHints_ = outputColumnHints_ ++ hints.map { case (c, v) => ColumnName(c) -> v }
     result
   }
   def outputColumnHints = outputColumnHints_
+
+  def withWrappingQuery[RNS2 >: RNS, CT2 >: CT](scope: RNS2, soql: String, params: (String, CT2)*): Q[RNS2, CT2] = {
+    val result = new Q[RNS2, CT2](this.scope, this.parent, this.soql, this.params : _*) {
+      override val wrappingQuery = Some(MockWrappingQuery(scope, soql, params.toMap))
+    }
+    result.copyVars(this)
+    result
+  }
 }
-case class U[+RNS, CT](scope: RNS, soql: String, params: (String, CT)*) extends Thing[RNS, CT] {
+case class U[+RNS, +CT](scope: RNS, soql: String, params: (String, CT)*) extends Thing[RNS, CT] { self =>
   private var canonicalName_ : Option[String] = None
   private var hiddenColumns_ : Set[ColumnName] = Set.empty
 
-  private def copyVars[RNS2 >: RNS, CT2 >: CT](that: U[RNS2, CT]): Unit = {
+  // variance makes this field special; we can't _set_ it, we have to
+  // _override_ it.
+  val wrappingQuery : Option[MockWrappingQuery[RNS, CT]] = None
+
+  private def copyVars[RNS2 >: RNS, CT2 >: CT](that: U[RNS2, CT2]): Unit = {
     this.canonicalName_ = that.canonicalName_
     this.hiddenColumns_ = that.hiddenColumns_
   }
 
   def withCanonicalName(name: String): U[RNS, CT] = {
-    val result = U(scope, soql, params : _*)
+    val result = new U[RNS, CT](scope, soql, params : _*) {
+      override val wrappingQuery = self.wrappingQuery
+    }
     result.copyVars(this)
     result.canonicalName_ = Some(name)
     result
@@ -135,12 +180,22 @@ case class U[+RNS, CT](scope: RNS, soql: String, params: (String, CT)*) extends 
   def canonicalName = canonicalName_
 
   def withHiddenColumns(column: String*): U[RNS, CT] = {
-    val result = U(scope, soql, params : _*)
+    val result = new U[RNS, CT](scope, soql, params : _*) {
+      override val wrappingQuery = self.wrappingQuery
+    }
     result.copyVars(this)
     result.hiddenColumns_ = hiddenColumns_ ++ column.iterator.map(ColumnName(_))
     result
   }
   def hiddenColumns = hiddenColumns_
+
+  def withWrappingQuery[RNS2 >: RNS, CT2 >: CT](scope: RNS2, soql: String, params: (String, CT2)*): U[RNS2, CT2] = {
+    val result = new U[RNS2, CT2](this.scope, this.soql, this.params : _*) {
+      override val wrappingQuery = Some(MockWrappingQuery(scope, soql, params.toMap))
+    }
+    result.copyVars(this)
+    result
+  }
 }
 
 object MockTableFinder {
@@ -149,20 +204,24 @@ object MockTableFinder {
   def apply[MT <: MetaTypes](items: UnparsedFoundTables[MT])(implicit dtnIsString: String =:= MT#DatabaseTableNameImpl, dcnIsString: String =:= MT#DatabaseColumnNameImpl) = UnparsedTableMap.asMockTableFinder(items.tableMap)
   def apply[MT <: MetaTypes](items: FoundTables[MT])(implicit dtnIsString: String =:= MT#DatabaseTableNameImpl, dcnIsString: String =:= MT#DatabaseColumnNameImpl): MockTableFinder[MT] = this(items.asUnparsedFoundTables)
 
+  private case class JWQ[+RNS,+CT](scope: Option[RNS], soql: String, params: Map[String, CT])
+
   private sealed abstract class JThing[+RNS, +CT]
-  private case class JD[+CT](schema: Seq[(String, CT)], canonicalName: Option[String], orderings: Option[Seq[(String, Boolean, Boolean)]], hiddenColumns: Option[Seq[String]], primaryKeys: Option[Seq[Seq[String]]]) extends JThing[Nothing, CT]
-  private case class JQ[+RNS,+CT](scope: Option[RNS], parent: String, soql: String, params: Map[String, CT], canonicalName: Option[String], hiddenColumns: Option[Seq[String]]) extends JThing[RNS, CT]
-  private case class JU[+RNS,+CT](scope: Option[RNS], soql: String, params: Seq[(String, CT)], canonicalName: Option[String], hiddenColumns: Option[Seq[String]]) extends JThing[RNS, CT]
+  private case class JD[+RNS, +CT](schema: Seq[(String, CT)], canonicalName: Option[String], orderings: Option[Seq[(String, Boolean, Boolean)]], hiddenColumns: Option[Seq[String]], primaryKeys: Option[Seq[Seq[String]]], wrappingQuery: Option[JWQ[RNS, CT]]) extends JThing[RNS, CT]
+  private case class JQ[+RNS,+CT](scope: Option[RNS], parent: String, soql: String, params: Map[String, CT], canonicalName: Option[String], hiddenColumns: Option[Seq[String]], wrappingQuery: Option[JWQ[RNS, CT]]) extends JThing[RNS, CT]
+  private case class JU[+RNS,+CT](scope: Option[RNS], soql: String, params: Seq[(String, CT)], canonicalName: Option[String], hiddenColumns: Option[Seq[String]], wrappingQuery: Option[JWQ[RNS, CT]]) extends JThing[RNS, CT]
 
   implicit def jDecode[MT <: MetaTypes](implicit rnsFieldDecode: FieldDecode[MT#ResourceNameScope], rnsDecode: JsonDecode[MT#ResourceNameScope], ctDecode: JsonDecode[MT#ColumnType], dtnIsString: String =:= MT#DatabaseTableNameImpl, dcnIsString: String =:= MT#DatabaseColumnNameImpl): JsonDecode[MockTableFinder[MT]] =
     new JsonDecode[MockTableFinder[MT]] with MetaTypeHelper[MT] {
-      private implicit val jdDecode = AutomaticJsonDecodeBuilder[JD[CT]]
+      private implicit val jwqDecode = AutomaticJsonDecodeBuilder[JWQ[RNS, CT]]
+
+      private implicit val jdDecode = AutomaticJsonDecodeBuilder[JD[RNS, CT]]
       private implicit val jqDecode = AutomaticJsonDecodeBuilder[JQ[RNS, CT]]
       private implicit val juDecode = AutomaticJsonDecodeBuilder[JU[RNS, CT]]
 
       private implicit val jDecode =
         SimpleHierarchyDecodeBuilder[JThing[RNS, CT]](InternalTag("type")).
-          branch[JD[CT]]("dataset").
+          branch[JD[RNS, CT]]("dataset").
           branch[JQ[RNS, CT]]("saved query").
           branch[JU[RNS, CT]]("udf").
           build
@@ -173,22 +232,34 @@ object MockTableFinder {
             OrderedMap() ++ m.iterator.flatMap { case (rns, jthings) =>
               jthings.map { case (name, jthing) =>
                 val thing = jthing match {
-                  case JD(schema, canonicalName, orderings, hiddenColumns, pks) =>
-                    pks.getOrElse(Nil).foldLeft(
-                      orderings.getOrElse(Nil).foldLeft(
-                        canonicalName.foldLeft(D(schema : _*)) { (d, cname) =>
-                          d.withCanonicalName(cname)
-                        }
-                      ) { (d, orderDir) =>
-                        d.withOrdering(orderDir._1, orderDir._2)
-                      }.withHiddenColumns(hiddenColumns.getOrElse(Nil) : _*)
-                    ) { (dataset, pk) => dataset.withPrimaryKey(pk: _*) }
-                  case JQ(scopeOpt, parent, soql, params, cname, hiddenColumns) =>
+                  case JD(schema, canonicalName, orderings, hiddenColumns, pks, wq) =>
+                    wq.foldLeft(
+                      pks.getOrElse(Nil).foldLeft(
+                        orderings.getOrElse(Nil).foldLeft(
+                          canonicalName.foldLeft(D[RNS, CT](schema : _*)) { (d, cname) =>
+                            d.withCanonicalName(cname)
+                          }
+                        ) { (d, orderDir) =>
+                          d.withOrdering(orderDir._1, orderDir._2)
+                        }.withHiddenColumns(hiddenColumns.getOrElse(Nil) : _*)
+                      ) { (dataset, pk) => dataset.withPrimaryKey(pk: _*) }
+                    ) { (ds, jwq) =>
+                      ds.withWrappingQuery(jwq.scope.getOrElse(rns), jwq.soql, jwq.params.toSeq : _*)
+                    }
+                  case JQ(scopeOpt, parent, soql, params, cname, hiddenColumns, wq) =>
                     val result = Q(scopeOpt.getOrElse(rns), parent, soql, params.toSeq : _*)
-                    cname.fold(result)(result.withCanonicalName).withHiddenColumns(hiddenColumns.getOrElse(Nil) : _*)
-                  case JU(scopeOpt, soql, params, cname, hiddenColumns) =>
+                    wq.foldLeft(
+                      cname.fold(result)(result.withCanonicalName).withHiddenColumns(hiddenColumns.getOrElse(Nil) : _*)
+                    ) { (q, jwq) =>
+                      q.withWrappingQuery(jwq.scope.getOrElse(rns), jwq.soql, jwq.params.toSeq : _*)
+                    }
+                  case JU(scopeOpt, soql, params, cname, hiddenColumns, wq) =>
                     val result = U(scopeOpt.getOrElse(rns), soql, params : _*)
-                    cname.fold(result)(result.withCanonicalName).withHiddenColumns(hiddenColumns.getOrElse(Nil) : _*)
+                    wq.foldLeft(
+                      cname.fold(result)(result.withCanonicalName).withHiddenColumns(hiddenColumns.getOrElse(Nil) : _*)
+                    ) { (u, jwq) =>
+                      u.withWrappingQuery(jwq.scope.getOrElse(rns), jwq.soql, jwq.params.toSeq : _*)
+                    }
                 }
 
                 (rns, name) -> thing
@@ -200,13 +271,15 @@ object MockTableFinder {
 
   implicit def jEncode[MT <: MetaTypes](implicit rnsFieldEncode: FieldEncode[MT#ResourceNameScope], rnsEncode: JsonEncode[MT#ResourceNameScope], ctEncode: JsonEncode[MT#ColumnType]): JsonEncode[MockTableFinder[MT]] =
     new JsonEncode[MockTableFinder[MT]] with MetaTypeHelper[MT] {
-      private implicit val jdEncode = AutomaticJsonEncodeBuilder[JD[CT]]
+      private implicit val jwqEncode = AutomaticJsonEncodeBuilder[JWQ[RNS, CT]]
+
+      private implicit val jdEncode = AutomaticJsonEncodeBuilder[JD[RNS, CT]]
       private implicit val jqEncode = AutomaticJsonEncodeBuilder[JQ[RNS, CT]]
       private implicit val juEncode = AutomaticJsonEncodeBuilder[JU[RNS, CT]]
 
       private implicit val jEncode =
         SimpleHierarchyEncodeBuilder[JThing[RNS, CT]](InternalTag("type")).
-          branch[JD[CT]]("dataset").
+          branch[JD[RNS, CT]]("dataset").
           branch[JQ[RNS, CT]]("saved query").
           branch[JU[RNS, CT]]("udf").
           build
@@ -225,7 +298,10 @@ object MockTableFinder {
                         d.canonicalName,
                         Some(d.orderings).filter(_.nonEmpty),
                         Some(d.hiddenColumns.toSeq).filter(_.nonEmpty),
-                        Some(d.primaryKeys).filter(_.nonEmpty)
+                        Some(d.primaryKeys).filter(_.nonEmpty),
+                        d.wrappingQuery.map { wq =>
+                          JWQ[RNS, CT](Some(wq.scope).filter(_ != rns), wq.soql, wq.params.toMap)
+                        }
                       )
                     case q@Q(scope, parent, soql, params@_*) =>
                       JQ(
@@ -234,7 +310,10 @@ object MockTableFinder {
                         soql,
                         params.toMap,
                         q.canonicalName.filter(_ != name),
-                        Some(q.hiddenColumns.map(_.name).toSeq).filter(_.nonEmpty)
+                        Some(q.hiddenColumns.map(_.name).toSeq).filter(_.nonEmpty),
+                        q.wrappingQuery.map { wq =>
+                          JWQ[RNS, CT](Some(wq.scope).filter(_ != rns), wq.soql, wq.params.toMap)
+                        }
                       )
                     case u@U(scope, soql, params@_*) =>
                       JU(
@@ -242,7 +321,10 @@ object MockTableFinder {
                         soql,
                         params,
                         u.canonicalName.filter(_ != name),
-                        Some(u.hiddenColumns.map(_.name).toSeq).filter(_.nonEmpty)
+                        Some(u.hiddenColumns.map(_.name).toSeq).filter(_.nonEmpty),
+                        u.wrappingQuery.map { wq =>
+                          JWQ[RNS, CT](Some(wq.scope).filter(_ != rns), wq.soql, wq.params.toMap)
+                        }
                       )
                   }
                   name -> jThing
@@ -255,6 +337,10 @@ object MockTableFinder {
 }
 
 class MockTableFinder[MT <: MetaTypes](private val raw: OrderedMap[(MT#ResourceNameScope, String), Thing[MT#ResourceNameScope, MT#ColumnType]])(implicit dtnIsString: String =:= MT#DatabaseTableNameImpl, dcnIsString: String =:= MT#DatabaseColumnNameImpl) extends TableFinder[MT] {
+
+  private def toTableFinder(wq: MockWrappingQuery[ResourceNameScope, ColumnType]): WrappingQuery =
+    WrappingQuery(wq.scope, wq.soql, wq.params.iterator.map { case (name, typ) => HoleName(name) -> typ }.toMap)
+
   private val tables: Map[ScopedResourceName, FinderTableDescription] = locally {
     // canonical names need to be unique within the whole tablefinder
     // (not just the scope) so unless the user has specified a
@@ -282,7 +368,8 @@ class MockTableFinder[MT <: MetaTypes](private val raw: OrderedMap[(MT#ResourceN
               DatabaseColumnName[MT#DatabaseColumnNameImpl](cn.caseFolded) -> DatasetColumnInfo(cn, ct, hidden = hiddenColumns(cn), hint = outputColumnHints.get(cn))
             },
             d.orderings.map { case (col, asc, nullLast) => Ordering(DatabaseColumnName(ColumnName(col).caseFolded), asc, nullLast) },
-            d.primaryKeys.map(_.map { col => DatabaseColumnName[MT#DatabaseColumnNameImpl](ColumnName(col).caseFolded) })
+            d.primaryKeys.map(_.map { col => DatabaseColumnName[MT#DatabaseColumnNameImpl](ColumnName(col).caseFolded) }),
+            d.wrappingQuery.map(toTableFinder)
           )
         case q@Q(scope, parent, soql, params @ _*) =>
           Query(
@@ -292,7 +379,8 @@ class MockTableFinder[MT <: MetaTypes](private val raw: OrderedMap[(MT#ResourceN
             soql,
             params.iterator.map { case (k, v) => HoleName(k) -> v }.toMap,
             q.hiddenColumns,
-            q.outputColumnHints
+            q.outputColumnHints,
+            q.wrappingQuery.map(toTableFinder)
           )
         case u@U(scope, soql, params @ _*) =>
           TableFunction(
@@ -300,7 +388,8 @@ class MockTableFinder[MT <: MetaTypes](private val raw: OrderedMap[(MT#ResourceN
             CanonicalName(u.canonicalName.getOrElse(canonicalNameForResourceName(rawResourceName))),
             soql,
             OrderedMap() ++ params.iterator.map { case (k,v) => HoleName(k) -> v },
-            u.hiddenColumns
+            u.hiddenColumns,
+            u.wrappingQuery.map(toTableFinder)
           )
       }
       ScopedResourceName(scope, ResourceName(rawResourceName)) -> converted
@@ -316,31 +405,17 @@ class MockTableFinder[MT <: MetaTypes](private val raw: OrderedMap[(MT#ResourceN
     }
   }
 
-  private def parsed(thing: FinderTableDescription) = {
-    thing match {
-      case ds: Dataset => ds.toParsed
-      case Query(scope, canonicalName, parent, soql, params, hiddenColumns, outputColumnHints) =>
-        TableDescription.Query[MT](
-          scope, canonicalName, parent,
-          ParserUtil.parseWithoutContext(soql, parserParameters.copy(allowHoles = false)).getOrElse(throw new Exception("broken soql fixture 1")),
-          soql, params, hiddenColumns, outputColumnHints,
-          None
-        )
-      case TableFunction(scope, canonicalName, soql, params, hiddenColumns) =>
-        TableDescription.TableFunction[MT](
-          scope, canonicalName,
-          ParserUtil.parseWithoutContext(soql, parserParameters.copy(allowHoles = true)).getOrElse(throw new Exception("broken soql fixture 2")),
-          soql, params, hiddenColumns,
-          None
-        )
-    }
-  }
-
   def apply(names: (MT#ResourceNameScope, String)*): Result[TableMap] = {
     val r = names.foldLeft(TableMap.empty[MT]) { (tableMap, scopeName) =>
       val (scope, n) = scopeName
       val name = ResourceName(n)
-      tableMap + (ScopedResourceName(scope, name) -> parsed(tables(ScopedResourceName(scope, name))))
+      val newScopedName = ScopedResourceName(scope, name)
+      convertToTableDescription(newScopedName, tables(newScopedName)) match {
+        case Right(result) =>
+          tableMap + (newScopedName -> result)
+        case Left(err) =>
+          throw new Exception("Broken fixture query: " + err)
+      }
     }
 
     if(r.size != names.length) {

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -344,17 +344,27 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
         case None =>
           withoutWrapper
         case Some(wq) =>
-          wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(srn), None, primaryTableName(srn), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(withoutWrapper, Some(srn.name))), withoutWrapper)
+          wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(srn), None, primaryTableName(srn), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(withoutWrapper, Some(srn.name))), withoutWrapper.label, srn)
       }
     }
 
-    def wrappedOrdering[F <: AtomicFrom](from: F, bound: AtomicFrom): F = {
+    def wrappedOrdering[F <: AtomicFrom](from: F, wrappedLabel: AutoTableLabel, activeResource: ScopedResourceName): F = {
       from match {
         case fs: FromStatement =>
-          // Using PreserveOrdering here isn't _perfect_ because it
-          // will recurse into other named queries that the wrapping
-          // query references, but it's better than nothing
-          fs.copy(statement = rewrite.PreserveOrdering.bounded(labelProvider, fs.statement, bound.label))
+          // we want to stop when we leave the wrapped query - either
+          // when we reach the wrapped query, or when the wrapping
+          // query reaches some other resource.
+          //
+          // This isn't _completely_ ideal - if the wrapping query is
+          // complex, it will preserve ordering within the wrapping
+          // query where such preservation isn't necessary, but most
+          // wrapping queries are expected to be simple filters, so it
+          // should work.
+          def stop(otherFrom: FromStatement): Boolean = {
+            otherFrom.label == wrappedLabel || otherFrom.resourceName != Some(activeResource)
+          }
+
+          fs.copy(statement = rewrite.PreserveOrdering.bounded(labelProvider, fs.statement, stop))
             .asInstanceOf[F] // ick.  Is there a better way to do this?  (this will work only as long as there are no subclasses of FromStatement)
         case _ =>
           from
@@ -381,7 +391,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
               case None =>
                 middle
               case Some(wq) =>
-                wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(middle, Some(name.name))), middle)
+                wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(middle, Some(name.name))), middle.label, name)
             }
           case TableDescription.TableFunction(_, _, _, _, _, _, _) =>
             parameterlessTableFunction(toSource(position), name.name)
@@ -1169,7 +1179,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 case None =>
                   unwrappedUseQuery
                 case Some(wq) =>
-                  wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, innerUdfParams, Set.empty, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name))), unwrappedUseQuery)
+                  wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, innerUdfParams, Set.empty, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name))), unwrappedUseQuery.label, udfScopedResourceName)
               }
 
               FromStatement(
@@ -1222,7 +1232,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 case None =>
                   unwrappedUseQuery
                 case Some(wq) =>
-                  wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, Map.empty, Set.empty, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name))), unwrappedUseQuery)
+                  wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, Map.empty, Set.empty, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name))), unwrappedUseQuery.label, udfScopedResourceName)
               }
           }
         case _ =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -280,73 +280,66 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
     }
 
     def fromTable(srn: ScopedResourceName, desc: TableDescription.Dataset[MT]): AtomicFrom = {
-      val withoutWrapper = if(desc.ordering.isEmpty) {
-        val hiddenColumns: Set[DatabaseColumnName] =
-          desc.schema.iterator.flatMap { case (databaseColumnName, FromTable.ColumnInfo(name, _, _)) =>
-            // if there is a wrapper, hidden columns will be handled at that point
-            if(desc.wrappingQuery.isEmpty && desc.hiddenColumns(name)) Some(databaseColumnName)
-            else None
-          }.toSet
+      val from = FromTable(
+        desc.name,
+        srn,
+        desc.canonicalName,
+        None,
+        labelProvider.tableLabel(),
+        columns = desc.schema,
+        primaryKeys = desc.primaryKeys
+      )
 
-        FromTable(
-          desc.name,
-          srn,
-          desc.canonicalName,
-          None,
-          labelProvider.tableLabel(),
-          columns = desc.schema.filter { case (databaseColumnName, _) => !hiddenColumns(databaseColumnName) },
-          primaryKeys = desc.primaryKeys.filter(_.forall(!hiddenColumns(_)))
-        )
-      } else {
-        for(TableDescription.Ordering(col, _ascending, _nullLast) <- desc.ordering) {
-          val typ = desc.schema(col).typ
-          if(!typeInfo.isOrdered(typ)) {
-            // should this be Synthetic instead of saved...?
-            throw Bail(SoQLAnalyzerError.TypecheckError.UnorderedOrderBy(Source.Saved(srn, NoPosition), typeInfo.typeNameFor(typ)))
-          }
+      for(TableDescription.Ordering(col, _ascending, _nullLast) <- desc.ordering) {
+        val typ = desc.schema(col).typ
+        if(!typeInfo.isOrdered(typ)) {
+          // should this be Synthetic instead of saved...?
+          throw Bail(SoQLAnalyzerError.TypecheckError.UnorderedOrderBy(Source.Saved(srn, NoPosition), typeInfo.typeNameFor(typ)))
         }
-
-        val from = FromTable(
-          desc.name,
-          srn,
-          desc.canonicalName,
-          None,
-          labelProvider.tableLabel(),
-          columns = desc.schema,
-          primaryKeys = desc.primaryKeys
-        )
-
-        val columnLabels = from.columns.map { case _ => labelProvider.columnLabel() }
-
-        FromStatement(
-          Select(
-            Distinctiveness.Indistinct(),
-            selectList = OrderedMap() ++ from.columns.iterator.zip(columnLabels.iterator).flatMap { case ((dcn, FromTable.ColumnInfo(name, typ, _hint)), outputLabel) =>
-              if(desc.hiddenColumns(name)) {
-                None
-              } else {
-                Some(outputLabel -> NamedExpr(PhysicalColumn[MT](from.label, from.tableName, dcn, typ)(AtomicPositionInfo.Synthetic), name, hint = None, isSynthetic = false))
-              }
-            },
-            from,
-            None,
-            Nil,
-            None,
-            desc.ordering.map { case TableDescription.Ordering(dcn, ascending, nullLast) =>
-              val FromTable.ColumnInfo(_, typ, _) = from.columns(dcn)
-              OrderBy(PhysicalColumn[MT](from.label, from.tableName, dcn, typ)(AtomicPositionInfo.Synthetic), ascending = ascending, nullLast = nullLast)
-            },
-            None,
-            None,
-            None,
-            Set.empty
-          ),
-          labelProvider.tableLabel(),
-          Some(srn),
-          Some(desc.canonicalName),
-          None
-        )
       }
+
+      val withoutWrapper =
+        if((desc.hiddenColumns.isEmpty || desc.wrappingQuery.isDefined) && desc.ordering.isEmpty) {
+          // No need to wrap the FromTable in a select to satisfy
+          // hidden or default sorts (if there's a wrapper query, it
+          // will be responsible for hiding the hidden columns)
+          from
+        } else {
+          val columnLabels = from.columns.map { case _ => labelProvider.columnLabel() }
+
+          FromStatement(
+            Select(
+              Distinctiveness.Indistinct(),
+              // remove hidden columns, unless there's a wrapping
+              // query (in which case they'll be removed at that
+              // layer)
+              selectList = OrderedMap() ++ from.columns.iterator.zip(columnLabels.iterator).flatMap { case ((dcn, FromTable.ColumnInfo(name, typ, _hint)), outputLabel) =>
+                if(desc.wrappingQuery.isEmpty && desc.hiddenColumns(name)) {
+                  None
+                } else {
+                  Some(outputLabel -> NamedExpr(PhysicalColumn[MT](from.label, from.tableName, dcn, typ)(AtomicPositionInfo.Synthetic), name, hint = None, isSynthetic = false))
+                }
+              },
+              from,
+              None,
+              Nil,
+              None,
+              // apply default ordering
+              desc.ordering.map { case TableDescription.Ordering(dcn, ascending, nullLast) =>
+                val FromTable.ColumnInfo(_, typ, _) = from.columns(dcn)
+                OrderBy(PhysicalColumn[MT](from.label, from.tableName, dcn, typ)(AtomicPositionInfo.Synthetic), ascending = ascending, nullLast = nullLast)
+              },
+              None,
+              None,
+              None,
+              Set.empty
+            ),
+            labelProvider.tableLabel(),
+            Some(srn),
+            Some(desc.canonicalName),
+            None
+          )
+        }
 
       desc.wrappingQuery match {
         case None =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -368,7 +368,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
               case None =>
                 middle
               case Some(wq) =>
-                analyzeStatement(Ctx(wq.scope, None, None, primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(middle, Some(name.name)))
+                analyzeStatement(Ctx(wq.scope, None, Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(middle, Some(name.name)))
             }
           case TableDescription.TableFunction(_, _, _, _, _, _, _) =>
             parameterlessTableFunction(source, name.name, position)

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -344,7 +344,20 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
         case None =>
           withoutWrapper
         case Some(wq) =>
-          analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(srn), None, primaryTableName(srn), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(withoutWrapper, Some(srn.name)))
+          wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(srn), None, primaryTableName(srn), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(withoutWrapper, Some(srn.name))), withoutWrapper)
+      }
+    }
+
+    def wrappedOrdering[F <: AtomicFrom](from: F, bound: AtomicFrom): F = {
+      from match {
+        case fs: FromStatement =>
+          // Using PreserveOrdering here isn't _perfect_ because it
+          // will recurse into other named queries that the wrapping
+          // query references, but it's better than nothing
+          fs.copy(statement = rewrite.PreserveOrdering.bounded(labelProvider, fs.statement, bound.label))
+            .asInstanceOf[F] // ick.  Is there a better way to do this?  (this will work only as long as there are no subclasses of FromStatement)
+        case _ =>
+          from
       }
     }
 
@@ -368,7 +381,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
               case None =>
                 middle
               case Some(wq) =>
-                analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(middle, Some(name.name)))
+                wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(middle, Some(name.name))), middle)
             }
           case TableDescription.TableFunction(_, _, _, _, _, _, _) =>
             parameterlessTableFunction(toSource(position), name.name)
@@ -1156,7 +1169,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 case None =>
                   unwrappedUseQuery
                 case Some(wq) =>
-                  analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, innerUdfParams, Set.empty, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name)))
+                  wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, innerUdfParams, Set.empty, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name))), unwrappedUseQuery)
               }
 
               FromStatement(
@@ -1209,7 +1222,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 case None =>
                   unwrappedUseQuery
                 case Some(wq) =>
-                  analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, Map.empty, Set.empty, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name)))
+                  wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, Map.empty, Set.empty, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name))), unwrappedUseQuery)
               }
           }
         case _ =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -178,16 +178,16 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
     }
 
     def analyze(scope: RNS, query: FoundTables.Query[MT]): Statement = {
-      val ctx = Ctx(scope, None, None, primaryTableName(scope, query), Environment.empty, Map.empty, Set.empty, Map.empty, preserveSystemColumnsRequested)
+      val ctx = Ctx(scope, Source.Anonymous(_), None, None, primaryTableName(scope, query), Environment.empty, Map.empty, Set.empty, Map.empty, preserveSystemColumnsRequested)
       val from =
         query match {
           case FoundTables.Saved(rn) =>
-            analyzeForFrom(ctx.scopedResourceName, ScopedResourceName(scope, rn), None, NoPosition)
+            analyzeForFrom(ctx.toSource, ScopedResourceName(scope, rn), None, NoPosition)
           case FoundTables.InContext(rn, q, _, parameters) =>
-            val from = analyzeForFrom(ctx.scopedResourceName, ScopedResourceName(scope, rn), None, NoPosition)
+            val from = analyzeForFrom(ctx.toSource, ScopedResourceName(scope, rn), None, NoPosition)
             analyzeStatement(ctx, q, ImplicitFrom.Required(from, Some(rn)))
           case FoundTables.InContextImpersonatingSaved(rn, q, _, parameters, impersonating) =>
-            val from = analyzeForFrom(ctx.scopedResourceName, ScopedResourceName(scope, rn), None, NoPosition)
+            val from = analyzeForFrom(ctx.toSource, ScopedResourceName(scope, rn), None, NoPosition)
             analyzeStatement(ctx.copy(canonicalName = Some(impersonating)), q, ImplicitFrom.Required(from, Some(rn)))
           case FoundTables.Standalone(q, _, parameters) =>
             analyzeStatement(ctx, q, ImplicitFrom.None)
@@ -344,17 +344,17 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
         case None =>
           withoutWrapper
         case Some(wq) =>
-          analyzeStatement(Ctx(wq.scope, None, None, primaryTableName(srn), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(withoutWrapper, Some(srn.name)))
+          analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(srn), None, primaryTableName(srn), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(withoutWrapper, Some(srn.name)))
       }
     }
 
-    def analyzeForFrom(source: Option[ScopedResourceName], name: ScopedResourceName, canonicalName: Option[CanonicalName], position: Position): AtomicFrom = {
+    def analyzeForFrom(toSource: Position => Source, name: ScopedResourceName, canonicalName: Option[CanonicalName], position: Position): AtomicFrom = {
       if(name.name == SoQLAnalyzer.SingleRow) {
         FromSingleRow(labelProvider.tableLabel(), None)
       } else if(name.name == SoQLAnalyzer.This) {
         // analyzeSelection will handle @this in the correct
         // position...
-        illegalThisReference(source, position)
+        illegalThisReference(toSource(position))
       } else {
         tableMap.find(name) match {
           case ds: TableDescription.Dataset[MT] =>
@@ -362,16 +362,16 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
           case TableDescription.Query(scope, canonicalName, basedOn, parsed, _unparsed, parameters, hiddenColumns, outputColumnHints, wq) =>
             // so this is basedOn |> parsed |> wq
             // so we want to use "basedOn" as the implicit "from" for "parsed"
-            val from = analyzeForFrom(source, ScopedResourceName(scope, basedOn), None, NoPosition /* Yes, actually NoPosition here */)
-            val middle = analyzeStatement(Ctx(scope, Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, hiddenColumns, outputColumnHints, true), parsed, ImplicitFrom.Required(from, Some(basedOn)))
+            val from = analyzeForFrom(toSource, ScopedResourceName(scope, basedOn), None, NoPosition /* Yes, actually NoPosition here */)
+            val middle = analyzeStatement(Ctx(scope, Source.Saved(name, _), Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, hiddenColumns, outputColumnHints, true), parsed, ImplicitFrom.Required(from, Some(basedOn)))
             wq match {
               case None =>
                 middle
               case Some(wq) =>
-                analyzeStatement(Ctx(wq.scope, None, Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(middle, Some(name.name)))
+                analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(middle, Some(name.name)))
             }
           case TableDescription.TableFunction(_, _, _, _, _, _, _) =>
-            parameterlessTableFunction(source, name.name, position)
+            parameterlessTableFunction(toSource(position), name.name)
         }
       }
     }
@@ -386,6 +386,8 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
       // necessarily the same as the scope above if we're crossing a
       // scope boundary!  This is just used to decorate the typed trees
       // with source information.
+      toSource: Position => Source,
+      // This is used when decorating Froms with the resource name
       scopedResourceName: Option[ScopedResourceName],
       // The canonical name of the source of the soql currently being
       // analyzed.  This is used to look up unqualified user
@@ -397,7 +399,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
       // column-names can be matched to input columns.
       enclosingEnv: Environment[MT],
       // Any UDF parameters available for the current soql.
-      udfParams: Map[HoleName, (Option[ScopedResourceName], Position) => Expr],
+      udfParams: Map[HoleName, Source => Expr],
       // What output columns generated by the current SoQL should be
       // marked as hidden.
       hiddenColumns: Set[ColumnName],
@@ -411,9 +413,9 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
         throw Bail(e)
 
       def expectedBoolean(expr: ast.Expression, got: CT): Nothing =
-        error(Error.ExpectedBoolean(Source.nonSynthetic(scopedResourceName, expr.position), typeInfo.typeNameFor(got)))
+        error(Error.ExpectedBoolean(toSource(expr.position), typeInfo.typeNameFor(got)))
       def incorrectNumberOfParameters(forUdf: ResourceName, expected: Int, got: Int, position: Position): Nothing =
-        error(Error.IncorrectNumberOfUdfParameters(Source.nonSynthetic(scopedResourceName, position), forUdf, expected, got))
+        error(Error.IncorrectNumberOfUdfParameters(toSource(position), forUdf, expected, got))
       def distinctOnMustBePrefixOfOrderBy(source: Source): Nothing =
         error(Error.DistinctOnNotPrefixOfOrderBy(source))
       def orderByMustBeSelected(source: Source): Nothing =
@@ -423,30 +425,30 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
       def unorderedOrderBy(typ: CT, source: Source): Nothing =
         error(Error.TypecheckError.UnorderedOrderBy(source, typeInfo.typeNameFor(typ)))
       def parametersForNonUdf(name: ResourceName, position: Position): Nothing =
-        error(Error.ParametersForNonUDF(Source.nonSynthetic(scopedResourceName, position), name))
+        error(Error.ParametersForNonUDF(toSource(position), name))
       def addScopeError(e: AddScopeError, position: Position): Nothing =
         e match {
           case AddScopeError.NameExists(n) =>
-            error(Error.TableAliasAlreadyExists(Source.nonSynthetic(scopedResourceName, position), n))
+            error(Error.TableAliasAlreadyExists(toSource(position), n))
           case AddScopeError.MultipleImplicit =>
             // This shouldn't be able to occur from user input - the
             // grammar disallows it.
             throw new Exception("Multiple implicit tables??")
         }
       def noDataSource(position: Position): Nothing =
-        error(Error.FromRequired(Source.nonSynthetic(scopedResourceName, position)))
+        error(Error.FromRequired(toSource(position)))
       def chainWithFrom(position: Position): Nothing =
-        error(Error.FromForbidden(Source.nonSynthetic(scopedResourceName, position)))
+        error(Error.FromForbidden(toSource(position)))
       def fromThisWithoutContext(position: Position): Nothing =
-        error(Error.FromThisWithoutContext(Source.nonSynthetic(scopedResourceName, position)))
+        error(Error.FromThisWithoutContext(toSource(position)))
       def tableOpTypeMismatch(left: OrderedMap[ColumnName, CT], right: OrderedMap[ColumnName, CT], position: Position): Nothing =
-        error(Error.TableOperationTypeMismatch(Source.nonSynthetic(scopedResourceName, position), left.valuesIterator.map(typeInfo.typeNameFor).toVector, right.valuesIterator.map(typeInfo.typeNameFor).toVector))
+        error(Error.TableOperationTypeMismatch(toSource(position), left.valuesIterator.map(typeInfo.typeNameFor).toVector, right.valuesIterator.map(typeInfo.typeNameFor).toVector))
       def literalNotAllowedInGroupBy(pos: Position): Nothing =
-        error(Error.LiteralNotAllowedInGroupBy(Source.nonSynthetic(scopedResourceName, pos)))
+        error(Error.LiteralNotAllowedInGroupBy(toSource(pos)))
       def literalNotAllowedInOrderBy(pos: Position): Nothing =
-        error(Error.LiteralNotAllowedInOrderBy(Source.nonSynthetic(scopedResourceName, pos)))
+        error(Error.LiteralNotAllowedInOrderBy(toSource(pos)))
       def literalNotAllowedInDistinctOn(pos: Position): Nothing =
-        error(Error.LiteralNotAllowedInDistinctOn(Source.nonSynthetic(scopedResourceName, pos)))
+        error(Error.LiteralNotAllowedInDistinctOn(toSource(pos)))
       def aggregateFunctionNotAllowed(name: FunctionName, source: Source): Nothing =
         error(Error.AggregateFunctionNotAllowed(source, name))
       def ungroupedColumnReference(source: Source): Nothing =
@@ -454,20 +456,20 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
       def windowFunctionNotAllowed(name: FunctionName, source: Source): Nothing =
         error(Error.WindowFunctionNotAllowed(source, name))
       def reservedTableName(name: ResourceName, pos: Position): Nothing =
-        error(Error.ReservedTableName(Source.nonSynthetic(scopedResourceName, pos), name))
+        error(Error.ReservedTableName(toSource(pos), name))
       def augmentAliasAnalysisException(aae: AliasAnalysisException): Nothing = {
         import com.socrata.soql.{exceptions => SE}
 
         aae match {
           case SE.RepeatedException(name, pos) =>
-            error(Error.AliasAnalysisError.RepeatedExclusion(Source.nonSynthetic(scopedResourceName, pos), name))
+            error(Error.AliasAnalysisError.RepeatedExclusion(toSource(pos), name))
           case SE.CircularAliasDefinition(name, pos) =>
-            error(Error.AliasAnalysisError.CircularAliasDefinition(Source.nonSynthetic(scopedResourceName, pos), name))
+            error(Error.AliasAnalysisError.CircularAliasDefinition(toSource(pos), name))
           case SE.DuplicateAlias(name, pos) =>
-            error(Error.AliasAnalysisError.DuplicateAlias(Source.nonSynthetic(scopedResourceName, pos), name))
+            error(Error.AliasAnalysisError.DuplicateAlias(toSource(pos), name))
           case nsc@SE.NoSuchColumn(name, pos) =>
             val qual = nsc.asInstanceOf[SE.NoSuchColumn.RealNoSuchColumn].qualifier.map(_.substring(1)).map(ResourceName(_)) // ew
-            error(Error.TypecheckError.NoSuchColumn(Source.nonSynthetic(scopedResourceName, pos), qual, name, Util.possibilitiesFor(enclosingEnv, Iterator.empty, qual, name)))
+            error(Error.TypecheckError.NoSuchColumn(toSource(pos), qual, name, Util.possibilitiesFor(enclosingEnv, Iterator.empty, qual, name)))
           case SE.NoSuchTable(_, _) =>
             throw new Exception("Alias analysis doesn't actually throw NoSuchTable")
         }
@@ -483,6 +485,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
             analyzeStatement(
               Ctx(
                 scope = ctx.scope,
+                toSource = ctx.toSource,
                 scopedResourceName = ctx.scopedResourceName,
                 canonicalName = ctx.canonicalName,
                 primaryTableName = ctx.primaryTableName,
@@ -504,8 +507,9 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
       val subCtx =
         Ctx(
           scope = ctx.scope,
-          scopedResourceName = None,
-          canonicalName = None,
+          toSource = ctx.toSource,
+          scopedResourceName = ctx.scopedResourceName,
+          canonicalName = ctx.canonicalName,
           primaryTableName = ctx.primaryTableName,
           enclosingEnv = ctx.enclosingEnv,
           udfParams = ctx.udfParams,
@@ -953,7 +957,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
       // analyzer wants from right to left.
 
       def fromNamedTable(rn: ResourceName, alias: ResourceName) = {
-        analyzeForFrom(ctx.scopedResourceName, ScopedResourceName(ctx.scope, rn), ctx.canonicalName, NoPosition /* TODO: NEED POS INFO FROM AST */).
+        analyzeForFrom(ctx.toSource, ScopedResourceName(ctx.scope, rn), ctx.canonicalName, NoPosition /* TODO: NEED POS INFO FROM AST */).
           reAlias(Some(alias))
       }
 
@@ -1068,14 +1072,15 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
       js match {
         case ast.JoinTable(tn) =>
           tn.aliasWithoutPrefix.foreach(ensureLegalAlias(ctx, _, NoPosition /* TODO: NEED POS INFO FROM AST */))
-          analyzeForFrom(ctx.scopedResourceName, ScopedResourceName(ctx.scope, ResourceName(tn.nameWithoutPrefix)), ctx.canonicalName, NoPosition /* TODO: NEED POS INFO FROM AST */).
+          analyzeForFrom(ctx.toSource, ScopedResourceName(ctx.scope, ResourceName(tn.nameWithoutPrefix)), ctx.canonicalName, NoPosition /* TODO: NEED POS INFO FROM AST */).
             reAlias(Some(ResourceName(tn.aliasWithoutPrefix.getOrElse(tn.nameWithoutPrefix))))
         case ast.JoinQuery(select, rawAlias) =>
           val alias = rawAlias.substring(1)
           ensureLegalAlias(ctx, alias, NoPosition /* TODO: NEED POS INFO FROM AST */)
           val subCtx = Ctx(
             scope = ctx.scope,
-            scopedResourceName = ctx.scopedResourceName, // still in the same source-code context...
+            toSource = ctx.toSource, // still in the same source-code context...
+            scopedResourceName = ctx.scopedResourceName,
             canonicalName = ctx.canonicalName,
             primaryTableName = primaryTableName(ctx.scope, select),
             enclosingEnv = ctx.enclosingEnv,
@@ -1130,11 +1135,12 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
               val outOfLineParamsLabel = labelProvider.tableLabel()
               val innerUdfParams =
                 outOfLineParamsQuery.schema.keys.lazyZip(typecheckedParams).map { case (colLabel, (name, expr)) =>
-                  name -> { (sourceName: Option[ScopedResourceName], p: Position) => VirtualColumn(outOfLineParamsLabel, colLabel, expr.typ)(new AtomicPositionInfo(Source.nonSynthetic(sourceName, p))) }
+                  name -> { (source: Source) => VirtualColumn(outOfLineParamsLabel, colLabel, expr.typ)(new AtomicPositionInfo(source)) }
                 }.toMap
 
               val udfCtx = Ctx(
                 scope = udfScope,
+                toSource = Source.Saved(udfScopedResourceName, _),
                 scopedResourceName = Some(udfScopedResourceName),
                 canonicalName = Some(udfCanonicalName),
                 primaryTableName = primaryTableName(udfScope, parsed),
@@ -1150,7 +1156,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 case None =>
                   unwrappedUseQuery
                 case Some(wq) =>
-                  analyzeStatement(Ctx(wq.scope, None, None, udfCtx.primaryTableName, Environment.empty, innerUdfParams, Set.empty, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name)))
+                  analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, innerUdfParams, Set.empty, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name)))
               }
 
               FromStatement(
@@ -1187,6 +1193,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
               // additional joining.
               val udfCtx = Ctx(
                 scope = udfScope,
+                toSource = Source.Saved(udfScopedResourceName, _),
                 scopedResourceName = Some(udfScopedResourceName),
                 canonicalName = Some(udfCanonicalName),
                 primaryTableName = primaryTableName(udfScope, parsed),
@@ -1202,7 +1209,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 case None =>
                   unwrappedUseQuery
                 case Some(wq) =>
-                  analyzeStatement(Ctx(wq.scope, None, None, udfCtx.primaryTableName, Environment.empty, Map.empty, Set.empty, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name)))
+                  analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, Map.empty, Set.empty, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name)))
               }
           }
         case _ =>
@@ -1217,7 +1224,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
       namedExprs: Map[ColumnName, Expr],
       expectedType: Option[CT]
     ): Expr = {
-      val tc = new Typechecker(ctx.scopedResourceName, ctx.canonicalName, ctx.primaryTableName, ctx.enclosingEnv, namedExprs, ctx.udfParams, userParameters, typeInfo, functionInfo)
+      val tc = new Typechecker(ctx.toSource, ctx.canonicalName, ctx.primaryTableName, ctx.enclosingEnv, namedExprs, ctx.udfParams, userParameters, typeInfo, functionInfo)
       tc(expr, expectedType) match {
         case Right(e) => e
         case Left(err) => augmentTypecheckException(err)
@@ -1278,8 +1285,8 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
       throw Bail(tce)
   }
 
-  def illegalThisReference(source: Option[ScopedResourceName], position: Position): Nothing =
-    throw Bail(Error.IllegalThisReference(Source.nonSynthetic(source, position)))
-  def parameterlessTableFunction(source: Option[ScopedResourceName], name: ResourceName, position: Position): Nothing =
-    throw Bail(Error.ParameterlessTableFunction(Source.nonSynthetic(source, position), name))
+  def illegalThisReference(source: Source): Nothing =
+    throw Bail(Error.IllegalThisReference(source))
+  def parameterlessTableFunction(source: Source, name: ResourceName): Nothing =
+    throw Bail(Error.ParameterlessTableFunction(source, name))
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -352,12 +352,12 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
         tableMap.find(name) match {
           case ds: TableDescription.Dataset[MT] =>
             fromTable(name, ds)
-          case TableDescription.Query(scope, canonicalName, basedOn, parsed, _unparsed, parameters, hiddenColumns, outputColumnHints) =>
-            // so this is basedOn |> parsed
+          case TableDescription.Query(scope, canonicalName, basedOn, parsed, _unparsed, parameters, hiddenColumns, outputColumnHints, wq) =>
+            // so this is basedOn |> parsed |> wq
             // so we want to use "basedOn" as the implicit "from" for "parsed"
             val from = analyzeForFrom(source, ScopedResourceName(scope, basedOn), None, NoPosition /* Yes, actually NoPosition here */)
             analyzeStatement(Ctx(scope, Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, hiddenColumns, outputColumnHints, true), parsed, ImplicitFrom.Required(from, Some(basedOn)))
-          case TableDescription.TableFunction(_, _, _, _, _, _) =>
+          case TableDescription.TableFunction(_, _, _, _, _, _, _) =>
             parameterlessTableFunction(source, name.name, position)
         }
       }
@@ -1089,7 +1089,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
     def analyzeUDF(callerCtx: Ctx, resource: ResourceName, params: Seq[ast.Expression]): AtomicFrom = {
       val udfScopedResourceName = ScopedResourceName(callerCtx.scope, resource)
       tableMap.find(udfScopedResourceName) match {
-        case TableDescription.TableFunction(udfScope, udfCanonicalName, parsed, _unparsed, paramSpecs, hiddenColumns) =>
+        case TableDescription.TableFunction(udfScope, udfCanonicalName, parsed, _unparsed, paramSpecs, hiddenColumns, wq) =>
           if(params.length != paramSpecs.size) {
             callerCtx.incorrectNumberOfParameters(resource, expected = paramSpecs.size, got = params.length, position = NoPosition /* TODO: NEED POS INFO FROM AST */)
           }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -126,6 +126,8 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
     sealed abstract class ImplicitFrom {
       def optionalize(left: Boolean): ImplicitFrom
       def forced: Boolean
+      def requiredSchema: Option[Seq[(ColumnName, CT)]]
+      def withoutRequiredSchema: ImplicitFrom
     }
     object ImplicitFrom {
       // "none" means "there is no implicit FROM; the current soql
@@ -134,14 +136,17 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
       case object None extends ImplicitFrom {
         def optionalize(left: Boolean) = this
         def forced = true
+        def requiredSchema = Option.empty
+        def withoutRequiredSchema = this
       }
       // "required" means "there is an implicit FROM; the current soql
       // query _must not_ provide one that queries something else, but
       // _may_ do "FROM @this AS @alias", or if the parent query was
       // named, "FROM @that-name [AS @alias]"
-      case class Required(from: AtomicFrom, named: Option[ResourceName]) extends ImplicitFrom {
+      case class Required(from: AtomicFrom, named: Option[ResourceName], requiredSchema: Option[Seq[(ColumnName, CT)]]) extends ImplicitFrom {
         def optionalize(left: Boolean) = new Optional(from, left)
         def forced = true
+        def withoutRequiredSchema = copy(requiredSchema = Option.empty)
       }
       // "optional" means "there is an implicit FROM, but it is not
       // required to be used in the current context; the current soql
@@ -174,6 +179,8 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
         }
         def optionalize(newLeft: Boolean) = new Optional(underlying, leftmost && newLeft, forcedOnce)
         def forced = forcedOnce.get
+        def requiredSchema = Option.empty
+        def withoutRequiredSchema = this
       }
     }
 
@@ -185,10 +192,10 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
             analyzeForFrom(ctx.toSource, ScopedResourceName(scope, rn), None, NoPosition)
           case FoundTables.InContext(rn, q, _, parameters) =>
             val from = analyzeForFrom(ctx.toSource, ScopedResourceName(scope, rn), None, NoPosition)
-            analyzeStatement(ctx, q, ImplicitFrom.Required(from, Some(rn)))
+            analyzeStatement(ctx, q, ImplicitFrom.Required(from, Some(rn), requiredSchema = None))
           case FoundTables.InContextImpersonatingSaved(rn, q, _, parameters, impersonating) =>
             val from = analyzeForFrom(ctx.toSource, ScopedResourceName(scope, rn), None, NoPosition)
-            analyzeStatement(ctx.copy(canonicalName = Some(impersonating)), q, ImplicitFrom.Required(from, Some(rn)))
+            analyzeStatement(ctx.copy(canonicalName = Some(impersonating)), q, ImplicitFrom.Required(from, Some(rn), requiredSchema = None))
           case FoundTables.Standalone(q, _, parameters) =>
             analyzeStatement(ctx, q, ImplicitFrom.None)
         }
@@ -349,7 +356,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
             if(dci.hidden) Set(dci.name)
             else None
           }.toSet
-          wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(srn), None, primaryTableName(srn), Environment.empty, Map.empty, hiddenColumns, Map.empty, true), wq.parsed, ImplicitFrom.Required(withoutWrapper, Some(srn.name))), withoutWrapper.label, srn)
+          wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(srn), None, primaryTableName(srn), Environment.empty, Map.empty, hiddenColumns, Map.empty, true), wq.parsed, ImplicitFrom.Required(withoutWrapper, Some(srn.name), requiredSchema = Some(schemaOf(withoutWrapper)))), withoutWrapper.label, srn)
       }
     }
 
@@ -391,12 +398,12 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
             // so this is basedOn |> parsed |> wq
             // so we want to use "basedOn" as the implicit "from" for "parsed"
             val from = analyzeForFrom(toSource, ScopedResourceName(scope, basedOn), None, NoPosition /* Yes, actually NoPosition here */)
-            val middle = analyzeStatement(Ctx(scope, Source.Saved(name, _), Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, if(wq.isDefined) Set.empty else hiddenColumns, outputColumnHints, true), parsed, ImplicitFrom.Required(from, Some(basedOn)))
+            val middle = analyzeStatement(Ctx(scope, Source.Saved(name, _), Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, if(wq.isDefined) Set.empty else hiddenColumns, outputColumnHints, true), parsed, ImplicitFrom.Required(from, Some(basedOn), requiredSchema = None))
             wq match {
               case None =>
                 middle
               case Some(wq) =>
-                wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, hiddenColumns, Map.empty, true), wq.parsed, ImplicitFrom.Required(middle, Some(name.name))), middle.label, name)
+                wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, hiddenColumns, Map.empty, true), wq.parsed, ImplicitFrom.Required(middle, Some(name.name), requiredSchema = Some(schemaOf(middle)))), middle.label, name)
             }
           case TableDescription.TableFunction(_, _, _, _, _, _, _) =>
             parameterlessTableFunction(toSource(position), name.name)
@@ -523,9 +530,9 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 outputColumnHints = Map.empty,
                 attemptToPreserveSystemColumns = preserveSystemColumnsRequested
               ),
-              left, from0
+              left, from0.withoutRequiredSchema
             )
-          analyzeStatement(ctx, right, ImplicitFrom.Required(analyzedLeft, None))
+          analyzeStatement(ctx, right, ImplicitFrom.Required(analyzedLeft, None, from0.requiredSchema))
         case other: TrueOp[ast.Select] =>
           analyzeTableOp(ctx, other, from0)
       }
@@ -565,6 +572,8 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
       }
 
       val combined = CombinedTables(opify(op), lhs, rhs)
+      checkRequiredSchema(ctx.scopedResourceName, combined, from0.requiredSchema)
+
       val fromCombined = FromStatement(combined, labelProvider.tableLabel(), ctx.scopedResourceName, ctx.canonicalName, None)
       if(ctx.hiddenColumns.isEmpty) {
         fromCombined
@@ -621,6 +630,17 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
           Nil
       }
 
+    def checkRequiredSchema(srn: Option[ScopedResourceName], stmt: Statement, requiredSchema: Option[Seq[(ColumnName, CT)]]): Unit = {
+      for(rs <- requiredSchema) {
+        if(stmt.schema.valuesIterator.map { se => (se.name, se.typ) }.toSeq != rs) {
+          val source = srn match {
+            case Some(name) => Source.Saved(name, NoPosition)
+            case None => Source.Anonymous(NoPosition) // this shouldn't ever actually happen
+          }
+          throw Bail(Error.WrappingQuerySchemaMismatch(source))
+        }
+      }
+    }
 
     def addSystemColumnsIfDesired(select: Select, attemptToPreserveSystemColumns: Boolean): Select =
       aggregateMerge match {
@@ -812,6 +832,8 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
 
       verifyAggregatesAndWindowFunctions(ctx, stmt)
 
+      checkRequiredSchema(ctx.scopedResourceName, stmt, from0.requiredSchema)
+
       if(ctx.hiddenColumns.isEmpty) {
         FromStatement(stmt, labelProvider.tableLabel(), ctx.scopedResourceName, ctx.canonicalName, None)
       } else {
@@ -993,7 +1015,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
         case (ImplicitFrom.None, None) =>
           // No required context and no from given; this is an error
           ctx.noDataSource(NoPosition /* TODO: NEED POS INFO FROM AST */)
-        case (ImplicitFrom.Required(prev, maybeName), Some(tn)) =>
+        case (ImplicitFrom.Required(prev, maybeName, _), Some(tn)) =>
           tn.aliasWithoutPrefix.foreach(ensureLegalAlias(ctx, _, NoPosition /* TODO: NEED POS INFO FROM AST */))
           val rn = ResourceName(tn.nameWithoutPrefix)
           if(rn == SoQLAnalyzer.This || Some(rn) == maybeName) {
@@ -1029,7 +1051,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
             // n.b., sometable may actually be a query
             fromNamedTable(rn, alias)
           }
-        case (ImplicitFrom.Required(input, _), None) =>
+        case (ImplicitFrom.Required(input, _, _), None) =>
           // chained query: {something} |> {the thing we're analyzing}
           input.reAlias(None)
         case (opt: ImplicitFrom.Optional, None) =>
@@ -1184,7 +1206,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 case None =>
                   unwrappedUseQuery
                 case Some(wq) =>
-                  wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, innerUdfParams, hiddenColumns, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name))), unwrappedUseQuery.label, udfScopedResourceName)
+                  wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, innerUdfParams, hiddenColumns, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name), requiredSchema = Some(schemaOf(unwrappedUseQuery)))), unwrappedUseQuery.label, udfScopedResourceName)
               }
 
               FromStatement(
@@ -1237,7 +1259,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 case None =>
                   unwrappedUseQuery
                 case Some(wq) =>
-                  wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, Map.empty, hiddenColumns, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name))), unwrappedUseQuery.label, udfScopedResourceName)
+                  wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, Map.empty, hiddenColumns, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name), requiredSchema = Some(schemaOf(unwrappedUseQuery)))), unwrappedUseQuery.label, udfScopedResourceName)
               }
           }
         case _ =>
@@ -1245,6 +1267,11 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
           callerCtx.parametersForNonUdf(resource, position = NoPosition /* TODO: NEED POS INFO FROM AST */)
       }
     }
+
+    def schemaOf(from: From): Seq[(ColumnName, CT)] =
+      from.schema.iterator.map { case se =>
+        se.name -> se.typ
+      }.toSeq
 
     def typecheck(
       ctx: Ctx,

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -273,7 +273,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
     }
 
     def fromTable(srn: ScopedResourceName, desc: TableDescription.Dataset[MT]): AtomicFrom = {
-      if(desc.ordering.isEmpty) {
+      val withoutWrapper = if(desc.ordering.isEmpty) {
         val hiddenColumns: Set[DatabaseColumnName] =
           desc.schema.iterator.flatMap { case (databaseColumnName, FromTable.ColumnInfo(name, _, _)) =>
             if(desc.hiddenColumns(name)) Some(databaseColumnName)
@@ -339,6 +339,13 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
           None
         )
       }
+
+      desc.wrappingQuery match {
+        case None =>
+          withoutWrapper
+        case Some(wq) =>
+          analyzeStatement(Ctx(wq.scope, None, None, primaryTableName(srn), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(withoutWrapper, Some(srn.name)))
+      }
     }
 
     def analyzeForFrom(source: Option[ScopedResourceName], name: ScopedResourceName, canonicalName: Option[CanonicalName], position: Position): AtomicFrom = {
@@ -356,7 +363,13 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
             // so this is basedOn |> parsed |> wq
             // so we want to use "basedOn" as the implicit "from" for "parsed"
             val from = analyzeForFrom(source, ScopedResourceName(scope, basedOn), None, NoPosition /* Yes, actually NoPosition here */)
-            analyzeStatement(Ctx(scope, Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, hiddenColumns, outputColumnHints, true), parsed, ImplicitFrom.Required(from, Some(basedOn)))
+            val middle = analyzeStatement(Ctx(scope, Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, hiddenColumns, outputColumnHints, true), parsed, ImplicitFrom.Required(from, Some(basedOn)))
+            wq match {
+              case None =>
+                middle
+              case Some(wq) =>
+                analyzeStatement(Ctx(wq.scope, None, None, primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(middle, Some(name.name)))
+            }
           case TableDescription.TableFunction(_, _, _, _, _, _, _) =>
             parameterlessTableFunction(source, name.name, position)
         }
@@ -1096,7 +1109,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
           // we're rewriting the UDF from
           //    @bleh(x, y, z)
           // to
-          //    select * from (values (x,y,z)) join lateral (udfexpansion) on true
+          //    select * from (values (x,y,z)) join lateral (udfexpansion |> wq) on true
           // Possibly we'll want a rewrite pass that inlines constants and
           // maybe simple column references into the udf expansion,
 
@@ -1132,7 +1145,13 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 attemptToPreserveSystemColumns = callerCtx.attemptToPreserveSystemColumns
               )
 
-              val useQuery = analyzeStatement(udfCtx, parsed, ImplicitFrom.None)
+              val unwrappedUseQuery = analyzeStatement(udfCtx, parsed, ImplicitFrom.None)
+              val useQuery = wq match {
+                case None =>
+                  unwrappedUseQuery
+                case Some(wq) =>
+                  analyzeStatement(Ctx(wq.scope, None, None, udfCtx.primaryTableName, Environment.empty, innerUdfParams, Set.empty, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name)))
+              }
 
               FromStatement(
                 Select(
@@ -1178,7 +1197,13 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 attemptToPreserveSystemColumns = callerCtx.attemptToPreserveSystemColumns
               )
 
-              analyzeStatement(udfCtx, parsed, ImplicitFrom.None)
+              val unwrappedUseQuery = analyzeStatement(udfCtx, parsed, ImplicitFrom.None)
+              wq match {
+                case None =>
+                  unwrappedUseQuery
+                case Some(wq) =>
+                  analyzeStatement(Ctx(wq.scope, None, None, udfCtx.primaryTableName, Environment.empty, Map.empty, Set.empty, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name)))
+              }
           }
         case _ =>
           // Non-UDF

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -276,7 +276,8 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
       val withoutWrapper = if(desc.ordering.isEmpty) {
         val hiddenColumns: Set[DatabaseColumnName] =
           desc.schema.iterator.flatMap { case (databaseColumnName, FromTable.ColumnInfo(name, _, _)) =>
-            if(desc.hiddenColumns(name)) Some(databaseColumnName)
+            // if there is a wrapper, hidden columns will be handled at that point
+            if(desc.wrappingQuery.isEmpty && desc.hiddenColumns(name)) Some(databaseColumnName)
             else None
           }.toSet
 
@@ -344,7 +345,11 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
         case None =>
           withoutWrapper
         case Some(wq) =>
-          wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(srn), None, primaryTableName(srn), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(withoutWrapper, Some(srn.name))), withoutWrapper.label, srn)
+          val hiddenColumns = desc.columns.valuesIterator.flatMap { dci =>
+            if(dci.hidden) Set(dci.name)
+            else None
+          }.toSet
+          wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(srn), None, primaryTableName(srn), Environment.empty, Map.empty, hiddenColumns, Map.empty, true), wq.parsed, ImplicitFrom.Required(withoutWrapper, Some(srn.name))), withoutWrapper.label, srn)
       }
     }
 
@@ -386,12 +391,12 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
             // so this is basedOn |> parsed |> wq
             // so we want to use "basedOn" as the implicit "from" for "parsed"
             val from = analyzeForFrom(toSource, ScopedResourceName(scope, basedOn), None, NoPosition /* Yes, actually NoPosition here */)
-            val middle = analyzeStatement(Ctx(scope, Source.Saved(name, _), Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, hiddenColumns, outputColumnHints, true), parsed, ImplicitFrom.Required(from, Some(basedOn)))
+            val middle = analyzeStatement(Ctx(scope, Source.Saved(name, _), Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, if(wq.isDefined) Set.empty else hiddenColumns, outputColumnHints, true), parsed, ImplicitFrom.Required(from, Some(basedOn)))
             wq match {
               case None =>
                 middle
               case Some(wq) =>
-                wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, Set.empty, Map.empty, true), wq.parsed, ImplicitFrom.Required(middle, Some(name.name))), middle.label, name)
+                wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, hiddenColumns, Map.empty, true), wq.parsed, ImplicitFrom.Required(middle, Some(name.name))), middle.label, name)
             }
           case TableDescription.TableFunction(_, _, _, _, _, _, _) =>
             parameterlessTableFunction(toSource(position), name.name)
@@ -1169,7 +1174,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 primaryTableName = primaryTableName(udfScope, parsed),
                 enclosingEnv = Environment.empty,
                 udfParams = innerUdfParams,
-                hiddenColumns = hiddenColumns,
+                hiddenColumns = if(wq.isDefined) Set.empty else hiddenColumns,
                 outputColumnHints = Map.empty,
                 attemptToPreserveSystemColumns = callerCtx.attemptToPreserveSystemColumns
               )
@@ -1179,7 +1184,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 case None =>
                   unwrappedUseQuery
                 case Some(wq) =>
-                  wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, innerUdfParams, Set.empty, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name))), unwrappedUseQuery.label, udfScopedResourceName)
+                  wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, innerUdfParams, hiddenColumns, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name))), unwrappedUseQuery.label, udfScopedResourceName)
               }
 
               FromStatement(
@@ -1222,7 +1227,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 primaryTableName = primaryTableName(udfScope, parsed),
                 enclosingEnv = Environment.empty,
                 udfParams = Map.empty,
-                hiddenColumns = hiddenColumns,
+                hiddenColumns = if(wq.isDefined) Set.empty else hiddenColumns,
                 outputColumnHints = Map.empty,
                 attemptToPreserveSystemColumns = callerCtx.attemptToPreserveSystemColumns
               )
@@ -1232,7 +1237,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 case None =>
                   unwrappedUseQuery
                 case Some(wq) =>
-                  wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, Map.empty, Set.empty, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name))), unwrappedUseQuery.label, udfScopedResourceName)
+                  wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, Map.empty, hiddenColumns, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name))), unwrappedUseQuery.label, udfScopedResourceName)
               }
           }
         case _ =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -571,8 +571,11 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
         )
       }
 
-      val combined = CombinedTables(opify(op), lhs, rhs)
-      checkRequiredSchema(ctx.scopedResourceName, combined, from0.requiredSchema)
+      val combinedPossiblyWrongOrder = CombinedTables(opify(op), lhs, rhs)
+      val combined = from0.requiredSchema match {
+        case None => combinedPossiblyWrongOrder
+        case Some(targetSchema) => combinedPossiblyWrongOrder.ensureSchema(labelProvider, targetSchema).getOrElse(wrappingQuerySchemaMismatch(ctx.scopedResourceName))
+      }
 
       val fromCombined = FromStatement(combined, labelProvider.tableLabel(), ctx.scopedResourceName, ctx.canonicalName, None)
       if(ctx.hiddenColumns.isEmpty) {
@@ -630,16 +633,12 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
           Nil
       }
 
-    def checkRequiredSchema(srn: Option[ScopedResourceName], stmt: Statement, requiredSchema: Option[Seq[(ColumnName, CT)]]): Unit = {
-      for(rs <- requiredSchema) {
-        if(stmt.schema.valuesIterator.map { se => (se.name, se.typ) }.toSeq != rs) {
-          val source = srn match {
-            case Some(name) => Source.Saved(name, NoPosition)
-            case None => Source.Anonymous(NoPosition) // this shouldn't ever actually happen
-          }
-          throw Bail(Error.WrappingQuerySchemaMismatch(source))
-        }
+    def wrappingQuerySchemaMismatch(srn: Option[ScopedResourceName]): Nothing = {
+      val source = srn match {
+        case Some(name) => Source.Saved(name, NoPosition)
+        case None => Source.Anonymous(NoPosition) // this shouldn't ever actually happen
       }
+      throw Bail(Error.WrappingQuerySchemaMismatch(source))
     }
 
     def addSystemColumnsIfDesired(select: Select, attemptToPreserveSystemColumns: Boolean): Select =
@@ -808,7 +807,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
         labelProvider.columnLabel() -> NamedExpr(expr, cn, ctx.outputColumnHints.get(cn), isSynthetic = false)
       }
 
-      val stmt = addSystemColumnsIfDesired(Select(
+      val stmtPossiblyWrongOrder = addSystemColumnsIfDesired(Select(
         checkedDistinct,
         selectList,
         completeFrom.typecheckOnClauses(ctx, finalState.referencableNamedExprs),
@@ -830,9 +829,12 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
         }.toSet
       ), attemptToPreserveSystemColumns = ctx.attemptToPreserveSystemColumns)
 
-      verifyAggregatesAndWindowFunctions(ctx, stmt)
+      verifyAggregatesAndWindowFunctions(ctx, stmtPossiblyWrongOrder)
 
-      checkRequiredSchema(ctx.scopedResourceName, stmt, from0.requiredSchema)
+      val stmt = from0.requiredSchema match {
+        case None => stmtPossiblyWrongOrder
+        case Some(targetSchema) => stmtPossiblyWrongOrder.ensureSchema(labelProvider, targetSchema).getOrElse(wrappingQuerySchemaMismatch(ctx.scopedResourceName))
+      }
 
       if(ctx.hiddenColumns.isEmpty) {
         FromStatement(stmt, labelProvider.tableLabel(), ctx.scopedResourceName, ctx.canonicalName, None)

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLError.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLError.scala
@@ -421,6 +421,33 @@ object SoQLAnalyzerError {
     }
   }
 
+  case class WrappingQuerySchemaMismatch[RNS](
+    source: Source[RNS]
+  ) extends TextualSoQLAnalyzerError[RNS]
+  object WrappingQuerySchemaMismatch {
+    private val tag = "soql.analyzer.wrapping-query-schema-mismatch"
+
+    @AutomaticJsonCodec
+    private case class Fields()
+
+    implicit def encode[RNS: JsonEncode] = new SoQLErrorEncode[WrappingQuerySchemaMismatch[RNS]] {
+      override val code = tag
+      def encode(err: WrappingQuerySchemaMismatch[RNS]) =
+        result(Fields(), s"Wrapping queries must produce the same schema as their wrapped query", err.source)
+    }
+
+    implicit def decode[RNS: JsonDecode] = new SoQLErrorDecode[WrappingQuerySchemaMismatch[RNS]] {
+      override val code = tag
+      def decode(v: EncodedError) =
+        for {
+          fields <- data[Fields](v)
+          source <- source[RNS](v)
+        } yield {
+          WrappingQuerySchemaMismatch(source)
+        }
+    }
+  }
+
   case class IncorrectNumberOfUdfParameters[+RNS](
     source: Source[RNS],
     udf: ResourceName,
@@ -1311,6 +1338,7 @@ object SoQLAnalyzerError {
   ): SoQLErrorCodec.ErrorCodecs[T] =
     AliasAnalysisError.errorCodecsMinusNoSuchColumn[RNS, T](TypecheckError.errorCodecs[RNS, T](codecs))
       .branch[InvalidParameterType]
+      .branch[WrappingQuerySchemaMismatch[RNS]]
       .branch[ExpectedBoolean[RNS]]
       .branch[IncorrectNumberOfUdfParameters[RNS]]
       .branch[DistinctOnNotPrefixOfOrderBy[RNS]]

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Statement.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Statement.scala
@@ -22,6 +22,8 @@ sealed abstract class Statement[MT <: MetaTypes] extends LabelUniverse[MT] {
 
   val schema: OrderedMap[AutoColumnLabel, Statement.SchemaEntry[MT]]
 
+  private[analyzer2] def ensureSchema(labelProvider: LabelProvider, schema: Seq[(ColumnName, CT)]): Option[Statement[MT]]
+
   // See the comment in From for an explanation of this.  It's just
   // labels here because, as a Statement, we don't have enough
   // information to produce a full Column.
@@ -182,11 +184,17 @@ object Statement {
   }
 }
 
+private[analyzer2] sealed trait EnsureSchemaSelf[MT <: MetaTypes] extends Statement[MT] {
+  // strengthen the contract to promise that when we ensure schema,
+  // we'll get the same kind of Statement back
+  private[analyzer2] override def ensureSchema(labelProvider: LabelProvider, schema: Seq[(ColumnName, CT)]): Option[Self[MT]]
+}
+
 case class CombinedTables[MT <: MetaTypes](
   op: TableFunc,
   left: Statement[MT],
   right: Statement[MT]
-) extends Statement[MT] with statement.CombinedTablesImpl[MT] {
+) extends Statement[MT] with EnsureSchemaSelf[MT] with statement.CombinedTablesImpl[MT] {
   require(left.schema.values.map(_.typ) == right.schema.values.map(_.typ))
 }
 object CombinedTables extends statement.OCombinedTablesImpl
@@ -199,7 +207,7 @@ object CombinedTables extends statement.OCombinedTablesImpl
 case class CTE[MT <: MetaTypes] private (
   definitions: OrderedMap[AutoCTELabel, CTE.Definition[MT]],
   useQuery: Statement[MT]
-) extends Statement[MT] with statement.CTEImpl[MT]
+) extends Statement[MT] with EnsureSchemaSelf[MT] with statement.CTEImpl[MT]
 object CTE extends statement.OCTEImpl {
   def apply[MT <: MetaTypes](
     definitions: OrderedMap[AutoCTELabel, CTE.Definition[MT]],
@@ -240,6 +248,6 @@ case class Select[MT <: MetaTypes](
   offset: Option[BigInt],
   search: Option[String],
   hint: Set[SelectHint]
-) extends Statement[MT] with statement.SelectImpl[MT]
+) extends Statement[MT] with EnsureSchemaSelf[MT] with statement.SelectImpl[MT]
 
 object Select extends statement.OSelectImpl

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/TableDescription.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/TableDescription.scala
@@ -45,20 +45,18 @@ object TableDescription {
   case class WrappingQuery[MT <: MetaTypes](
     scope: MT#ResourceNameScope,
     parsed: BinaryTree[ast.Select],
-    unparsed: String,
-    parameters: Map[HoleName, MT#ColumnType]
+    unparsed: String
   ) extends LabelUniverse[MT] {
     private[analyzer2] def rewriteScopes[MT2 <: MetaTypes](scopeMap: Map[RNS, MT2#ResourceNameScope])(implicit ev: MetaTypes.ChangesOnlyRNS[MT, MT2]): WrappingQuery[MT2] =
       WrappingQuery(
         scopeMap(scope),
         parsed,
-        unparsed,
-        parameters.asInstanceOf[Map[HoleName, MT2#ColumnType]] // SAFETY: ColumnType isn't changing,
+        unparsed
       )
     def rewriteDatabaseNames[MT2 <: MetaTypes](implicit ev: MetaTypes.ChangesOnlyLabels[MT, MT2]) =
       this.asInstanceOf[WrappingQuery[MT2]] // SAFETY: no labels in here
 
-    def asUnparsedWrappingQuery = UnparsedTableDescription.WrappingQuery[MT](scope, unparsed, parameters)
+    def asUnparsedWrappingQuery = UnparsedTableDescription.WrappingQuery[MT](scope, unparsed)
   }
 
   private[analyzer2] def jsonEncode[MT <: MetaTypes](implicit enc: JsonEncode[UnparsedTableDescription[MT]]) =

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/TableDescription.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/TableDescription.scala
@@ -42,6 +42,25 @@ sealed trait TableDescription[MT <: MetaTypes] extends TableDescriptionLike with
 }
 
 object TableDescription {
+  case class WrappingQuery[MT <: MetaTypes](
+    scope: MT#ResourceNameScope,
+    parsed: BinaryTree[ast.Select],
+    unparsed: String,
+    parameters: Map[HoleName, MT#ColumnType]
+  ) extends LabelUniverse[MT] {
+    private[analyzer2] def rewriteScopes[MT2 <: MetaTypes](scopeMap: Map[RNS, MT2#ResourceNameScope])(implicit ev: MetaTypes.ChangesOnlyRNS[MT, MT2]): WrappingQuery[MT2] =
+      WrappingQuery(
+        scopeMap(scope),
+        parsed,
+        unparsed,
+        parameters.asInstanceOf[Map[HoleName, MT2#ColumnType]] // SAFETY: ColumnType isn't changing,
+      )
+    def rewriteDatabaseNames[MT2 <: MetaTypes](implicit ev: MetaTypes.ChangesOnlyLabels[MT, MT2]) =
+      this.asInstanceOf[WrappingQuery[MT2]] // SAFETY: no labels in here
+
+    def asUnparsedWrappingQuery = UnparsedTableDescription.WrappingQuery[MT](scope, unparsed, parameters)
+  }
+
   private[analyzer2] def jsonEncode[MT <: MetaTypes](implicit enc: JsonEncode[UnparsedTableDescription[MT]]) =
     new JsonEncode[TableDescription[MT]] {
       def encode(x: TableDescription[MT]) =
@@ -51,13 +70,10 @@ object TableDescription {
   private[analyzer2] def jsonDecode[MT <: MetaTypes](parserParameters: AbstractParser.Parameters)(implicit dec: JsonDecode[UnparsedTableDescription[MT]]) =
     new JsonDecode[TableDescription[MT]] {
       def decode(x: JValue) =
-        JsonDecode.fromJValue[UnparsedTableDescription[MT]](x).flatMap {
-          case c: UnparsedTableDescription.SoQLUnparsedTableDescription[MT] =>
-            c.parse(parserParameters).left.map { _ =>
-              DecodeError.InvalidValue(JString(c.soql)).prefix("soql")
-            }
-          case UnparsedTableDescription.Dataset(name, canonicalName, schema, ordering, primaryKey) =>
-            Right(Dataset[MT](name, canonicalName, schema, ordering, primaryKey))
+        JsonDecode.fromJValue[UnparsedTableDescription[MT]](x).flatMap { unparsed =>
+          unparsed.parse(parserParameters).left.map { case (err, fields, text) =>
+            fields.reverse.foldLeft[DecodeError](DecodeError.InvalidValue(JString(text)))(_.prefix(_))
+          }
         }
     }
 
@@ -78,7 +94,8 @@ object TableDescription {
     canonicalName: CanonicalName,
     columns: OrderedMap[types.DatabaseColumnName[MT], DatasetColumnInfo[MT#ColumnType]],
     ordering: Seq[Ordering[MT]],
-    primaryKeys: Seq[Seq[types.DatabaseColumnName[MT]]]
+    primaryKeys: Seq[Seq[types.DatabaseColumnName[MT]]],
+    wrappingQuery: Option[WrappingQuery[MT]]
   ) extends TableDescription[MT] with TableDescriptionLike.Dataset[MT] {
     for(o <- ordering) {
       require(columns.contains(o.column), "Ordering not in dataset")
@@ -101,7 +118,14 @@ object TableDescription {
     require(ordering.forall { o => columns.contains(o.column) })
 
     private[analyzer2] def rewriteScopes[MT2 <: MetaTypes](scopeMap: Map[RNS, MT2#ResourceNameScope])(implicit ev: MetaTypes.ChangesOnlyRNS[MT, MT2]): TableDescription[MT2] =
-      this.asInstanceOf[TableDescription[MT2]] // SAFETY: We only care about the NameImpls and ColumnType, neither of which are changing
+      Dataset[MT2](
+        ev.convertDTN(name),
+        canonicalName,
+        columns.asInstanceOf, // SAFETY: None of
+        ordering.asInstanceOf, // these things
+        primaryKeys.asInstanceOf, // contain scopes
+        wrappingQuery.map(_.rewriteScopes[MT2](scopeMap))
+      )
 
     private[analyzer2] def rewriteDatabaseNames[MT2 <: MetaTypes](
       tableName: DatabaseTableName => types.DatabaseTableName[MT2],
@@ -118,12 +142,13 @@ object TableDescription {
         ordering.map { case TableDescription.Ordering(dcn, ascending, nullLast) =>
           TableDescription.Ordering(columnName(name, dcn), ascending, nullLast)
         },
-        primaryKeys.map(_.map(columnName(name, _)))
+        primaryKeys.map(_.map(columnName(name, _))),
+        wrappingQuery.map(_.rewriteDatabaseNames[MT2])
       )
     }
 
     def asUnparsedTableDescription =
-      UnparsedTableDescription.Dataset(name, canonicalName, columns, ordering, primaryKeys)
+      UnparsedTableDescription.Dataset(name, canonicalName, columns, ordering, primaryKeys, wrappingQuery.map(_.asUnparsedWrappingQuery))
 
     def directlyReferencedTables: Set[types.ScopedResourceName[MT]] =
       Set.empty
@@ -137,12 +162,14 @@ object TableDescription {
     unparsed: String,
     parameters: Map[HoleName, MT#ColumnType],
     hiddenColumns: Set[ColumnName],
-    outputColumnHints: Map[ColumnName, JValue]
+    outputColumnHints: Map[ColumnName, JValue],
+    wrappingQuery: Option[WrappingQuery[MT]]
   ) extends TableDescription[MT] {
     private[analyzer2] def rewriteScopes[MT2 <: MetaTypes](scopeMap: Map[RNS, MT2#ResourceNameScope])(implicit ev: MetaTypes.ChangesOnlyRNS[MT, MT2]): Query[MT2] =
       copy(
         scope = scopeMap(scope),
-        parameters = parameters.asInstanceOf[Map[HoleName, MT2#ColumnType]] // SAFETY: ColumnType isn't changing
+        parameters = parameters.asInstanceOf[Map[HoleName, MT2#ColumnType]], // SAFETY: ColumnType isn't changing
+        wrappingQuery = wrappingQuery.map(_.rewriteScopes[MT2](scopeMap))
       )
 
     private[analyzer2] def rewriteDatabaseNames[MT2 <: MetaTypes](
@@ -152,7 +179,7 @@ object TableDescription {
       this.asInstanceOf[Query[MT2]] // SAFETY: ColumnType isn't changing
 
     def asUnparsedTableDescription =
-      UnparsedTableDescription.Query(scope, canonicalName, basedOn, unparsed, parameters, hiddenColumns, outputColumnHints)
+      UnparsedTableDescription.Query(scope, canonicalName, basedOn, unparsed, parameters, hiddenColumns, outputColumnHints, wrappingQuery.map(_.asUnparsedWrappingQuery))
 
     def directlyReferencedTables: Set[types.ScopedResourceName[MT]] =
       Util.walkParsed[MT](Set(ScopedResourceName(scope, basedOn)), scope, parsed)
@@ -164,12 +191,14 @@ object TableDescription {
     parsed: BinaryTree[ast.Select],
     unparsed: String,
     parameters: OrderedMap[HoleName, MT#ColumnType],
-    hiddenColumns: Set[ColumnName]
+    hiddenColumns: Set[ColumnName],
+    wrappingQuery: Option[WrappingQuery[MT]],
   ) extends TableDescription[MT] {
     private[analyzer2] def rewriteScopes[MT2 <: MetaTypes](scopeMap: Map[RNS, MT2#ResourceNameScope])(implicit ev: MetaTypes.ChangesOnlyRNS[MT, MT2]): TableFunction[MT2] =
       copy(
         scope = scopeMap(scope),
-        parameters = parameters.asInstanceOf[OrderedMap[HoleName, MT2#ColumnType]] // SAFETY: ColumnType isn't changing
+        parameters = parameters.asInstanceOf[OrderedMap[HoleName, MT2#ColumnType]], // SAFETY: ColumnType isn't changing
+        wrappingQuery = wrappingQuery.map(_.rewriteScopes[MT2](scopeMap))
       )
 
     private[analyzer2] def rewriteDatabaseNames[MT2 <: MetaTypes](
@@ -179,7 +208,7 @@ object TableDescription {
       this.asInstanceOf[TableFunction[MT2]] // SAFETY: ColumnType isn't changing
 
     def asUnparsedTableDescription =
-      UnparsedTableDescription.TableFunction(scope, canonicalName, unparsed, parameters, hiddenColumns)
+      UnparsedTableDescription.TableFunction(scope, canonicalName, unparsed, parameters, hiddenColumns, wrappingQuery.map(_.asUnparsedWrappingQuery))
 
     def directlyReferencedTables: Set[types.ScopedResourceName[MT]] =
       Util.walkParsed[MT](Set.empty[types.ScopedResourceName[MT]], scope, parsed)

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/TableFinder.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/TableFinder.scala
@@ -63,7 +63,8 @@ trait TableFinder[MT <: MetaTypes] {
         ordering.map { case Ordering(column, ascending, nullLast) =>
           TableDescription.Ordering(column, ascending, nullLast)
         },
-        primaryKeys
+        primaryKeys,
+        None
       )
   }
   /** A saved query, with any parameters it (non-transitively!) defines. */
@@ -237,9 +238,9 @@ trait TableFinder[MT <: MetaTypes] {
       case Right(ds: Dataset) =>
         Right(ds.toParsed)
       case Right(Query(scope, canonicalName, basedOn, text, params, hiddenColumns, outputColumnHints)) =>
-        parse(Some(scopedName), text, false).map(TableDescription.Query[MT](scope, canonicalName, basedOn, _, text, params, hiddenColumns, outputColumnHints))
+        parse(Some(scopedName), text, false).map(TableDescription.Query[MT](scope, canonicalName, basedOn, _, text, params, hiddenColumns, outputColumnHints, None))
       case Right(TableFunction(scope, canonicalName, text, params, hiddenColumns)) =>
-        parse(Some(scopedName), text, true).map(TableDescription.TableFunction[MT](scope, canonicalName, _, text, params, hiddenColumns))
+        parse(Some(scopedName), text, true).map(TableDescription.TableFunction[MT](scope, canonicalName, _, text, params, hiddenColumns, None))
       case Left(LookupError.NotFound) =>
         Left(TableFinderError.NotFound(caller, scopedName.name))
       case Left(LookupError.PermissionDenied) =>
@@ -282,14 +283,25 @@ trait TableFinder[MT <: MetaTypes] {
 
   def walkDesc(scopedName: ScopedResourceName, desc: TableDescription[MT], acc: TableMap, stack: CallStack): Result[TableMap] = {
     desc match {
-      case TableDescription.Dataset(_, _, _, _, _) => Right(acc)
-      case TableDescription.Query(scope, canonicalName, basedOn, tree, _unparsed, _params, _hiddenColumns, _outputColumnHints) =>
+      case TableDescription.Dataset(_, _, _, _, _, None) => Right(acc)
+      case TableDescription.Dataset(_, _, _, _, _, Some(wq)) => walkTree(wq.scope, SelectName.Synthetic, wq.parsed, acc, stack)
+      case TableDescription.Query(scope, canonicalName, basedOn, tree, _unparsed, _params, _hiddenColumns, _outputColumnHints, wq) =>
         for {
           acc <- walkFromName(ScopedResourceName(scope, basedOn), acc, CallerStack.Implicit(stack))
-          acc <- walkTree(scope, Some(scopedName), tree, acc, stack)
+          acc <- walkTree(scope, SelectName.Named(scopedName), tree, acc, stack)
+          acc <- wq match {
+            case None => Right(acc)
+            case Some(wq) => walkTree(wq.scope, SelectName.Synthetic, wq.parsed, acc, stack)
+          }
         } yield acc
-      case TableDescription.TableFunction(scope, canonicalName, tree, _unparsed, _params, _hiddenColumns) =>
-        walkTree(scope, Some(scopedName), tree, acc, stack)
+      case TableDescription.TableFunction(scope, canonicalName, tree, _unparsed, _params, _hiddenColumns, wq) =>
+        for {
+          acc <- walkTree(scope, SelectName.Named(scopedName), tree, acc, stack)
+          acc <- wq match {
+            case None => Right(acc)
+            case Some(wq) => walkTree(wq.scope, SelectName.Synthetic, wq.parsed, acc, stack)
+          }
+        } yield acc
     }
   }
 
@@ -297,13 +309,13 @@ trait TableFinder[MT <: MetaTypes] {
   private def walkSoQL(scope: ResourceNameScope, context: (BinaryTree[ast.Select], String) => FoundTables.Query[MT], text: String, acc: TableMap, stack: CallStack): Result[FoundTables[MT]] = {
     for {
       tree <- parse(None, text, udfParamsAllowed = false)
-      acc <- walkTree(scope, None, tree, acc, stack)
+      acc <- walkTree(scope, SelectName.Anonymous, tree, acc, stack)
     } yield {
       FoundTables[MT](acc, scope, context(tree, text), parserParameters)
     }
   }
 
-  private def walkTree(scope: ResourceNameScope, treeName: Option[ScopedResourceName], bt: BinaryTree[ast.Select], acc: TableMap, stack: CallStack): Result[TableMap] = {
+  private def walkTree(scope: ResourceNameScope, treeName: SelectName, bt: BinaryTree[ast.Select], acc: TableMap, stack: CallStack): Result[TableMap] = {
     bt match {
       case Leaf(s) => walkSelect(scope, treeName, s, acc, stack)
       case c: Compound[ast.Select] =>
@@ -314,7 +326,14 @@ trait TableFinder[MT <: MetaTypes] {
     }
   }
 
-  private def walkSelect(scope: ResourceNameScope, selectName: Option[ScopedResourceName], s: ast.Select, acc0: TableMap, stack: CallStack): Result[TableMap] = {
+  sealed abstract class SelectName
+  object SelectName {
+    case object Synthetic extends SelectName
+    case object Anonymous extends SelectName
+    case class Named(name: ScopedResourceName) extends SelectName
+  }
+
+  private def walkSelect(scope: ResourceNameScope, selectName: SelectName, s: ast.Select, acc0: TableMap, stack: CallStack): Result[TableMap] = {
     val ast.Select(
       _distinct,
       _selection,
@@ -332,8 +351,14 @@ trait TableFinder[MT <: MetaTypes] {
 
     var acc = acc0
 
-    def effectiveSource(pos: Position) =
-      Some(Source.nonSynthetic(selectName, pos))
+    def effectiveSource(pos: Position) = {
+      val source = selectName match {
+        case SelectName.Named(name) => Source.nonSynthetic(Some(name), pos)
+        case SelectName.Anonymous => Source.nonSynthetic(None, pos)
+        case SelectName.Synthetic => Source.Synthetic
+      }
+      Some(source)
+    }
 
     for(tn <- from) {
       val scopedName = ScopedResourceName(scope, ResourceName(tn.nameWithoutPrefix))

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/TableFinder.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/TableFinder.scala
@@ -41,7 +41,7 @@ trait TableFinder[MT <: MetaTypes] {
 
   case class DatasetColumnInfo(name: ColumnName, typ: ColumnType, hidden: Boolean, hint: Option[JValue])
 
-  case class WrappingQuery(scope: ResourceNameScope, soql: String, parameters: Map[HoleName, ColumnType])
+  case class WrappingQuery(scope: ResourceNameScope, soql: String)
 
   /** A base dataset, or a saved query which is being analyzed opaquely. */
   case class Dataset(
@@ -227,7 +227,7 @@ trait TableFinder[MT <: MetaTypes] {
           parsedWrappingQuery <- wrappingQuery match {
             case None => Right(None)
             case Some(wq) => parse(None, wq.soql, false).map { parsed =>
-              Some(TableDescription.WrappingQuery[MT](wq.scope, parsed, wq.soql, wq.parameters))
+              Some(TableDescription.WrappingQuery[MT](wq.scope, parsed, wq.soql))
             }
           }
         } yield {
@@ -250,7 +250,7 @@ trait TableFinder[MT <: MetaTypes] {
           parsedWrappingQuery <- wrappingQuery match {
             case None => Right(None)
             case Some(wq) => parse(None, wq.soql, false).map { parsed =>
-              Some(TableDescription.WrappingQuery[MT](wq.scope, parsed, wq.soql, wq.parameters))
+              Some(TableDescription.WrappingQuery[MT](wq.scope, parsed, wq.soql))
             }
           }
         } yield {
@@ -262,7 +262,7 @@ trait TableFinder[MT <: MetaTypes] {
           parsedWrappingQuery <- wrappingQuery match {
             case None => Right(None)
             case Some(wq) => parse(None, wq.soql, true).map { parsed =>
-              Some(TableDescription.WrappingQuery[MT](wq.scope, parsed, wq.soql, wq.parameters))
+              Some(TableDescription.WrappingQuery[MT](wq.scope, parsed, wq.soql))
             }
           }
         } yield {

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/TableFinder.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/TableFinder.scala
@@ -41,31 +41,20 @@ trait TableFinder[MT <: MetaTypes] {
 
   case class DatasetColumnInfo(name: ColumnName, typ: ColumnType, hidden: Boolean, hint: Option[JValue])
 
+  case class WrappingQuery(scope: ResourceNameScope, soql: String, parameters: Map[HoleName, ColumnType])
+
   /** A base dataset, or a saved query which is being analyzed opaquely. */
   case class Dataset(
     databaseName: types.DatabaseTableName[MT],
     canonicalName: CanonicalName,
     schema: OrderedMap[types.DatabaseColumnName[MT], DatasetColumnInfo],
     ordering: Seq[Ordering],
-    primaryKeys: Seq[Seq[types.DatabaseColumnName[MT]]]
+    primaryKeys: Seq[Seq[types.DatabaseColumnName[MT]]],
+    wrappingQuery: Option[WrappingQuery]
   ) extends FinderTableDescription {
     require(schema.valuesIterator.map(_.name).toSet.size == schema.size)
     require(ordering.forall { ordering => schema.contains(ordering.column) })
     require(primaryKeys.forall { pk => pk.forall { pkCol => schema.contains(pkCol) } })
-
-    private[analyzer2] def toParsed =
-      TableDescription.Dataset[MT](
-        databaseName,
-        canonicalName,
-        schema.map { case (cl, DatasetColumnInfo(cn, ct, hidden, hint)) =>
-          cl -> TableDescription.DatasetColumnInfo(cn, ct, hidden, hint)
-        },
-        ordering.map { case Ordering(column, ascending, nullLast) =>
-          TableDescription.Ordering(column, ascending, nullLast)
-        },
-        primaryKeys,
-        None
-      )
   }
   /** A saved query, with any parameters it (non-transitively!) defines. */
   case class Query(
@@ -75,7 +64,8 @@ trait TableFinder[MT <: MetaTypes] {
     soql: String,
     parameters: Map[HoleName, ColumnType],
     hiddenColumns: Set[ColumnName],
-    outputColumnHints: Map[ColumnName, JValue]
+    outputColumnHints: Map[ColumnName, JValue],
+    wrappingQuery: Option[WrappingQuery]
   ) extends FinderTableDescription {
   }
   /** A saved table query ("UDF"), with any parameters it defines for itself. */
@@ -84,7 +74,8 @@ trait TableFinder[MT <: MetaTypes] {
     canonicalName: CanonicalName,
     soql: String,
     parameters: OrderedMap[HoleName, ColumnType],
-    hiddenColumns: Set[ColumnName]
+    hiddenColumns: Set[ColumnName],
+    wrappingQuery: Option[WrappingQuery]
   ) extends FinderTableDescription
 
   type ScopedResourceName = com.socrata.soql.environment.ScopedResourceName[ResourceNameScope]
@@ -229,18 +220,65 @@ trait TableFinder[MT <: MetaTypes] {
     }
   }
 
+  private[analyzer2] def convertToTableDescription(scopedName: ScopedResourceName, ftd: FinderTableDescription): Result[TableDescription[MT]] = {
+    ftd match {
+      case Dataset(databaseName, canonicalName, schema, ordering, primaryKeys, wrappingQuery) =>
+        for {
+          parsedWrappingQuery <- wrappingQuery match {
+            case None => Right(None)
+            case Some(wq) => parse(None, wq.soql, false).map { parsed =>
+              Some(TableDescription.WrappingQuery[MT](wq.scope, parsed, wq.soql, wq.parameters))
+            }
+          }
+        } yield {
+          TableDescription.Dataset[MT](
+            databaseName,
+            canonicalName,
+            schema.map { case (cl, DatasetColumnInfo(cn, ct, hidden, hint)) =>
+              cl -> TableDescription.DatasetColumnInfo(cn, ct, hidden, hint)
+            },
+            ordering.map { case Ordering(column, ascending, nullLast) =>
+              TableDescription.Ordering(column, ascending, nullLast)
+            },
+            primaryKeys,
+            parsedWrappingQuery
+          )
+        }
+      case Query(scope, canonicalName, basedOn, text, params, hiddenColumns, outputColumnHints, wrappingQuery) =>
+        for {
+          parsedQuery <- parse(Some(scopedName), text, false)
+          parsedWrappingQuery <- wrappingQuery match {
+            case None => Right(None)
+            case Some(wq) => parse(None, wq.soql, false).map { parsed =>
+              Some(TableDescription.WrappingQuery[MT](wq.scope, parsed, wq.soql, wq.parameters))
+            }
+          }
+        } yield {
+          TableDescription.Query[MT](scope, canonicalName, basedOn, parsedQuery, text, params, hiddenColumns, outputColumnHints, parsedWrappingQuery)
+        }
+      case TableFunction(scope, canonicalName, text, params, hiddenColumns, wrappingQuery) =>
+        for {
+          parsedQuery <- parse(Some(scopedName), text, true)
+          parsedWrappingQuery <- wrappingQuery match {
+            case None => Right(None)
+            case Some(wq) => parse(None, wq.soql, true).map { parsed =>
+              Some(TableDescription.WrappingQuery[MT](wq.scope, parsed, wq.soql, wq.parameters))
+            }
+          }
+        } yield {
+          TableDescription.TableFunction[MT](scope, canonicalName, parsedQuery, text, params, hiddenColumns, parsedWrappingQuery)
+        }
+    }
+  }
+
   // A helper that lifts the abstract function into the Result world
   private def doLookup(
     scopedName: ScopedResourceName, // the name of the thing we're looking up
     caller: Option[Source[ResourceNameScope]] // the location of the reference of `scopedName`
   ): Result[TableDescription[MT]] = {
     lookup(scopedName) match {
-      case Right(ds: Dataset) =>
-        Right(ds.toParsed)
-      case Right(Query(scope, canonicalName, basedOn, text, params, hiddenColumns, outputColumnHints)) =>
-        parse(Some(scopedName), text, false).map(TableDescription.Query[MT](scope, canonicalName, basedOn, _, text, params, hiddenColumns, outputColumnHints, None))
-      case Right(TableFunction(scope, canonicalName, text, params, hiddenColumns)) =>
-        parse(Some(scopedName), text, true).map(TableDescription.TableFunction[MT](scope, canonicalName, _, text, params, hiddenColumns, None))
+      case Right(ftd) =>
+        convertToTableDescription(scopedName, ftd)
       case Left(LookupError.NotFound) =>
         Left(TableFinderError.NotFound(caller, scopedName.name))
       case Left(LookupError.PermissionDenied) =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/TableMap.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/TableMap.scala
@@ -131,7 +131,7 @@ class TableMap[MT <: MetaTypes] private[analyzer2] (private val underlying: Map[
   def allTableDescriptions =
     for {
       tablesForScope <- underlying.valuesIterator
-      d@TableDescription.Dataset(_, _, _, _, _) <- tablesForScope.valuesIterator
+      d@TableDescription.Dataset(_, _, _, _, _, _) <- tablesForScope.valuesIterator
     } yield d
 
   override def toString = "TableMap(" + underlying + ")"

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Typechecker.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Typechecker.scala
@@ -10,12 +10,12 @@ import com.socrata.soql.functions.FunctionType
 import com.socrata.soql.typechecker.{TypeInfo2, FunctionInfo, FunctionCallTypechecker, Passed, TypeMismatchFailure}
 
 class Typechecker[MT <: MetaTypes](
-  sourceName: Option[types.ScopedResourceName[MT]],
+  toSource: Position => Source[MT#ResourceNameScope],
   canonicalName: Option[CanonicalName],
   primaryTable: Option[Provenance],
   env: Environment[MT],
   namedExprs: Map[ColumnName, Expr[MT]],
-  udfParams: Map[HoleName, (Option[types.ScopedResourceName[MT]], Position) => Expr[MT]],
+  udfParams: Map[HoleName, Source[MT#ResourceNameScope] => Expr[MT]],
   userParameters: UserParameters[MT#ColumnType, MT#ColumnValue],
   typeInfo: TypeInfo2[MT],
   functionInfo: FunctionInfo[MT#ColumnType]
@@ -53,7 +53,7 @@ class Typechecker[MT <: MetaTypes](
           val candidates = exprs.filter(_.typ == t)
           if(candidates.isEmpty) {
             return Left(
-              TypeMismatch(Source.nonSynthetic(sourceName, pos), Set(typeInfo.typeNameFor(t)), typeInfo.typeNameFor(mostPreferredType(exprs.iterator.map(_.typ).toSet)))
+              TypeMismatch(toSource(pos), Set(typeInfo.typeNameFor(t)), typeInfo.typeNameFor(mostPreferredType(exprs.iterator.map(_.typ).toSet)))
             )
           }
           candidates
@@ -155,31 +155,31 @@ class Typechecker[MT <: MetaTypes](
       case col@ast.ColumnOrAliasRef(None, name) =>
         namedExprs.get(name) match {
           case Some(prechecked) =>
-            Right(Seq(prechecked.reReference(Source.nonSynthetic(sourceName, col.position))))
+            Right(Seq(prechecked.reReference(toSource(col.position))))
           case None =>
             env.lookup(name) match {
-              case None => Left(NoSuchColumn(Source.nonSynthetic(sourceName, col.position), None, name, Util.possibilitiesFor(env, namedExprs.keysIterator, None, name)))
+              case None => Left(NoSuchColumn(toSource(col.position), None, name, Util.possibilitiesFor(env, namedExprs.keysIterator, None, name)))
               case Some(Environment.LookupResult.Virtual(table, column, typ)) =>
-                Right(Seq(VirtualColumn(table, column, typ)(new AtomicPositionInfo(Source.nonSynthetic(sourceName, col.position)))))
+                Right(Seq(VirtualColumn(table, column, typ)(new AtomicPositionInfo(toSource(col.position)))))
               case Some(Environment.LookupResult.Physical(tableName, tableLabel, column, typ)) =>
-                Right(Seq(PhysicalColumn[MT](tableLabel, tableName, column, typ)(new AtomicPositionInfo(Source.nonSynthetic(sourceName, col.position)))))
+                Right(Seq(PhysicalColumn[MT](tableLabel, tableName, column, typ)(new AtomicPositionInfo(toSource(col.position)))))
             }
         }
       case col@ast.ColumnOrAliasRef(Some(qual), name) =>
         val trueQual = ResourceName(qual.substring(TableName.PrefixIndex))
         env.lookup(trueQual, name) match {
-          case None => Left(NoSuchColumn(Source.nonSynthetic(sourceName, col.position), Some(trueQual), name, Util.possibilitiesFor(env, namedExprs.keysIterator, Some(trueQual), name)))
+          case None => Left(NoSuchColumn(toSource(col.position), Some(trueQual), name, Util.possibilitiesFor(env, namedExprs.keysIterator, Some(trueQual), name)))
           case Some(Environment.LookupResult.Virtual(table, column, typ)) =>
-            Right(Seq(VirtualColumn(table, column, typ)(new AtomicPositionInfo(Source.nonSynthetic(sourceName, col.position)))))
+            Right(Seq(VirtualColumn(table, column, typ)(new AtomicPositionInfo(toSource(col.position)))))
           case Some(Environment.LookupResult.Physical(tableName, tableLabel, column, typ)) =>
-            Right(Seq(PhysicalColumn[MT](tableLabel, tableName, column, typ)(new AtomicPositionInfo(Source.nonSynthetic(sourceName, col.position)))))
+            Right(Seq(PhysicalColumn[MT](tableLabel, tableName, column, typ)(new AtomicPositionInfo(toSource(col.position)))))
         }
       case l: ast.Literal =>
-        squash(typeInfo.potentialExprs(l, sourceName, primaryTable), l.position)
+        squash(typeInfo.potentialExprs(l, toSource, primaryTable), l.position)
       case hole@ast.Hole.UDF(name) =>
         udfParams.get(name) match {
-          case Some(expr) => Right(Seq(expr(sourceName, hole.position)))
-          case None => Left(UnknownUDFParameter(Source.nonSynthetic(sourceName, hole.position), name))
+          case Some(expr) => Right(Seq(expr(toSource(hole.position))))
+          case None => Left(UnknownUDFParameter(toSource(hole.position), name))
         }
       case hole@ast.Hole.SavedQuery(name, view) =>
         userParameter(view.map(CanonicalName), name, hole.position)
@@ -198,9 +198,9 @@ class Typechecker[MT <: MetaTypes](
       }
 
     paramSet.flatMap(_.get(name)) match {
-      case Some(UserParameters.Null(t)) => Right(Seq(NullLiteral(t)(new AtomicPositionInfo(Source.nonSynthetic(sourceName, position)))))
-      case Some(UserParameters.Value(v)) => Right(Seq(LiteralValue(v)(new AtomicPositionInfo(Source.nonSynthetic(sourceName, position)))(typeInfo.hasType)))
-      case None => Left(UnknownUserParameter(Source.nonSynthetic(sourceName, position), canonicalView, name))
+      case Some(UserParameters.Null(t)) => Right(Seq(NullLiteral(t)(new AtomicPositionInfo(toSource(position)))))
+      case Some(UserParameters.Value(v)) => Right(Seq(LiteralValue(v)(new AtomicPositionInfo(toSource(position)))(typeInfo.hasType)))
+      case None => Left(UnknownUserParameter(toSource(position), canonicalView, name))
     }
   }
 
@@ -217,7 +217,7 @@ class Typechecker[MT <: MetaTypes](
       val typedOrderings = w.orderings.map { ob =>
         val typedExpr = finalCheck(ob.expression, None)
         if(!typeInfo.isOrdered(typedExpr.typ)) {
-          return Left(UnorderedOrderBy(Source.nonSynthetic(sourceName, ob.expression.position), typeInfo.typeNameFor(typedExpr.typ)))
+          return Left(UnorderedOrderBy(toSource(ob.expression.position), typeInfo.typeNameFor(typedExpr.typ)))
         }
         OrderBy(typedExpr, ob.ascending, ob.nullLast)
       }
@@ -229,7 +229,7 @@ class Typechecker[MT <: MetaTypes](
     val options = functionInfo.functionsWithArity(name, typedParameters.length)
 
     if(options.isEmpty) {
-      return Left(NoSuchFunction(Source.nonSynthetic(sourceName, fc.functionNamePosition), name, typedParameters.length))
+      return Left(NoSuchFunction(toSource(fc.functionNamePosition), name, typedParameters.length))
     }
 
     val (failed, resolved) = divide(funcallTypechecker.resolveOverload(options, typedParameters.map(_.map(_.typ).toSet))) {
@@ -239,7 +239,7 @@ class Typechecker[MT <: MetaTypes](
 
     if(resolved.isEmpty) {
       val TypeMismatchFailure(expected, found, idx) = failed.maxBy(_.idx)
-      return Left(TypeMismatch(Source.nonSynthetic(sourceName, parameters(idx).position), expected.map(typeInfo.typeNameFor), typeInfo.typeNameFor(mostPreferredType(found))))
+      return Left(TypeMismatch(toSource(parameters(idx).position), expected.map(typeInfo.typeNameFor), typeInfo.typeNameFor(mostPreferredType(found))))
     }
 
     val potentials = resolved.flatMap { f =>
@@ -267,17 +267,17 @@ class Typechecker[MT <: MetaTypes](
           case (Some(boolExpr), None) =>
             f.functionType match {
               case FunctionType.Window(_) =>
-                return Left(RequiresWindow(Source.nonSynthetic(sourceName, fc.functionNamePosition), fc.functionName))
+                return Left(RequiresWindow(toSource(fc.functionNamePosition), fc.functionName))
               case FunctionType.Normal =>
-                return Left(NonAggregateFunction(Source.nonSynthetic(sourceName, fc.functionNamePosition), fc.functionName))
+                return Left(NonAggregateFunction(toSource(fc.functionNamePosition), fc.functionName))
               case FunctionType.Aggregate =>
-                AggregateFunctionCall(f, params, false, Some(boolExpr))(new FuncallPositionInfo(Source.nonSynthetic(sourceName, fc.position), fc.functionNamePosition))
+                AggregateFunctionCall(f, params, false, Some(boolExpr))(new FuncallPositionInfo(toSource(fc.position), fc.functionNamePosition))
             }
           case (maybeFilter, Some((partitions, orderings, frames))) =>
             val frameAllowed =
               f.functionType match {
                 case FunctionType.Normal =>
-                  return Left(NonWindowFunction(Source.nonSynthetic(sourceName, fc.functionNamePosition), fc.functionName))
+                  return Left(NonWindowFunction(toSource(fc.functionNamePosition), fc.functionName))
                 case FunctionType.Aggregate =>
                   true
                 case FunctionType.Window(frameAllowed) =>
@@ -285,7 +285,7 @@ class Typechecker[MT <: MetaTypes](
               }
 
             if(fc.distinct) {
-              return Left(DistinctWithOver(Source.nonSynthetic(sourceName, fc.functionNamePosition)))
+              return Left(DistinctWithOver(toSource(fc.functionNamePosition)))
             }
 
             // blearghhh ok so the parser does in fact parse this
@@ -351,13 +351,13 @@ class Typechecker[MT <: MetaTypes](
                       val (end, rest3) = frameBound(rest2)
 
                       if(start == FrameBound.UnboundedFollowing) {
-                        return Left(IllegalStartFrameBound(Source.nonSynthetic(sourceName, frames.head.position), start.text))
+                        return Left(IllegalStartFrameBound(toSource(frames.head.position), start.text))
                       }
                       if(end == FrameBound.UnboundedPreceding) {
-                        return Left(IllegalEndFrameBound(Source.nonSynthetic(sourceName, rest2.head.position), end.text))
+                        return Left(IllegalEndFrameBound(toSource(rest2.head.position), end.text))
                       }
                       if(start.level > end.level) {
-                        return Left(MismatchedFrameBound(Source.nonSynthetic(sourceName, rest2.head.position), start.text, end.text))
+                        return Left(MismatchedFrameBound(toSource(rest2.head.position), start.text, end.text))
                       }
 
                       val excl = optFrameExclusion(rest3)
@@ -366,7 +366,7 @@ class Typechecker[MT <: MetaTypes](
                       val (start, rest1) = frameBound(rest)
 
                       if(start == FrameBound.UnboundedFollowing) {
-                        return Left(IllegalStartFrameBound(Source.nonSynthetic(sourceName, frames.head.position), start.text))
+                        return Left(IllegalStartFrameBound(toSource(frames.head.position), start.text))
                       }
 
                       val excl = optFrameExclusion(rest1)
@@ -379,22 +379,22 @@ class Typechecker[MT <: MetaTypes](
               }
 
             if(parsedFrames.map(_.context) == FrameContext.Groups && orderings.isEmpty) {
-              return Left(GroupsRequiresOrderBy(Source.nonSynthetic(sourceName, frames.head.position)))
+              return Left(GroupsRequiresOrderBy(toSource(frames.head.position)))
             }
 
             if(parsedFrames.isDefined && !frameAllowed) {
               // TODO: reject once we've verified that this isn't being used by anything
             }
 
-            WindowedFunctionCall(f, params, maybeFilter, partitions, orderings, parsedFrames)(new FuncallPositionInfo(Source.nonSynthetic(sourceName, fc.position), fc.functionNamePosition))
+            WindowedFunctionCall(f, params, maybeFilter, partitions, orderings, parsedFrames)(new FuncallPositionInfo(toSource(fc.position), fc.functionNamePosition))
           case (None, None) =>
             f.functionType match {
               case FunctionType.Window(_) =>
-                return Left(RequiresWindow(Source.nonSynthetic(sourceName, fc.functionNamePosition), fc.functionName))
+                return Left(RequiresWindow(toSource(fc.functionNamePosition), fc.functionName))
               case FunctionType.Aggregate =>
-                AggregateFunctionCall(f, params, false, None)(new FuncallPositionInfo(Source.nonSynthetic(sourceName, fc.position), fc.functionNamePosition))
+                AggregateFunctionCall(f, params, false, None)(new FuncallPositionInfo(toSource(fc.position), fc.functionNamePosition))
               case FunctionType.Normal =>
-                FunctionCall(f, params)(new FuncallPositionInfo(Source.nonSynthetic(sourceName, fc.position), fc.functionNamePosition))
+                FunctionCall(f, params)(new FuncallPositionInfo(toSource(fc.position), fc.functionNamePosition))
             }
         }
       }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/UnparsedTableDescription.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/UnparsedTableDescription.scala
@@ -34,14 +34,12 @@ sealed trait UnparsedTableDescription[MT <: MetaTypes] extends TableDescriptionL
 object UnparsedTableDescription {
   case class WrappingQuery[MT <: MetaTypes](
     scope: MT#ResourceNameScope,
-    soql: String,
-    parameters: Map[HoleName, MT#ColumnType]
+    soql: String
   ) extends LabelUniverse[MT] {
     private[analyzer2] def rewriteScopes[MT2 <: MetaTypes](scopeMap: Map[RNS, MT2#ResourceNameScope])(implicit ev: MetaTypes.ChangesOnlyRNS[MT, MT2]): WrappingQuery[MT2] =
       WrappingQuery(
         scopeMap(scope),
-        soql,
-        parameters.asInstanceOf[Map[HoleName, MT2#ColumnType]] // SAFETY: ColumnType isn't changing,
+        soql
       )
     def rewriteDatabaseNames[MT2 <: MetaTypes](implicit ev: MetaTypes.ChangesOnlyLabels[MT, MT2]) =
       this.asInstanceOf[WrappingQuery[MT2]] // SAFETY: no labels in here
@@ -86,7 +84,7 @@ object UnparsedTableDescription {
         parsedWrappingQuery <- wrappingQuery.map { wq =>
           ParserUtil.parseWithoutContext(wq.soql, params.copy(allowHoles = false))
             .left.map((_, Seq("wrappingQuery", "soql"), wq.soql))
-            .map(TableDescription.WrappingQuery(wq.scope, _, wq.soql, wq.parameters))
+            .map(TableDescription.WrappingQuery(wq.scope, _, wq.soql))
         }.transposeOptionEither
       } yield {
         TableDescription.Dataset[MT](
@@ -169,7 +167,7 @@ object UnparsedTableDescription {
         parsedWrappingQuery <- wrappingQuery.map { wq =>
           ParserUtil.parseWithoutContext(wq.soql, params.copy(allowHoles = false))
             .left.map((_, Seq("wrappingQuerySoql", "soql"), wq.soql))
-            .map(TableDescription.WrappingQuery(wq.scope, _, wq.soql, wq.parameters))
+            .map(TableDescription.WrappingQuery(wq.scope, _, wq.soql))
         }.transposeOptionEither
       } yield {
         TableDescription.Query[MT](
@@ -220,7 +218,7 @@ object UnparsedTableDescription {
         parsedWrappingQuery <- wrappingQuery.map { wq =>
           ParserUtil.parseWithoutContext(wq.soql, params.copy(allowHoles = false))
             .left.map((_, Seq("wrappingQuery","soql"), wq.soql))
-            .map(TableDescription.WrappingQuery(wq.scope, _, wq.soql, wq.parameters))
+            .map(TableDescription.WrappingQuery(wq.scope, _, wq.soql))
         }.transposeOptionEither
       } yield {
         TableDescription.TableFunction(

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/UnparsedTableDescription.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/UnparsedTableDescription.scala
@@ -14,6 +14,7 @@ import com.socrata.soql.parsing.standalone_exceptions.LexerParserException
 import com.socrata.soql.parsing.AbstractParser
 import com.socrata.soql.BinaryTree
 import com.socrata.soql.analyzer2
+import com.socrata.soql.analyzer2.Util.OptionEitherExt
 
 // This class exists purely to be the JSON-serialized form of
 // TableDescriptions, but it can also be used by something that
@@ -25,9 +26,31 @@ sealed trait UnparsedTableDescription[MT <: MetaTypes] extends TableDescriptionL
     tableName: DatabaseTableName => types.DatabaseTableName[MT2],
     columnName: (DatabaseTableName, DatabaseColumnName) => types.DatabaseColumnName[MT2]
   )(implicit changesOnlyLabels: MetaTypes.ChangesOnlyLabels[MT, MT2]): UnparsedTableDescription[MT2]
+
+  val wrappingQuery: Option[UnparsedTableDescription.WrappingQuery[MT]]
+  private[analyzer2] def parse(params: AbstractParser.Parameters): Either[(LexerParserException, Seq[String], String), TableDescription[MT]]
 }
 
 object UnparsedTableDescription {
+  case class WrappingQuery[MT <: MetaTypes](
+    scope: MT#ResourceNameScope,
+    soql: String,
+    parameters: Map[HoleName, MT#ColumnType]
+  ) extends LabelUniverse[MT] {
+    private[analyzer2] def rewriteScopes[MT2 <: MetaTypes](scopeMap: Map[RNS, MT2#ResourceNameScope])(implicit ev: MetaTypes.ChangesOnlyRNS[MT, MT2]): WrappingQuery[MT2] =
+      WrappingQuery(
+        scopeMap(scope),
+        soql,
+        parameters.asInstanceOf[Map[HoleName, MT2#ColumnType]] // SAFETY: ColumnType isn't changing,
+      )
+    def rewriteDatabaseNames[MT2 <: MetaTypes](implicit ev: MetaTypes.ChangesOnlyLabels[MT, MT2]) =
+      this.asInstanceOf[WrappingQuery[MT2]] // SAFETY: no labels in here
+  }
+  object WrappingQuery {
+    implicit def encode[MT <: MetaTypes](implicit encRNS: JsonEncode[MT#ResourceNameScope], encCT: JsonEncode[MT#ColumnType]) = AutomaticJsonEncodeBuilder[WrappingQuery[MT]]
+    implicit def decode[MT <: MetaTypes](implicit decRNS: JsonDecode[MT#ResourceNameScope], decCT: JsonDecode[MT#ColumnType]) = AutomaticJsonDecodeBuilder[WrappingQuery[MT]]
+  }
+
   implicit def jEncode[MT <: MetaTypes](implicit encRNS: JsonEncode[MT#ResourceNameScope], encCT: JsonEncode[MT#ColumnType], encDTN: JsonEncode[MT#DatabaseTableNameImpl], encDCN: JsonEncode[MT#DatabaseColumnNameImpl]) =
     SimpleHierarchyEncodeBuilder[UnparsedTableDescription[MT]](InternalTag("type")).
       branch[Dataset[MT]]("dataset")(Dataset.encode[MT], implicitly).
@@ -47,7 +70,8 @@ object UnparsedTableDescription {
     canonicalName: CanonicalName,
     columns: OrderedMap[types.DatabaseColumnName[MT], types.TableDescription.DatasetColumnInfo[MT]],
     ordering: Seq[TableDescription.Ordering[MT]],
-    primaryKeys: Seq[Seq[types.DatabaseColumnName[MT]]]
+    primaryKeys: Seq[Seq[types.DatabaseColumnName[MT]]],
+    wrappingQuery: Option[WrappingQuery[MT]]
   ) extends UnparsedTableDescription[MT] with TableDescriptionLike.Dataset[MT] {
     val hiddenColumns = columns.values.flatMap { case TableDescription.DatasetColumnInfo(name, _, hidden, _) =>
       if(hidden) Some(name) else None
@@ -57,7 +81,32 @@ object UnparsedTableDescription {
     // fires while json-decoding
     require(ordering.forall { o => columns.contains(o.column) })
 
-    private[analyzer2] def rewriteScopes[MT2 <: MetaTypes](scopeMap: Map[RNS, MT2#ResourceNameScope])(implicit ev: MetaTypes.ChangesOnlyRNS[MT, MT2]) = this
+    private[analyzer2] def parse(params: AbstractParser.Parameters) =
+      for {
+        parsedWrappingQuery <- wrappingQuery.map { wq =>
+          ParserUtil.parseWithoutContext(wq.soql, params.copy(allowHoles = false))
+            .left.map((_, Seq("wrappingQuery", "soql"), wq.soql))
+            .map(TableDescription.WrappingQuery(wq.scope, _, wq.soql, wq.parameters))
+        }.transposeOptionEither
+      } yield {
+        TableDescription.Dataset[MT](
+          name,
+          canonicalName,
+          columns,
+          ordering,
+          primaryKeys,
+          parsedWrappingQuery
+        )
+      }
+
+    private[analyzer2] def rewriteScopes[MT2 <: MetaTypes](scopeMap: Map[RNS, MT2#ResourceNameScope])(implicit ev: MetaTypes.ChangesOnlyRNS[MT, MT2]): Dataset[MT2] =
+      copy[MT2](
+        name = ev.convertDTN(name),
+        columns = columns.asInstanceOf, // SAFETY: No scopes in the columns
+        ordering = ordering.asInstanceOf, // safety: No scopes in the labesl,
+        primaryKeys = primaryKeys.map(_.map(ev.convertDCN)),
+        wrappingQuery = wrappingQuery.map(_.rewriteScopes[MT2](scopeMap))
+      )
 
     private[analyzer2] def rewriteDatabaseNames[MT2 <: MetaTypes](
       tableName: DatabaseTableName => types.DatabaseTableName[MT2],
@@ -74,12 +123,13 @@ object UnparsedTableDescription {
         ordering.map { case TableDescription.Ordering(dcn, ascending, nullLast) =>
           TableDescription.Ordering(columnName(name, dcn), ascending, nullLast)
         },
-        primaryKeys.map(_.map(columnName(name, _)))
+        primaryKeys.map(_.map(columnName(name, _))),
+        wrappingQuery.map(_.rewriteDatabaseNames[MT2])
       )
     }
   }
   object Dataset {
-    private[UnparsedTableDescription] def encode[MT <: MetaTypes](implicit encCT: JsonEncode[MT#ColumnType], encDTN: JsonEncode[MT#DatabaseTableNameImpl], encDCN: JsonEncode[MT#DatabaseColumnNameImpl]): JsonEncode[Dataset[MT]] =
+    private[UnparsedTableDescription] def encode[MT <: MetaTypes](implicit encRNS: JsonEncode[MT#ResourceNameScope], encCT: JsonEncode[MT#ColumnType], encDTN: JsonEncode[MT#DatabaseTableNameImpl], encDCN: JsonEncode[MT#DatabaseColumnNameImpl]): JsonEncode[Dataset[MT]] =
       new JsonEncode[Dataset[MT]] with LabelUniverse[MT] {
         implicit val schemaEncode = OrderedMapHelper.jsonEncode[DatabaseColumnName, TableDescription.DatasetColumnInfo[CT]]
         val encoder = AutomaticJsonEncodeBuilder[Dataset[MT]]
@@ -87,18 +137,13 @@ object UnparsedTableDescription {
         def encode(ds: Dataset[MT]): JValue = encoder.encode(ds)
       }
 
-    private[UnparsedTableDescription] def decode[MT <: MetaTypes](implicit decCT: JsonDecode[MT#ColumnType], decDTN: JsonDecode[MT#DatabaseTableNameImpl], decDCN: JsonDecode[MT#DatabaseColumnNameImpl]): JsonDecode[Dataset[MT]] =
+    private[UnparsedTableDescription] def decode[MT <: MetaTypes](implicit decRNS: JsonDecode[MT#ResourceNameScope], decCT: JsonDecode[MT#ColumnType], decDTN: JsonDecode[MT#DatabaseTableNameImpl], decDCN: JsonDecode[MT#DatabaseColumnNameImpl]): JsonDecode[Dataset[MT]] =
       new JsonDecode[Dataset[MT]] with LabelUniverse[MT] {
         implicit val schemaDecode = OrderedMapHelper.jsonDecode[DatabaseColumnName, TableDescription.DatasetColumnInfo[CT]]
         val decoder = AutomaticJsonDecodeBuilder[Dataset[MT]]
 
         def decode(v: JValue) = decoder.decode(v)
       }
-  }
-
-  sealed trait SoQLUnparsedTableDescription[MT <: MetaTypes] extends UnparsedTableDescription[MT] {
-    def soql: String
-    private[analyzer2] def parse(params: AbstractParser.Parameters): Either[LexerParserException, TableDescription[MT]]
   }
 
   case class Query[MT <: MetaTypes](
@@ -109,24 +154,34 @@ object UnparsedTableDescription {
     parameters: Map[HoleName, MT#ColumnType],
     hiddenColumns: Set[ColumnName],
     @AllowMissing("Map.empty")
-    outputColumnHints: Map[ColumnName, JValue]
-  ) extends SoQLUnparsedTableDescription[MT] {
+    outputColumnHints: Map[ColumnName, JValue],
+    wrappingQuery: Option[WrappingQuery[MT]]
+  ) extends UnparsedTableDescription[MT] {
     private[analyzer2] def rewriteScopes[MT2 <: MetaTypes](scopeMap: Map[RNS, MT2#ResourceNameScope])(implicit ev: MetaTypes.ChangesOnlyRNS[MT, MT2]): Query[MT2] =
       copy(
         scope = scopeMap(scope),
-        parameters = parameters.asInstanceOf[Map[HoleName, MT2#ColumnType]] // SAFETY: ColumnType isn't changing
+        parameters = parameters.asInstanceOf[Map[HoleName, MT2#ColumnType]], // SAFETY: ColumnType isn't changing
+        wrappingQuery = wrappingQuery.map(_.rewriteScopes[MT2](scopeMap))
       )
     private[analyzer2] def parse(params: AbstractParser.Parameters) =
-      ParserUtil.parseWithoutContext(soql, params.copy(allowHoles = false)).map { parsed =>
+      for {
+        parsedSoql <- ParserUtil.parseWithoutContext(soql, params.copy(allowHoles = false)).left.map((_, Seq("soql"), soql))
+        parsedWrappingQuery <- wrappingQuery.map { wq =>
+          ParserUtil.parseWithoutContext(wq.soql, params.copy(allowHoles = false))
+            .left.map((_, Seq("wrappingQuerySoql", "soql"), wq.soql))
+            .map(TableDescription.WrappingQuery(wq.scope, _, wq.soql, wq.parameters))
+        }.transposeOptionEither
+      } yield {
         TableDescription.Query[MT](
           scope,
           canonicalName,
           basedOn,
-          parsed,
+          parsedSoql,
           soql,
           parameters,
           hiddenColumns,
-          outputColumnHints
+          outputColumnHints,
+          parsedWrappingQuery
         )
       }
 
@@ -149,23 +204,33 @@ object UnparsedTableDescription {
     canonicalName: CanonicalName, // This is the canonical name of this UDF; it is assumed to be unique across scopes
     soql: String,
     parameters: OrderedMap[HoleName, MT#ColumnType],
-    hiddenColumns: Set[ColumnName]
-  ) extends SoQLUnparsedTableDescription[MT] {
+    hiddenColumns: Set[ColumnName],
+    wrappingQuery: Option[WrappingQuery[MT]]
+  ) extends UnparsedTableDescription[MT] {
     private[analyzer2] def rewriteScopes[MT2 <: MetaTypes](scopeMap: Map[RNS, MT2#ResourceNameScope])(implicit ev: MetaTypes.ChangesOnlyRNS[MT, MT2]): TableFunction[MT2] =
       copy(
         scope = scopeMap(scope),
-        parameters = parameters.asInstanceOf[OrderedMap[HoleName, MT2#ColumnType]] // SAFETY: ColumnType isn't changing
+        parameters = parameters.asInstanceOf[OrderedMap[HoleName, MT2#ColumnType]], // SAFETY: ColumnType isn't changing
+        wrappingQuery = wrappingQuery.map(_.rewriteScopes[MT2](scopeMap))
       )
 
     private[analyzer2] def parse(params: AbstractParser.Parameters) =
-      ParserUtil.parseWithoutContext(soql, params.copy(allowHoles = true)).map { parsed =>
+      for {
+        parsedSoql <- ParserUtil.parseWithoutContext(soql, params.copy(allowHoles = true)).left.map((_, Seq("soql"), soql))
+        parsedWrappingQuery <- wrappingQuery.map { wq =>
+          ParserUtil.parseWithoutContext(wq.soql, params.copy(allowHoles = false))
+            .left.map((_, Seq("wrappingQuery","soql"), wq.soql))
+            .map(TableDescription.WrappingQuery(wq.scope, _, wq.soql, wq.parameters))
+        }.transposeOptionEither
+      } yield {
         TableDescription.TableFunction(
           scope,
           canonicalName,
-          parsed,
+          parsedSoql,
           soql,
           parameters,
-          hiddenColumns
+          hiddenColumns,
+          parsedWrappingQuery
         )
       }
 

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/UnparsedTableMap.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/UnparsedTableMap.scala
@@ -67,11 +67,10 @@ object UnparsedTableMap {
     new mocktablefinder.MockTableFinder[MT](
       OrderedMap() ++ self.underlying.iterator.flatMap { case (rns, resources) =>
         resources.iterator.map { case (rn, desc) =>
-          // TODO: attach the wrapping queries to the MTF!!!
           val thing =
             desc match {
-              case UnparsedTableDescription.Dataset(_name, canonicalName, schema, ordering, pks, wq) =>
-                val base =
+              case UnparsedTableDescription.Dataset(_name, canonicalName, schema, ordering, pks, wrappingQuery) =>
+                var dataset: mocktablefinder.D[MT#ResourceNameScope, MT#ColumnType] =
                   mocktablefinder.D(schema.valuesIterator.map { case TableDescription.DatasetColumnInfo(n, t, _, _) => n.name -> t }.toSeq : _*).
                     withHiddenColumns(schema.valuesIterator.filter(_.hidden).map(_.name.name).toSeq : _*).
                     withCanonicalName(canonicalName.name).
@@ -81,20 +80,35 @@ object UnparsedTableMap {
                           name.name -> hint
                       }.toSeq : _*
                     )
-                pks.foldLeft(
-                  ordering.foldLeft(base) { (base, ordering) =>
-                    base.withOrdering(schema(ordering.column).name.name, ordering.ascending)
-                  }
-                ) { (dataset, pk) => dataset.withPrimaryKey(pk.map(schema(_).name.name) : _*) }
-              case UnparsedTableDescription.Query(scope, canonicalName, basedOn, soql, parameters, hiddenColumns, outputColumnHints, wq) =>
-                mocktablefinder.Q(scope, basedOn.name, soql, parameters.toSeq.map { case (hn, ct) => hn.name -> ct } : _*).
-                  withCanonicalName(canonicalName.name).
-                  withHiddenColumns(hiddenColumns.map(_.name).toSeq : _*).
-                  withOutputColumnHints(outputColumnHints.map { case (k, v) => k.name -> v}.toSeq : _*)
-              case UnparsedTableDescription.TableFunction(scope, canonicalName, soql, parameters, hiddenColumns, wq) =>
-                mocktablefinder.U(scope, soql, parameters.toSeq.map { case (hn, ct) => hn.name -> ct } : _*).
-                  withCanonicalName(canonicalName.name).
-                  withHiddenColumns(hiddenColumns.map(_.name).toSeq : _*)
+                for(ordering <- ordering) {
+                  dataset = dataset.withOrdering(schema(ordering.column).name.name, ordering.ascending)
+                }
+                for(pk <- pks) {
+                  dataset =  dataset.withPrimaryKey(pk.map(schema(_).name.name) : _*)
+                }
+                for(wq <- wrappingQuery) {
+                  dataset = dataset.withWrappingQuery(wq.scope, wq.soql)
+                }
+                dataset
+              case UnparsedTableDescription.Query(scope, canonicalName, basedOn, soql, parameters, hiddenColumns, outputColumnHints, wrappingQuery) =>
+                var query =
+                  mocktablefinder.Q(scope, basedOn.name, soql, parameters.toSeq.map { case (hn, ct) => hn.name -> ct } : _*).
+                    withCanonicalName(canonicalName.name).
+                    withHiddenColumns(hiddenColumns.map(_.name).toSeq : _*).
+                    withOutputColumnHints(outputColumnHints.map { case (k, v) => k.name -> v}.toSeq : _*)
+                for(wq <- wrappingQuery) {
+                  query = query.withWrappingQuery(wq.scope, wq.soql)
+                }
+                query
+              case UnparsedTableDescription.TableFunction(scope, canonicalName, soql, parameters, hiddenColumns, wrappingQuery) =>
+                var udf =
+                  mocktablefinder.U(scope, soql, parameters.toSeq.map { case (hn, ct) => hn.name -> ct } : _*).
+                    withCanonicalName(canonicalName.name).
+                    withHiddenColumns(hiddenColumns.map(_.name).toSeq : _*)
+                for(wq <- wrappingQuery) {
+                  udf = udf.withWrappingQuery(wq.scope, wq.soql)
+                }
+                udf
             }
           (rns, rn.name) -> thing
         }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/UnparsedTableMap.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/UnparsedTableMap.scala
@@ -19,17 +19,12 @@ class UnparsedTableMap[MT <: MetaTypes] private[analyzer2] (private val underlyi
 
   type Self[MT <: MetaTypes] = UnparsedTableMap[MT]
 
-  private[analyzer2] def parse(params: AbstractParser.Parameters): Either[LexerParserException, TableMap[MT]] =
+  private[analyzer2] def parse(params: AbstractParser.Parameters): Either[(LexerParserException, Seq[String], String), TableMap[MT]] =
     Right(new TableMap(underlying.iterator.map { case (rns, m) =>
       rns -> m.iterator.map { case (rn, utd) =>
-        utd match {
-          case UnparsedTableDescription.Dataset(name, canonicalName, schema, ordering, pk) =>
-            rn -> TableDescription.Dataset(name, canonicalName, schema, ordering, pk)
-          case other: UnparsedTableDescription.SoQLUnparsedTableDescription[MT] =>
-            other.parse(params) match {
-              case Right(ptd) => rn -> ptd
-              case Left(e) => return Left(e)
-            }
+        utd.parse(params) match {
+          case Right(ptd) => rn -> ptd
+          case Left(e) => return Left(e)
         }
       }.toMap
     }.toMap))
@@ -48,7 +43,7 @@ class UnparsedTableMap[MT <: MetaTypes] private[analyzer2] (private val underlyi
   def allTableDescriptions =
     for {
       tablesForScope <- underlying.valuesIterator
-      d@UnparsedTableDescription.Dataset(_, _, _, _, _) <- tablesForScope.valuesIterator
+      d@UnparsedTableDescription.Dataset(_, _, _, _, _, _) <- tablesForScope.valuesIterator
     } yield d
 
   def get(name: ScopedResourceName) = underlying.get(name.scope).flatMap(_.get(name.name))
@@ -72,9 +67,10 @@ object UnparsedTableMap {
     new mocktablefinder.MockTableFinder[MT](
       OrderedMap() ++ self.underlying.iterator.flatMap { case (rns, resources) =>
         resources.iterator.map { case (rn, desc) =>
+          // TODO: attach the wrapping queries to the MTF!!!
           val thing =
             desc match {
-              case UnparsedTableDescription.Dataset(_name, canonicalName, schema, ordering, pks) =>
+              case UnparsedTableDescription.Dataset(_name, canonicalName, schema, ordering, pks, wq) =>
                 val base =
                   mocktablefinder.D(schema.valuesIterator.map { case TableDescription.DatasetColumnInfo(n, t, _, _) => n.name -> t }.toSeq : _*).
                     withHiddenColumns(schema.valuesIterator.filter(_.hidden).map(_.name.name).toSeq : _*).
@@ -90,12 +86,12 @@ object UnparsedTableMap {
                     base.withOrdering(schema(ordering.column).name.name, ordering.ascending)
                   }
                 ) { (dataset, pk) => dataset.withPrimaryKey(pk.map(schema(_).name.name) : _*) }
-              case UnparsedTableDescription.Query(scope, canonicalName, basedOn, soql, parameters, hiddenColumns, outputColumnHints) =>
+              case UnparsedTableDescription.Query(scope, canonicalName, basedOn, soql, parameters, hiddenColumns, outputColumnHints, wq) =>
                 mocktablefinder.Q(scope, basedOn.name, soql, parameters.toSeq.map { case (hn, ct) => hn.name -> ct } : _*).
                   withCanonicalName(canonicalName.name).
                   withHiddenColumns(hiddenColumns.map(_.name).toSeq : _*).
                   withOutputColumnHints(outputColumnHints.map { case (k, v) => k.name -> v}.toSeq : _*)
-              case UnparsedTableDescription.TableFunction(scope, canonicalName, soql, parameters, hiddenColumns) =>
+              case UnparsedTableDescription.TableFunction(scope, canonicalName, soql, parameters, hiddenColumns, wq) =>
                 mocktablefinder.U(scope, soql, parameters.toSeq.map { case (hn, ct) => hn.name -> ct } : _*).
                   withCanonicalName(canonicalName.name).
                   withHiddenColumns(hiddenColumns.map(_.name).toSeq : _*)

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Util.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Util.scala
@@ -2,6 +2,7 @@ package com.socrata.soql.analyzer2
 
 import com.socrata.soql.ast
 import com.socrata.soql.environment.{ColumnName, ResourceName, ScopedResourceName, TableName}
+import com.socrata.soql.collection.{OrderedMap, OrderedSet}
 import com.socrata.soql.{BinaryTree, Leaf, Compound}
 
 import SoQLAnalyzerError.TypecheckError.NoSuchColumn
@@ -92,5 +93,31 @@ private[analyzer2] object Util {
         case Some(Right(b)) => Right(Some(b))
         case None => Right(None)
       }
+  }
+
+  def reorderSchema[MT <: MetaTypes](
+    currentSchema: OrderedMap[AutoColumnLabel, Statement.SchemaEntry[MT]],
+    targetSchema: Seq[(ColumnName, MT#ColumnType)]
+  ): Option[Seq[AutoColumnLabel]] = {
+    val labelsByName = currentSchema.iterator.map { case (label, ent) =>
+      (ent.name, (label, ent.typ))
+    }.toMap
+    if(targetSchema.size != labelsByName.size) return None
+
+    val desiredLabels = for {
+      (name, typ) <- targetSchema
+    } yield {
+      val (label, desiredTyp) = labelsByName.get(name).getOrElse {
+        return None
+      }
+
+      if(typ != desiredTyp) {
+        return None
+      }
+
+      label
+    }
+
+    Some(desiredLabels.toVector)
   }
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Util.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Util.scala
@@ -84,4 +84,13 @@ private[analyzer2] object Util {
       acc + (table -> newCols)
     }
   }
+
+  implicit class OptionEitherExt[A, B](private val underlying: Option[Either[A, B]]) extends AnyVal {
+    def transposeOptionEither: Either[A, Option[B]] =
+      underlying match {
+        case Some(Left(a)) => Left(a)
+        case Some(Right(b)) => Right(Some(b))
+        case None => Right(None)
+      }
+  }
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromCTE.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromCTE.scala
@@ -26,7 +26,7 @@ trait FromCTEImpl[MT <: MetaTypes] { this: FromCTE[MT] =>
 
   lazy val schema = basedOn.schema.iterator.map { case (columnLabel, ent) =>
     From.SchemaEntry(
-      label, columnLabel, ent.typ, ent.hint,
+      label, columnLabel, ent.name, ent.typ, ent.hint,
       ent.isSynthetic
     )
   }.toVector

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromStatement.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromStatement.scala
@@ -19,8 +19,8 @@ trait FromStatementImpl[MT <: MetaTypes] { this: FromStatement[MT] =>
 
   lazy val referencedCTEs = statement.referencedCTEs
 
-  def schema = statement.schema.map { case (acl, Statement.SchemaEntry(_, typ, hint, isSynthetic)) =>
-    From.SchemaEntry(label, acl, typ, hint, isSynthetic = isSynthetic)
+  def schema = statement.schema.map { case (acl, Statement.SchemaEntry(name, typ, hint, isSynthetic)) =>
+    From.SchemaEntry(label, acl, name, typ, hint, isSynthetic = isSynthetic)
   }.toVector
 
   private[analyzer2] val scope: Scope[MT] = new Scope.Virtual[MT](label, statement.schema.withValuesMapped(_.asNameEntry))

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
@@ -22,9 +22,9 @@ trait FromTableImpl[MT <: MetaTypes] { this: FromTable[MT] =>
   def find(predicate: Expr[MT] => Boolean) = None
   def contains(e: Expr[MT]): Boolean = false
 
-  def schema = columns.iterator.map { case (dcn, FromTable.ColumnInfo(_, typ, hint)) =>
+  def schema = columns.iterator.map { case (dcn, FromTable.ColumnInfo(name, typ, hint)) =>
     From.SchemaEntry(
-      label, dcn, typ, hint,
+      label, dcn, name, typ, hint,
       isSynthetic = false // table columns are never synthetic
     )
   }.toVector

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
@@ -59,19 +59,17 @@ trait FromTableImpl[MT <: MetaTypes] { this: FromTable[MT] =>
     that: From[MT],
     recurseStmt: (Statement[MT], IsomorphismState, Option[AutoTableLabel], Option[AutoTableLabel], Statement[MT]) => Boolean
   ): Boolean =
-    // TODO: make this constant-stack if it ever gets used outside of tests
     that match {
       case FromTable(thatTableName, thatResourceName, thatCanonicalName, thatAlias, thatLabel, thatColumns, thatPrimaryKeys) =>
         this.tableName == thatTableName &&
           // don't care about aliases
-          state.tryAssociate(this.label, thatLabel) &&
-          this.columns.size == thatColumns.size &&
-          this.columns.iterator.zip(thatColumns.iterator).forall { case ((thisColName, thisEntry), (thatColName, thatEntry)) =>
-            thisColName == thatColName &&
-              thisEntry.typ == thatEntry.typ
-            // don't care about the entry's name.  Or hints?
-          } &&
-          this.primaryKeys.toSet == thatPrimaryKeys.toSet
+          state.tryAssociate(this.label, thatLabel)
+
+        // we're going to assume that if two tables have the same
+        // database name, then they are the same table.  That's what
+        // having the same database name _means_.  So we won't compare
+        // our schemas etc, because those depend on things like
+        // hidden-column resolution.
       case _ =>
         false
     }
@@ -81,6 +79,10 @@ trait FromTableImpl[MT <: MetaTypes] { this: FromTable[MT] =>
       case FromTable(thatTableName, thatResourceName, thatCanonicalName, thatAlias, thatLabel, thatColumns, thatPrimaryKeys) =>
         this.tableName == thatTableName &&
           state.tryAssociate(this.label, thatLabel) &&
+          // But we _will_ compare schemas for vertical-slice
+          // resolution, because here we're asking "can we use B to
+          // answer everything A could be used for", and that _does_
+          // depend on the presence of columns.
           this.columns.forall { case (thisColName, thisEntry) =>
             // We care about column database names and types, but not
             // human names.

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
@@ -62,7 +62,12 @@ trait FromTableImpl[MT <: MetaTypes] { this: FromTable[MT] =>
     that match {
       case FromTable(thatTableName, thatResourceName, thatCanonicalName, thatAlias, thatLabel, thatColumns, thatPrimaryKeys) =>
         this.tableName == thatTableName &&
-          // don't care about aliases
+          this.columns.size == thatColumns.size &&
+          this.columns.iterator.zip(thatColumns.iterator).forall { case ((thisColName, thisEntry), (thatColName, thatEntry)) =>
+            thisColName == thatColName &&
+              thisEntry.typ == thatEntry.typ
+            // don't care about the entry's name.  Or hints?
+          }
           state.tryAssociate(this.label, thatLabel)
 
         // we're going to assume that if two tables have the same
@@ -79,10 +84,6 @@ trait FromTableImpl[MT <: MetaTypes] { this: FromTable[MT] =>
       case FromTable(thatTableName, thatResourceName, thatCanonicalName, thatAlias, thatLabel, thatColumns, thatPrimaryKeys) =>
         this.tableName == thatTableName &&
           state.tryAssociate(this.label, thatLabel) &&
-          // But we _will_ compare schemas for vertical-slice
-          // resolution, because here we're asking "can we use B to
-          // answer everything A could be used for", and that _does_
-          // depend on the presence of columns.
           this.columns.forall { case (thisColName, thisEntry) =>
             // We care about column database names and types, but not
             // human names.

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveOrdering.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveOrdering.scala
@@ -9,7 +9,7 @@ import com.socrata.soql.collection._
 import com.socrata.soql.environment.ColumnName
 import com.socrata.soql.functions.MonomorphicFunction
 
-class PreserveOrdering[MT <: MetaTypes] private (provider: LabelProvider) extends StatementUniverse[MT] {
+class PreserveOrdering[MT <: MetaTypes] private (provider: LabelProvider, untilIdentity: Option[AutoTableLabel]) extends StatementUniverse[MT] {
   type ACTEs = AvailableCTEs[Seq[(AutoColumnLabel, CT, Boolean, Boolean)]]
 
   // "wantOutputOrdered" == "if this statement can be rewritten to
@@ -25,7 +25,7 @@ class PreserveOrdering[MT <: MetaTypes] private (provider: LabelProvider) extend
 
       case CTE(defns, useQuery) =>
         val (newAvailableCTEs, newDefinitions) = availableCTEs.collect(defns) { (aCTEs, query) =>
-          rewriteStatement(aCTEs, query, true, true)
+          rewriteStatement(aCTEs, query, wantOutputOrdered, wantOutputOrdered)
         }
         val (orderingColumns, newUseQuery) = rewriteStatement(newAvailableCTEs, useQuery, wantOutputOrdered, wantOrderingColumns)
 
@@ -53,7 +53,12 @@ class PreserveOrdering[MT <: MetaTypes] private (provider: LabelProvider) extend
         }
 
         val wantSubqueryOrdered = (wantOutputOrdered || select.isWindowed) && !select.isAggregated && distinctiveness == Distinctiveness.Indistinct()
-        val (extraOrdering, newFrom) = rewriteFrom(availableCTEs, from, wantSubqueryOrdered, wantSubqueryOrdered)
+        val (extraOrdering, newFrom) =
+          if(wantSubqueryOrdered) {
+            rewriteFrom(availableCTEs, from, wantSubqueryOrdered, wantSubqueryOrdered)
+          } else {
+            (Nil, from)
+          }
 
         // We will at the very least want to add the ordering
         // columns from the subquery onto the end of our order-by...
@@ -147,7 +152,8 @@ class PreserveOrdering[MT <: MetaTypes] private (provider: LabelProvider) extend
             (Nil, fc)
         }
       case fs@FromStatement(stmt, label, resourceName, canonicalName, alias) =>
-        val (orderColumn, newStmt) = rewriteStatement(availableCTEs, stmt, wantOutputOrdered, wantOrderingColumns)
+        val actuallyWantOutputOrdered = wantOutputOrdered && untilIdentity.fold(false)(_ != label)
+        val (orderColumn, newStmt) = rewriteStatement(availableCTEs, stmt, actuallyWantOutputOrdered, wantOrderingColumns)
         (orderColumn.map { case (col, typ, asc, nullLast) => OrderBy(VirtualColumn(label, col, typ)(AtomicPositionInfo.Synthetic), asc, nullLast) }, fs.copy(statement = newStmt))
     }
   }
@@ -157,10 +163,14 @@ class PreserveOrdering[MT <: MetaTypes] private (provider: LabelProvider) extend
   * SelectListReferences must not be present (this is unchecked!!). */
 object PreserveOrdering {
   def apply[MT <: MetaTypes](labelProvider: LabelProvider, stmt: Statement[MT]): Statement[MT] = {
-    new PreserveOrdering[MT](labelProvider).rewriteStatement(AvailableCTEs.empty, stmt, true, false)._2
+    new PreserveOrdering[MT](labelProvider, None).rewriteStatement(AvailableCTEs.empty, stmt, true, false)._2
   }
 
   def withExtraOutputColumns[MT <: MetaTypes](labelProvider: LabelProvider, stmt: Statement[MT]): Statement[MT] = {
-    new PreserveOrdering[MT](labelProvider).rewriteStatement(AvailableCTEs.empty, stmt, true, true)._2
+    new PreserveOrdering[MT](labelProvider, None).rewriteStatement(AvailableCTEs.empty, stmt, true, true)._2
+  }
+
+  def bounded[MT <: MetaTypes](labelProvider: LabelProvider, stmt: Statement[MT], bound: AutoTableLabel): Statement[MT] = {
+    new PreserveOrdering[MT](labelProvider, Some(bound)).rewriteStatement(AvailableCTEs.empty, stmt, true, false)._2
   }
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveOrdering.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveOrdering.scala
@@ -9,7 +9,7 @@ import com.socrata.soql.collection._
 import com.socrata.soql.environment.ColumnName
 import com.socrata.soql.functions.MonomorphicFunction
 
-class PreserveOrdering[MT <: MetaTypes] private (provider: LabelProvider, untilIdentity: Option[AutoTableLabel]) extends StatementUniverse[MT] {
+class PreserveOrdering[MT <: MetaTypes] private (provider: LabelProvider, stop: FromStatement[MT] => Boolean) extends StatementUniverse[MT] {
   type ACTEs = AvailableCTEs[Seq[(AutoColumnLabel, CT, Boolean, Boolean)]]
 
   // "wantOutputOrdered" == "if this statement can be rewritten to
@@ -152,7 +152,7 @@ class PreserveOrdering[MT <: MetaTypes] private (provider: LabelProvider, untilI
             (Nil, fc)
         }
       case fs@FromStatement(stmt, label, resourceName, canonicalName, alias) =>
-        val actuallyWantOutputOrdered = wantOutputOrdered && untilIdentity.fold(false)(_ != label)
+        val actuallyWantOutputOrdered = wantOutputOrdered && !stop(fs)
         val (orderColumn, newStmt) = rewriteStatement(availableCTEs, stmt, actuallyWantOutputOrdered, wantOrderingColumns)
         (orderColumn.map { case (col, typ, asc, nullLast) => OrderBy(VirtualColumn(label, col, typ)(AtomicPositionInfo.Synthetic), asc, nullLast) }, fs.copy(statement = newStmt))
     }
@@ -163,14 +163,14 @@ class PreserveOrdering[MT <: MetaTypes] private (provider: LabelProvider, untilI
   * SelectListReferences must not be present (this is unchecked!!). */
 object PreserveOrdering {
   def apply[MT <: MetaTypes](labelProvider: LabelProvider, stmt: Statement[MT]): Statement[MT] = {
-    new PreserveOrdering[MT](labelProvider, None).rewriteStatement(AvailableCTEs.empty, stmt, true, false)._2
+    new PreserveOrdering[MT](labelProvider, _ => false).rewriteStatement(AvailableCTEs.empty, stmt, true, false)._2
   }
 
   def withExtraOutputColumns[MT <: MetaTypes](labelProvider: LabelProvider, stmt: Statement[MT]): Statement[MT] = {
-    new PreserveOrdering[MT](labelProvider, None).rewriteStatement(AvailableCTEs.empty, stmt, true, true)._2
+    new PreserveOrdering[MT](labelProvider, _ => false).rewriteStatement(AvailableCTEs.empty, stmt, true, true)._2
   }
 
-  def bounded[MT <: MetaTypes](labelProvider: LabelProvider, stmt: Statement[MT], bound: AutoTableLabel): Statement[MT] = {
-    new PreserveOrdering[MT](labelProvider, Some(bound)).rewriteStatement(AvailableCTEs.empty, stmt, true, false)._2
+  def bounded[MT <: MetaTypes](labelProvider: LabelProvider, stmt: Statement[MT], stop: FromStatement[MT] => Boolean): Statement[MT] = {
+    new PreserveOrdering[MT](labelProvider, stop).rewriteStatement(AvailableCTEs.empty, stmt, true, false)._2
   }
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CTE.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CTE.scala
@@ -7,7 +7,7 @@ import com.socrata.prettyprint.prelude._
 import com.socrata.soql.analyzer2._
 import com.socrata.soql.serialize.{Readable, ReadBuffer, Writable, WriteBuffer}
 import com.socrata.soql.collection._
-import com.socrata.soql.environment.ResourceName
+import com.socrata.soql.environment.{ColumnName, ResourceName}
 import com.socrata.soql.functions.MonomorphicFunction
 
 import DocUtils._
@@ -137,6 +137,10 @@ trait CTEImpl[MT <: MetaTypes] { this: CTE[MT] =>
     definitions.valuesIterator.foldLeft(useQuery.nonlocalColumnReferences) { (acc, defn) =>
       Util.mergeColumnSet(acc, defn.query.nonlocalColumnReferences)
     }
+
+  private[analyzer2] override def ensureSchema(labelProvider: LabelProvider, schema: Seq[(ColumnName, CT)]): Option[Self[MT]] = {
+    useQuery.ensureSchema(labelProvider, schema).map(CTE(definitions, _))
+  }
 }
 
 trait OCTEImpl { this: CTE.type =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CombinedTables.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CombinedTables.scala
@@ -7,7 +7,7 @@ import com.socrata.prettyprint.prelude._
 import com.socrata.soql.analyzer2._
 import com.socrata.soql.serialize.{Readable, ReadBuffer, Writable, WriteBuffer}
 import com.socrata.soql.collection._
-import com.socrata.soql.environment.ResourceName
+import com.socrata.soql.environment.{ResourceName, ColumnName}
 import com.socrata.soql.functions.MonomorphicFunction
 
 import DocUtils._
@@ -153,6 +153,15 @@ trait CombinedTablesImpl[MT <: MetaTypes] { this: CombinedTables[MT] =>
 
   override def nonlocalColumnReferences =
     Util.mergeColumnSet(left.nonlocalColumnReferences, right.nonlocalColumnReferences)
+
+  private[analyzer2] override def ensureSchema(labelProvider: LabelProvider, schema: Seq[(ColumnName, CT)]): Option[Self[MT]] = {
+    for {
+      newLeft <- left.ensureSchema(labelProvider, schema)
+      newRight <- right.ensureSchema(labelProvider, schema)
+    } yield {
+      CombinedTables(op, newLeft, newRight)
+    }
+  }
 }
 
 trait OCombinedTablesImpl { this: CombinedTables.type =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Select.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Select.scala
@@ -434,6 +434,21 @@ trait SelectImpl[MT <: MetaTypes] { this: Select[MT] =>
 
     acc -- localTables
   }
+
+  private[analyzer2] override def ensureSchema(labelProvider: LabelProvider, targetSchema: Seq[(ColumnName, CT)]): Option[Self[MT]] = {
+    // NOTE: This is NOT CORRECT if there are any SelectListReferences
+    // in any of the exprs in here.  In the context where this is
+    // called (in the soql analyzer, pre-rewrites) there will in fact
+    // be none.  If that ever changes, this needs to grow a call to
+    // SelectListReferences.undo() in order to remove them.
+    for(ordering <- Util.reorderSchema(schema, targetSchema)) yield {
+      copy(
+        selectList = OrderedMap() ++ ordering.map { label =>
+          label -> selectList(label)
+        }
+      )
+    }
+  }
 }
 
 trait OSelectImpl { this: Select.type =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Values.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Values.scala
@@ -7,7 +7,7 @@ import com.socrata.prettyprint.prelude._
 import com.socrata.soql.analyzer2._
 import com.socrata.soql.serialize.{Readable, ReadBuffer, Writable, WriteBuffer}
 import com.socrata.soql.collection._
-import com.socrata.soql.environment.{ColumnName, ResourceName}
+import com.socrata.soql.environment.{ColumnName, ResourceName, Source}
 import com.socrata.soql.functions.MonomorphicFunction
 
 import DocUtils._
@@ -152,6 +152,21 @@ trait ValuesImpl[MT <: MetaTypes] { this: Values[MT] =>
     values.foldLeft(Map.empty[AutoTableLabel, Set[ColumnLabel]]) { (acc, row) =>
       row.foldLeft(acc) { (acc, expr) => Util.mergeColumnSet(acc, expr.columnReferences) }
     }
+
+  private[analyzer2] override def ensureSchema(labelProvider: LabelProvider, targetSchema: Seq[(ColumnName, CT)]): Option[Statement[MT]] = {
+    for(ordering <- Util.reorderSchema(schema, targetSchema)) yield {
+      val myLabel = labelProvider.tableLabel()
+      Select(
+        Distinctiveness.Indistinct(),
+        OrderedMap() ++ ordering.iterator.map { sourceLabel =>
+          val sourceEnt = schema(sourceLabel)
+          labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](myLabel, sourceLabel, sourceEnt.typ)(new AtomicPositionInfo(Source.Synthetic)), sourceEnt.name, sourceEnt.hint, sourceEnt.isSynthetic)
+        },
+        FromStatement(this, myLabel, None, None, None),
+        None, Nil, None, Nil, None, None, None, Set.empty
+      )
+    }
+  }
 }
 
 trait OValuesImpl { this: Values.type =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/typechecker/TypeInfo.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/typechecker/TypeInfo.scala
@@ -36,7 +36,7 @@ trait TypeInfo[Type, Value] extends TypeInfoCommon[Type, Value] {
 }
 
 trait TypeInfo2[MT <: analyzer2.MetaTypes] extends analyzer2.StatementUniverse[MT] with TypeInfoCommon[MT#ColumnType, MT#ColumnValue] {
-  def potentialExprs(l: ast.Literal, currentSource: Option[ScopedResourceName], currentPrimaryTable: Option[Provenance]): Seq[Expr]
+  def potentialExprs(l: ast.Literal, toSource: Position => Source, currentPrimaryTable: Option[Provenance]): Seq[Expr]
   def literalBoolean(b: Boolean, currentSource: Source): Expr
 
   def boolType: CT

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
@@ -1522,4 +1522,15 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
 
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
+
+   test("type errors in wrapping queries are marked as having synthetic sources") {
+     val tf = tableFinder(
+       (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber).withWrappingQuery(0, "select * where num > 'hello'")
+     )
+
+     val Right(ft) = tf.findTables(0, rn("ds1"), "select text, num+num", Map.empty)
+     val Left(SoQLAnalyzerError.TypecheckError.TypeMismatch(source, _, _)) = analyzer(ft, UserParameters.empty)
+
+     source must be (Source.Synthetic)
+  }
 }

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
@@ -1518,7 +1518,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
       Map.empty
     )
     val Right(analysis2) = analyzer(ft2, UserParameters.empty)
-      .map(_.removeTrivialJoins(isLiteralTrue)) // need to get rid of the 'from @single_row`
+      .map(_.removeTrivialJoins(isLiteralTrue)) // need to get rid of the first 'from @single_row`
 
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
@@ -1574,6 +1574,88 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     val Right(ft2) = tf2.findTables(0, rn("ds1"), "select text, num * num as numsq order by numsq |> select * where text = 'hello' order by numsq", Map.empty)
     val Right(analysis2) = analyzer(ft2, UserParameters.empty)
 
+    analysis1.statement must be (isomorphicTo(analysis2.statement))
+  }
+
+  test("Hidden-column resolution on tables is deferred until after wrapping queries are generated") {
+    val tf1 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber)
+        .withHiddenColumns("text")
+        .withWrappingQuery(0, "select * where text = 'hello'")
+    )
+
+    val tf2 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber)
+    )
+
+    val Right(ft1) = tf1.findTables(0, rn("ds1"), "select * order by num", Map.empty)
+    val Right(analysis1) = analyzer(ft1, UserParameters.empty)
+
+    val Right(ft2) = tf2.findTables(0, rn("ds1"), "select num where text = 'hello' |> select num order by num", Map.empty)
+    val Right(analysis2) = analyzer(ft2, UserParameters.empty)
+
+    analysis1.statement must be (isomorphicTo(analysis2.statement))
+  }
+
+  test("Hidden-column resolution on queries is deferred until after wrapping queries are generated") {
+    val tf1 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber),
+      (0, "q") -> Q(0, "ds1", "select text, num * num as numsq order by text")
+        .withHiddenColumns("text")
+        .withWrappingQuery(0, "select * where text = 'hello'")
+    )
+
+    val tf2 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber)
+    )
+
+    val Right(ft1) = tf1.findTables(0, rn("q"), "select * order by numsq", Map.empty)
+    val Right(analysis1) = analyzer(ft1, UserParameters.empty)
+
+    val Right(ft2) = tf2.findTables(0, rn("ds1"), "select text, num * num as numsq order by text |> select numsq where text = 'hello' order by text |> select numsq order by numsq", Map.empty)
+    val Right(analysis2) = analyzer(ft2, UserParameters.empty)
+
+    analysis1.statement must be (isomorphicTo(analysis2.statement))
+  }
+
+  test("Hidden-column resolution on UDFs is deferred until after wrapping queries are generated") {
+    val tf1 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber),
+      (0, "ds2") -> D("text2" -> TestText, "num2" -> TestNumber),
+      (0, "u") -> U(0, "select text2, num2 * num2 as num2sq from @ds2 where text2 = ?t order by text2", "t" -> TestText)
+        .withHiddenColumns("text2")
+        .withWrappingQuery(0, "select text2, num2sq where num2sq > 5")
+    )
+
+    val tf2 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber),
+      (0, "ds2") -> D("text2" -> TestText, "num2" -> TestNumber),
+    )
+
+    val Right(ft1) = tf1.findTables(0, rn("ds1"), "select *, @u.* from @this as @t join @u(text) on true", Map.empty)
+    val Right(analysis1) = analyzer(ft1, UserParameters.empty)
+
+    val Right(ft2) = tf2.findTables(
+      0, rn("ds1"),
+      """select
+        |  text, num, @u.num2sq
+        |  from
+        |    @this as @t
+        |    join lateral (
+        |      select @u.*
+        |      from @single_row
+        |      join lateral (
+        |        select @t.text as t from @single_row
+        |      ) as @params on true
+        |      join lateral (
+        |        select text2, num2 * num2 as num2sq from @ds2 where text2 = @params.t order by text2
+        |        |> select num2sq where num2sq > 5 order by text2
+        |      ) as @u on true
+        |    ) as @u on true""".stripMargin,
+      Map.empty
+    )
+    val Right(analysis2) = analyzer(ft2, UserParameters.empty)
+      .map(_.removeTrivialJoins(isLiteralTrue)) // need to get rid of the first `from @single_row`
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 }

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
@@ -1658,4 +1658,21 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
       .map(_.removeTrivialJoins(isLiteralTrue)) // need to get rid of the first `from @single_row`
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
+
+  test("Wrapper queries must have the same schema as their underlying table") {
+    val tf1 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber)
+        .withWrappingQuery(0, "select text")
+      )
+
+    val Right(ft1) = tf1.findTables(0, rn("ds1"))
+    analyzer(ft1, UserParameters.empty) match {
+      case Left(SoQLAnalyzerError.WrappingQuerySchemaMismatch(source)) =>
+        source must equal (Source.Saved(ScopedResourceName(0, rn("ds1")), NoPosition))
+      case Left(err) =>
+        fail("Unexpected error: " + err)
+      case Right(_) =>
+        fail("Unexpected success")
+    }
+  }
 }

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
@@ -1675,4 +1675,23 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
         fail("Unexpected success")
     }
   }
+
+  test("Wrapper is rewritten to have the same order as the underlying query") {
+    val tf1 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber)
+        .withWrappingQuery(0, "select num, text")
+    )
+
+    val tf2 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber)
+    )
+
+    val Right(ft1) = tf1.findTables(0, rn("ds1"))
+    val Right(analysis1) = analyzer(ft1, UserParameters.empty)
+
+    val Right(ft2) = tf2.findTables(0, rn("ds1"), "select text, num", Map.empty)
+    val Right(analysis2) = analyzer(ft2, UserParameters.empty)
+
+    analysis1.statement must be (isomorphicTo(analysis2.statement))
+  }
 }

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
@@ -1437,4 +1437,21 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     fromTable.primaryKeys must be (Seq(Seq(DatabaseColumnName(":id"))))
   }
 
+  test("base dataset wrapping query") {
+    val tf1 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber).withWrappingQuery(0, "select * where num > 5")
+    )
+
+    val tf2 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber)
+    )
+
+    val Right(ft1) = tf1.findTables(0, rn("ds1"), "select text, num+num", Map.empty)
+    val Right(analysis1) = analyzer(ft1, UserParameters.empty)
+
+    val Right(ft2) = tf2.findTables(0, rn("ds1"), "select * where num > 5 |> select text, num+num", Map.empty)
+    val Right(analysis2) = analyzer(ft2, UserParameters.empty)
+
+    analysis1.statement must be (isomorphicTo(analysis2.statement))
+  }
 }

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
@@ -838,9 +838,9 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     val analysis1 = analyzeSaved(tf1, "aaaa-aaaa")
 
     val tf2 = tableFinder(
-      (0, "aaaa-aaaa") -> D("n1" -> TestNumber)
+      (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber)
     )
-    val analysis2 = analyzeSaved(tf2, "aaaa-aaaa")
+    val analysis2 = analyze(tf2, "aaaa-aaaa", "select n1", UserParameters.empty)
 
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
@@ -854,7 +854,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     val tf2 = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber)
     )
-    val analysis2 = analyze(tf2, "aaaa-aaaa", "select n1 order by n2").merge(TestFunctions.And.monomorphic.get)
+    val analysis2 = analyze(tf2, "aaaa-aaaa", "select n1 order by n2")
 
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
@@ -1428,13 +1428,14 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
       (0, "ds1") -> D(":id" -> TestNumber, "text" -> TestText, "num" -> TestNumber).withHiddenColumns("text").withPrimaryKey(":id").withPrimaryKey("text")
     )
 
-    val Right(ft) = tf.findTables(0, rn("ds1"), "select *", Map.empty)
+    val Right(ft) = tf.findTables(0, rn("ds1"))
     val Right(analysis) = analyzer(ft, UserParameters.empty)
+    val select = analysis.statement.asInstanceOf[Select[TestMT]] // wrapper query to remove the text column
 
-    val select = analysis.statement.asInstanceOf[Select[TestMT]]
-    val fromTable = select.from.asInstanceOf[FromTable[TestMT]]
+    select.from must be (a[FromTable[_]])
 
-    fromTable.primaryKeys must be (Seq(Seq(DatabaseColumnName(":id"))))
+    val Seq(Seq(idColumnLabel)) = select.unique
+    select.schema(idColumnLabel).name must be (cn(":id"))
   }
 
   test("base dataset wrapping query") {

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
@@ -24,7 +24,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
       }
   }
 
-  test("alias analysis qualifiers are correct") {
+   test("alias analysis qualifiers are correct") {
     val tf = MockTableFinder.empty[TestMT]
     val Right(start) = tf.findTables(0, "select @bleh.whatever from @single_row", Map.empty)
     analyzer(start, UserParameters.empty) match {
@@ -37,7 +37,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-  test("simple contextless") {
+   test("simple contextless") {
     val tf = MockTableFinder.empty[TestMT]
 
     // Getting rid of parents, literal coersions, function overloading, disambiguation....
@@ -103,7 +103,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     val Select(Distinctiveness.Indistinct(), _, _, None, Nil, None, Nil, None, None, None, _) = select
   }
 
-  test("simple context") {
+   test("simple context") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber).withCanonicalName("a")
     )
@@ -164,7 +164,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     val Select(Distinctiveness.Indistinct(), _, _, None, Nil, None, Nil, None, None, None, _) = select
   }
 
-  test("untagged parameters in anonymous soql - impersonating a saved query") {
+   test("untagged parameters in anonymous soql - impersonating a saved query") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber)
     )
@@ -196,7 +196,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-  test("untagged parameters in anonymous soql - anonymous parameters") {
+   test("untagged parameters in anonymous soql - anonymous parameters") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber)
     )
@@ -225,7 +225,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-  test("untagged parameters in anonymous soql - redirected parameters") {
+   test("untagged parameters in anonymous soql - redirected parameters") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber)
     )
@@ -253,7 +253,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-  test("dataset ordering - direct select") {
+   test("dataset ordering - direct select") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber).withCanonicalName("a").withOrdering("text")
     )
@@ -294,7 +294,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
   }
 
 
-  test("dataset ordering - nested select") {
+   test("dataset ordering - nested select") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber).withCanonicalName("a").withOrdering("text")
     )
@@ -348,7 +348,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-  test("distinct on - ignores permutations") {
+   test("distinct on - ignores permutations") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber)
     )
@@ -356,7 +356,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     // didn't throw an exception, good
   }
 
-  test("distinct on - requires prefix match") {
+   test("distinct on - requires prefix match") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber)
     )
@@ -375,7 +375,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-  test("distinct on - allows extra order bys") {
+   test("distinct on - allows extra order bys") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber)
     )
@@ -383,7 +383,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analyze(tf, "aaaa-aaaa", "select distinct on (text, num) 5 order by num, text, num*2")
   }
 
-  test("UDF - no parameter") {
+   test("UDF - no parameter") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber).withCanonicalName("a"),
       (0, "bbbb-bbbb") -> D("user" -> TestText, "allowed" -> TestBoolean).withCanonicalName("b"),
@@ -490,7 +490,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-  test("UDF - referencing outer column") {
+   test("UDF - referencing outer column") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber).withCanonicalName("a"),
       (0, "bbbb-bbbb") -> D("user" -> TestText, "allowed" -> TestBoolean).withCanonicalName("b"),
@@ -597,7 +597,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-  test("UDF - some parameters are function calls") {
+   test("UDF - some parameters are function calls") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber).withCanonicalName("a"),
       (0, "bbbb-bbbb") -> U(0, "select ?a, ?b, ?c, ?d from @single_row", "d" -> TestText, "c" -> TestNumber, "b" -> TestBoolean, "a" -> TestText).withCanonicalName("b")
@@ -716,7 +716,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-  test("logical positions - alias expansion") {
+   test("logical positions - alias expansion") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber)
     )
@@ -749,7 +749,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-  test("Cannot reference non-explicitly-aliased foreign columns") {
+   test("Cannot reference non-explicitly-aliased foreign columns") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "bbbb-bbbb") -> D("x" -> TestNumber)
@@ -770,7 +770,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-  test("A non-aliased qualified column does not shadow local names") {
+   test("A non-aliased qualified column does not shadow local names") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "bbbb-bbbb") -> D("n1" -> TestNumber, "n2" -> TestNumber)
@@ -783,7 +783,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
-  test("can refer to qualified column expressions with an explicit alias") {
+   test("can refer to qualified column expressions with an explicit alias") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "bbbb-bbbb") -> D("n1" -> TestNumber, "n2" -> TestNumber)
@@ -796,7 +796,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
-  test("logical positions - udf parameters") {
+   test("logical positions - udf parameters") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "bbbb-bbbb") -> U(0, "select 1 from @single-row where ?x = 5", "x" -> TestNumber)
@@ -831,7 +831,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-  test("Hidden columns - an unordered table") {
+   test("Hidden columns - an unordered table") {
     val tf1 = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber).withHiddenColumns("n2")
     )
@@ -845,7 +845,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-  test("Hidden columns - table with a hidden ordering") {
+   test("Hidden columns - table with a hidden ordering") {
     val tf1 = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber).withHiddenColumns("n2").withOrdering("n2")
     )
@@ -859,7 +859,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-  test("Hidden columns - within a query on a sorted table") {
+   test("Hidden columns - within a query on a sorted table") {
     val tf1 = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber).withHiddenColumns("n2").withOrdering("n2")
     )
@@ -873,7 +873,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-  test("Hidden columns - within a UDF") {
+   test("Hidden columns - within a UDF") {
     val tf1 = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "udf") -> U(0, "select n1, n2 from @aaaa-aaaa where n2 = ?x", "x" -> TestNumber).withHiddenColumns("n2")
@@ -889,7 +889,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-  test("Hidden columns - indistinct") {
+   test("Hidden columns - indistinct") {
     val tf1 = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "q") -> Q(0, "aaaa-aaaa", "select n1, n2 order by n2 limit 5 offset 6").withHiddenColumns("n2")
@@ -905,7 +905,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-  test("Hidden columns - distinct on") {
+   test("Hidden columns - distinct on") {
     val tf1 = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "q") -> Q(0, "aaaa-aaaa", "select distinct on(n2) n1, n2 order by n2").withHiddenColumns("n2")
@@ -921,7 +921,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-  test("Hidden columns - distinct") {
+   test("Hidden columns - distinct") {
     val tf1 = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "q") -> Q(0, "aaaa-aaaa", "select distinct n1, n2, n1 + n2 order by n2 limit 5 offset 6").withHiddenColumns("n2")
@@ -937,7 +937,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-  test("Hidden columns - union") {
+   test("Hidden columns - union") {
     val tf1 = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "bbbb-bbbb") -> D("n3" -> TestNumber, "n4" -> TestNumber, "n5" -> TestNumber),
@@ -955,7 +955,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-  test("fully distinct requires selected order by") {
+   test("fully distinct requires selected order by") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
     )
@@ -974,7 +974,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-  test("preserve system columns - simple") {
+   test("preserve system columns - simple") {
     val tf = tableFinder(
       (0, "twocol") -> D(":id" -> TestNumber, "text" -> TestText, "num" -> TestNumber)
     )
@@ -987,7 +987,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
-  test("preserve system columns - partially selected") {
+   test("preserve system columns - partially selected") {
     val tf = tableFinder(
       (0, "twocol") -> D(":id" -> TestNumber, ":version" -> TestNumber, "text" -> TestText, "num" -> TestNumber)
     )
@@ -1000,7 +1000,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
-  test("preserve system columns - distinct blocks") {
+   test("preserve system columns - distinct blocks") {
     val tf = tableFinder(
       (0, "twocol") -> D(":id" -> TestNumber, ":version" -> TestNumber, "text" -> TestText, "num" -> TestNumber)
     )
@@ -1013,7 +1013,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
-  test("preserve system columns - table ops block") {
+   test("preserve system columns - table ops block") {
     val tf = tableFinder(
       (0, "twocol") -> D(":id" -> TestNumber, ":version" -> TestNumber, "text" -> TestText, "num" -> TestNumber)
     )
@@ -1026,7 +1026,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
-  test("preserve system columns - aggregating") {
+   test("preserve system columns - aggregating") {
     val tf = tableFinder(
       (0, "twocol") -> D(":id" -> TestNumber, "text" -> TestText, "num" -> TestNumber)
     )
@@ -1040,7 +1040,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement.schema.find(_._2.name == cn(":id")) must not be empty
   }
 
-  test("preserve system columns - udf") {
+   test("preserve system columns - udf") {
     val tf = tableFinder(
       (0, "twocol") -> D(":id" -> TestNumber, "text" -> TestText, "num" -> TestNumber),
       (0, "udf") -> U(0, "select num from @twocol where text = ?t", "t" -> TestText),
@@ -1056,7 +1056,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement.schema.find(_._2.name == cn(":id")) must not be empty
   }
 
-  test("case expression gets rewritten to case function") {
+   test("case expression gets rewritten to case function") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber).withOrdering("text")
     )
@@ -1067,7 +1067,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement must be (isomorphicTo(analysis2.statement))
   }
 
-  test("cannot use OVER with count(distinct)") {
+   test("cannot use OVER with count(distinct)") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber).withOrdering("text")
     )
@@ -1082,7 +1082,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-  test("Can use @this on the RHS of a table op") {
+   test("Can use @this on the RHS of a table op") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select text as t, num*2 as n"),
@@ -1097,7 +1097,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-  test("Can use nothing on the RHS of a table op") {
+   test("Can use nothing on the RHS of a table op") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select text as t, num*2 as n"),
@@ -1112,7 +1112,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-  test("Can use @this on the LHS of a table op") {
+   test("Can use @this on the LHS of a table op") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select text as t, num*2 as n"),
@@ -1127,7 +1127,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-  test("Can use nothing on the LHS of a table op") {
+   test("Can use nothing on the LHS of a table op") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select text as t, num*2 as n"),
@@ -1142,7 +1142,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-  test("Must use the context _somewhere_ in a contextual table op") {
+   test("Must use the context _somewhere_ in a contextual table op") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select text as t, num*2 as n"),
@@ -1153,7 +1153,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     val Left(SoQLAnalyzerError.FromForbidden(_)) = analyzer(ft, UserParameters.empty)
   }
 
-  test("May refer to the parent by name") {
+   test("May refer to the parent by name") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber)
     )
@@ -1169,7 +1169,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
-  test("May not ignore the parent") {
+   test("May not ignore the parent") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "ds2") -> D("text" -> TestText, "num" -> TestNumber)
@@ -1179,7 +1179,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     val Left(SoQLAnalyzerError.FromForbidden(_)) = analyzer(ft, UserParameters.empty)
   }
 
-  test("hints get piped through - originating in a table") {
+   test("hints get piped through - originating in a table") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber).withOutputColumnHints("num" -> j"true"),
       (0, "q") -> Q(0, "ds", "select num as a, num*2 as b"),
@@ -1192,7 +1192,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement.schema.values.map(_.hint).toSeq must be (Seq(Some(j"true"), None, None, None))
   }
 
-  test("hints directly on a table") {
+   test("hints directly on a table") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber).withOutputColumnHints("num" -> j"true")
     )
@@ -1203,7 +1203,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement.schema.values.map(_.hint).toSeq must be (Seq(None, Some(j"true")))
   }
 
-  test("hints get piped through - originating in a query") {
+   test("hints get piped through - originating in a query") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select num as a, num*2 as b").withOutputColumnHints("b" -> j"true"),
@@ -1216,7 +1216,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement.schema.values.map(_.hint).toSeq must be (Seq(None, Some(j"true"), None, None))
   }
 
-  test("hints can be overridden") {
+   test("hints can be overridden") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber).withOutputColumnHints("num" -> j"true"),
       (0, "q") -> Q(0, "ds", "select num as a, num*2 as b").withOutputColumnHints("a" -> j"false"),
@@ -1229,7 +1229,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement.schema.values.map(_.hint).toSeq must be (Seq(Some(j"false"), None, None, None))
   }
 
-  test("errors in anonymous soql have an anonymous source") {
+   test("errors in anonymous soql have an anonymous source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select num as a, num*2 as b")
@@ -1244,7 +1244,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-  test("errors in saved soql referenced by anonymous soql have a saved source") {
+   test("errors in saved soql referenced by anonymous soql have a saved source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select not_found")
@@ -1259,7 +1259,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-  test("errors in saved soql referenced by saved soql have a saved source") {
+   test("errors in saved soql referenced by saved soql have a saved source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select not_found"),
@@ -1275,7 +1275,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-  test("errors in saved subselect soql referenced directly have a saved source") {
+   test("errors in saved subselect soql referenced directly have a saved source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select 1 join (select not_found from @single_row) as x on true")
@@ -1290,7 +1290,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-  test("errors in a parameterless udf soql referenced directly have a saved source") {
+   test("errors in a parameterless udf soql referenced directly have a saved source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "udf") -> U(0, "select not_found from @single_row"),
@@ -1306,7 +1306,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-  test("errors in a parametered udf soql referenced directly have a saved source") {
+   test("errors in a parametered udf soql referenced directly have a saved source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "udf") -> U(0, "select not_found from @single_row", "x" -> TestNumber),
@@ -1322,7 +1322,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-  test("errors in a udf parameter have the right source") {
+   test("errors in a udf parameter have the right source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "udf") -> U(0, "select ?x from @single_row", "x" -> TestNumber),
@@ -1338,7 +1338,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-  test("errors on the left hand side of a a pipe have the right source") {
+   test("errors on the left hand side of a a pipe have the right source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select not_found |> select *")
@@ -1353,7 +1353,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-  test("errors on the right hand side of a a pipe have the right source") {
+   test("errors on the right hand side of a a pipe have the right source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select * |> select not_found")
@@ -1368,7 +1368,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-  test("An ON clause can reference output columns which only include references to tables here or left of here") {
+   test("An ON clause can reference output columns which only include references to tables here or left of here") {
     val tf = tableFinder(
       (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "ds2") -> D("hello" -> TestText, "world" -> TestNumber),
@@ -1379,7 +1379,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     val Right(_) = analyzer(ft, UserParameters.empty)
   }
 
-  test("An ON clause can NOT reference output columns which include references to tables right of here") {
+   test("An ON clause can NOT reference output columns which include references to tables right of here") {
     val tf = tableFinder(
       (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "ds2") -> D("hello" -> TestText, "world" -> TestNumber),
@@ -1391,7 +1391,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     badColName must equal(cn("t"))
   }
 
-  test("An explicit LATERAL on a UDF call is ignored if it's not required") {
+   test("An explicit LATERAL on a UDF call is ignored if it's not required") {
     val tf = tableFinder(
       (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "ds2") -> D("another_text" -> TestText, "another_num" -> TestNumber),
@@ -1407,7 +1407,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     from.lateral must be (false)
   }
 
-  test("An absent LATERAL on a UDF call is provided if it is required") {
+   test("An absent LATERAL on a UDF call is provided if it is required") {
     val tf = tableFinder(
       (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "ds2") -> D("another_text" -> TestText, "another_num" -> TestNumber),
@@ -1423,7 +1423,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     from.lateral must be (true)
   }
 
-  test("Hidden columns get removed from primary-key sets during analysis") {
+   test("Hidden columns get removed from primary-key sets during analysis") {
     val tf = tableFinder(
       (0, "ds1") -> D(":id" -> TestNumber, "text" -> TestText, "num" -> TestNumber).withHiddenColumns("text").withPrimaryKey(":id").withPrimaryKey("text")
     )
@@ -1437,7 +1437,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     fromTable.primaryKeys must be (Seq(Seq(DatabaseColumnName(":id"))))
   }
 
-  test("base dataset wrapping query") {
+   test("base dataset wrapping query") {
     val tf1 = tableFinder(
       (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber).withWrappingQuery(0, "select * where num > 5")
     )
@@ -1451,6 +1451,74 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
 
     val Right(ft2) = tf2.findTables(0, rn("ds1"), "select * where num > 5 |> select text, num+num", Map.empty)
     val Right(analysis2) = analyzer(ft2, UserParameters.empty)
+
+    analysis1.statement must be (isomorphicTo(analysis2.statement))
+  }
+
+   test("a wrapping query can access a parameterized view's parameters") {
+    val tf1 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber),
+      (0, "q") -> Q(0, "ds1", "select * where text = param('t')", "t" -> TestText)
+        .withWrappingQuery(0, "select * where num > 5 and param('t') = 'gnu'")
+    )
+
+    val tf2 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber)
+    )
+
+    val Right(ft1) = tf1.findTables(0, rn("q"), "select text, num+num", Map.empty)
+    val Right(analysis1) = analyzer(ft1, UserParameters[TestType, TestValue](
+                                      Map(canon("q") -> Map(hn("t") -> UserParameters.Value(TestText("hello"))))
+                                    ))
+
+    val Right(ft2) = tf2.findTables(0, rn("ds1"), "select * where text = 'hello' |> select * where num > 5 and 'hello' = 'gnu' |> select text, num + num", Map.empty)
+    val Right(analysis2) = analyzer(ft2, UserParameters.empty)
+
+    analysis1.statement must be (isomorphicTo(analysis2.statement))
+  }
+
+   test("a wrapping query can access a table function's parameters") {
+    val tf1 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber),
+      (0, "ds2") -> D("text2" -> TestText, "num2" -> TestNumber),
+      (0, "u") -> U(0, "select * from @ds2 where text2 = ?t", "t" -> TestText)
+        .withWrappingQuery(0, "select * where num2 > 5 and ?t = 'gnu'")
+    )
+
+    val tf2 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber),
+      (0, "ds2") -> D("text2" -> TestText, "num2" -> TestNumber),
+    )
+
+    val Right(ft1) = tf1.findTables(0, rn("ds1"), "select *, @u.* from @this as @t join @u(text) on true", Map.empty)
+    val Right(analysis1) = analyzer(ft1, UserParameters.empty)
+
+    val Right(ft2) = tf2.findTables(
+      0, rn("ds1"),
+      """select *, @u.*
+        |  from @this as @t
+        |  join lateral (
+        |    select @u.*
+        |      from @single_row
+        |      join lateral (
+        |        select @t.text as t
+        |          from @single_row
+        |      ) as @params
+        |      on true
+        |      join lateral (
+        |        select *
+        |          from @ds2
+        |          where text2 = @params.t
+        |        |>
+        |        select *
+        |          where num2 > 5 and @params.t = 'gnu'
+        |      ) as @u on true
+        |  ) as @u
+        |  on true""".stripMargin,
+      Map.empty
+    )
+    val Right(analysis2) = analyzer(ft2, UserParameters.empty)
+      .map(_.removeTrivialJoins(isLiteralTrue)) // need to get rid of the 'from @single_row`
 
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
@@ -1533,4 +1533,47 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
 
      source must be (Source.Synthetic)
   }
+
+   test("Ordering is preserved through a wrapping query on a table") {
+    val tf1 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber)
+        .withOrdering("text")
+        .withWrappingQuery(0, "select * where num > 5")
+    )
+
+    val tf2 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber)
+        .withOrdering("text")
+    )
+
+    val Right(ft1) = tf1.findTables(0, rn("ds1"), "select text, num+num", Map.empty)
+    val Right(analysis1) = analyzer(ft1, UserParameters.empty)
+
+    val Right(ft2) = tf2.findTables(0, rn("ds1"), "select * where num > 5 order by text |> select text, num+num", Map.empty)
+    val Right(analysis2) = analyzer(ft2, UserParameters.empty)
+
+    analysis1.statement must be (isomorphicTo(analysis2.statement))
+  }
+
+   test("Ordering is preserved through a wrapping query on a query, up to the query itself") {
+    val tf1 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber)
+        .withOrdering("text"),
+      (0, "q") -> Q(0, "ds1", "select text, num * num as numsq order by numsq")
+        .withWrappingQuery(0, "select * where text = 'hello'")
+    )
+
+    val tf2 = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber)
+        .withOrdering("text")
+    )
+
+    val Right(ft1) = tf1.findTables(0, rn("q"))
+    val Right(analysis1) = analyzer(ft1, UserParameters.empty)
+
+    val Right(ft2) = tf2.findTables(0, rn("ds1"), "select text, num * num as numsq order by numsq |> select * where text = 'hello' order by numsq", Map.empty)
+    val Right(analysis2) = analyzer(ft2, UserParameters.empty)
+
+    analysis1.statement must be (isomorphicTo(analysis2.statement))
+  }
 }

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
@@ -1694,4 +1694,23 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
 
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
+
+  test("Wrapper is rewritten to have the same order as the underlying query, even in the presence of hidden columns") {
+    val tf1 = tableFinder(
+      (0, "ds1") -> D("a" -> TestText, "b" -> TestNumber, "c" -> TestBoolean)
+        .withHiddenColumns("b")
+        .withWrappingQuery(0, "select c, b, a")
+    )
+
+    val tf2 = tableFinder(
+      (0, "ds1") -> D("a" -> TestText, "b" -> TestNumber, "c" -> TestBoolean)
+        .withHiddenColumns("b")
+    )
+
+    val Right(ft1) = tf1.findTables(0, rn("ds1"))
+    val Right(analysis1) = analyzer(ft1, UserParameters.empty)
+
+    val Right(ft2) = tf2.findTables(0, rn("ds1"), "select a, c", Map.empty)
+    val Right(analysis2) = analyzer(ft2, UserParameters.empty)
+  }
 }

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
@@ -24,7 +24,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
       }
   }
 
-   test("alias analysis qualifiers are correct") {
+  test("alias analysis qualifiers are correct") {
     val tf = MockTableFinder.empty[TestMT]
     val Right(start) = tf.findTables(0, "select @bleh.whatever from @single_row", Map.empty)
     analyzer(start, UserParameters.empty) match {
@@ -37,7 +37,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-   test("simple contextless") {
+  test("simple contextless") {
     val tf = MockTableFinder.empty[TestMT]
 
     // Getting rid of parents, literal coersions, function overloading, disambiguation....
@@ -103,7 +103,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     val Select(Distinctiveness.Indistinct(), _, _, None, Nil, None, Nil, None, None, None, _) = select
   }
 
-   test("simple context") {
+  test("simple context") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber).withCanonicalName("a")
     )
@@ -164,7 +164,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     val Select(Distinctiveness.Indistinct(), _, _, None, Nil, None, Nil, None, None, None, _) = select
   }
 
-   test("untagged parameters in anonymous soql - impersonating a saved query") {
+  test("untagged parameters in anonymous soql - impersonating a saved query") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber)
     )
@@ -196,7 +196,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-   test("untagged parameters in anonymous soql - anonymous parameters") {
+  test("untagged parameters in anonymous soql - anonymous parameters") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber)
     )
@@ -225,7 +225,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-   test("untagged parameters in anonymous soql - redirected parameters") {
+  test("untagged parameters in anonymous soql - redirected parameters") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber)
     )
@@ -253,7 +253,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-   test("dataset ordering - direct select") {
+  test("dataset ordering - direct select") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber).withCanonicalName("a").withOrdering("text")
     )
@@ -294,7 +294,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
   }
 
 
-   test("dataset ordering - nested select") {
+  test("dataset ordering - nested select") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber).withCanonicalName("a").withOrdering("text")
     )
@@ -348,7 +348,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-   test("distinct on - ignores permutations") {
+  test("distinct on - ignores permutations") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber)
     )
@@ -356,7 +356,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     // didn't throw an exception, good
   }
 
-   test("distinct on - requires prefix match") {
+  test("distinct on - requires prefix match") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber)
     )
@@ -375,7 +375,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-   test("distinct on - allows extra order bys") {
+  test("distinct on - allows extra order bys") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber)
     )
@@ -383,7 +383,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analyze(tf, "aaaa-aaaa", "select distinct on (text, num) 5 order by num, text, num*2")
   }
 
-   test("UDF - no parameter") {
+  test("UDF - no parameter") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber).withCanonicalName("a"),
       (0, "bbbb-bbbb") -> D("user" -> TestText, "allowed" -> TestBoolean).withCanonicalName("b"),
@@ -490,7 +490,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-   test("UDF - referencing outer column") {
+  test("UDF - referencing outer column") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber).withCanonicalName("a"),
       (0, "bbbb-bbbb") -> D("user" -> TestText, "allowed" -> TestBoolean).withCanonicalName("b"),
@@ -597,7 +597,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-   test("UDF - some parameters are function calls") {
+  test("UDF - some parameters are function calls") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber).withCanonicalName("a"),
       (0, "bbbb-bbbb") -> U(0, "select ?a, ?b, ?c, ?d from @single_row", "d" -> TestText, "c" -> TestNumber, "b" -> TestBoolean, "a" -> TestText).withCanonicalName("b")
@@ -716,7 +716,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-   test("logical positions - alias expansion") {
+  test("logical positions - alias expansion") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber)
     )
@@ -749,7 +749,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-   test("Cannot reference non-explicitly-aliased foreign columns") {
+  test("Cannot reference non-explicitly-aliased foreign columns") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "bbbb-bbbb") -> D("x" -> TestNumber)
@@ -770,7 +770,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-   test("A non-aliased qualified column does not shadow local names") {
+  test("A non-aliased qualified column does not shadow local names") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "bbbb-bbbb") -> D("n1" -> TestNumber, "n2" -> TestNumber)
@@ -783,7 +783,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
-   test("can refer to qualified column expressions with an explicit alias") {
+  test("can refer to qualified column expressions with an explicit alias") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "bbbb-bbbb") -> D("n1" -> TestNumber, "n2" -> TestNumber)
@@ -796,7 +796,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
-   test("logical positions - udf parameters") {
+  test("logical positions - udf parameters") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "bbbb-bbbb") -> U(0, "select 1 from @single-row where ?x = 5", "x" -> TestNumber)
@@ -831,7 +831,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     )
   }
 
-   test("Hidden columns - an unordered table") {
+  test("Hidden columns - an unordered table") {
     val tf1 = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber).withHiddenColumns("n2")
     )
@@ -845,7 +845,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-   test("Hidden columns - table with a hidden ordering") {
+  test("Hidden columns - table with a hidden ordering") {
     val tf1 = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber).withHiddenColumns("n2").withOrdering("n2")
     )
@@ -859,7 +859,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-   test("Hidden columns - within a query on a sorted table") {
+  test("Hidden columns - within a query on a sorted table") {
     val tf1 = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber).withHiddenColumns("n2").withOrdering("n2")
     )
@@ -873,7 +873,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-   test("Hidden columns - within a UDF") {
+  test("Hidden columns - within a UDF") {
     val tf1 = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "udf") -> U(0, "select n1, n2 from @aaaa-aaaa where n2 = ?x", "x" -> TestNumber).withHiddenColumns("n2")
@@ -889,7 +889,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-   test("Hidden columns - indistinct") {
+  test("Hidden columns - indistinct") {
     val tf1 = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "q") -> Q(0, "aaaa-aaaa", "select n1, n2 order by n2 limit 5 offset 6").withHiddenColumns("n2")
@@ -905,7 +905,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-   test("Hidden columns - distinct on") {
+  test("Hidden columns - distinct on") {
     val tf1 = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "q") -> Q(0, "aaaa-aaaa", "select distinct on(n2) n1, n2 order by n2").withHiddenColumns("n2")
@@ -921,7 +921,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-   test("Hidden columns - distinct") {
+  test("Hidden columns - distinct") {
     val tf1 = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "q") -> Q(0, "aaaa-aaaa", "select distinct n1, n2, n1 + n2 order by n2 limit 5 offset 6").withHiddenColumns("n2")
@@ -937,7 +937,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-   test("Hidden columns - union") {
+  test("Hidden columns - union") {
     val tf1 = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
       (0, "bbbb-bbbb") -> D("n3" -> TestNumber, "n4" -> TestNumber, "n5" -> TestNumber),
@@ -955,7 +955,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-   test("fully distinct requires selected order by") {
+  test("fully distinct requires selected order by") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("n1" -> TestNumber, "n2" -> TestNumber),
     )
@@ -974,7 +974,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-   test("preserve system columns - simple") {
+  test("preserve system columns - simple") {
     val tf = tableFinder(
       (0, "twocol") -> D(":id" -> TestNumber, "text" -> TestText, "num" -> TestNumber)
     )
@@ -987,7 +987,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
-   test("preserve system columns - partially selected") {
+  test("preserve system columns - partially selected") {
     val tf = tableFinder(
       (0, "twocol") -> D(":id" -> TestNumber, ":version" -> TestNumber, "text" -> TestText, "num" -> TestNumber)
     )
@@ -1000,7 +1000,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
-   test("preserve system columns - distinct blocks") {
+  test("preserve system columns - distinct blocks") {
     val tf = tableFinder(
       (0, "twocol") -> D(":id" -> TestNumber, ":version" -> TestNumber, "text" -> TestText, "num" -> TestNumber)
     )
@@ -1013,7 +1013,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
-   test("preserve system columns - table ops block") {
+  test("preserve system columns - table ops block") {
     val tf = tableFinder(
       (0, "twocol") -> D(":id" -> TestNumber, ":version" -> TestNumber, "text" -> TestText, "num" -> TestNumber)
     )
@@ -1026,7 +1026,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
-   test("preserve system columns - aggregating") {
+  test("preserve system columns - aggregating") {
     val tf = tableFinder(
       (0, "twocol") -> D(":id" -> TestNumber, "text" -> TestText, "num" -> TestNumber)
     )
@@ -1040,7 +1040,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement.schema.find(_._2.name == cn(":id")) must not be empty
   }
 
-   test("preserve system columns - udf") {
+  test("preserve system columns - udf") {
     val tf = tableFinder(
       (0, "twocol") -> D(":id" -> TestNumber, "text" -> TestText, "num" -> TestNumber),
       (0, "udf") -> U(0, "select num from @twocol where text = ?t", "t" -> TestText),
@@ -1056,7 +1056,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement.schema.find(_._2.name == cn(":id")) must not be empty
   }
 
-   test("case expression gets rewritten to case function") {
+  test("case expression gets rewritten to case function") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber).withOrdering("text")
     )
@@ -1067,7 +1067,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement must be (isomorphicTo(analysis2.statement))
   }
 
-   test("cannot use OVER with count(distinct)") {
+  test("cannot use OVER with count(distinct)") {
     val tf = tableFinder(
       (0, "aaaa-aaaa") -> D("text" -> TestText, "num" -> TestNumber).withOrdering("text")
     )
@@ -1082,7 +1082,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-   test("Can use @this on the RHS of a table op") {
+  test("Can use @this on the RHS of a table op") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select text as t, num*2 as n"),
@@ -1097,7 +1097,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-   test("Can use nothing on the RHS of a table op") {
+  test("Can use nothing on the RHS of a table op") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select text as t, num*2 as n"),
@@ -1112,7 +1112,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-   test("Can use @this on the LHS of a table op") {
+  test("Can use @this on the LHS of a table op") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select text as t, num*2 as n"),
@@ -1127,7 +1127,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-   test("Can use nothing on the LHS of a table op") {
+  test("Can use nothing on the LHS of a table op") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select text as t, num*2 as n"),
@@ -1142,7 +1142,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-   test("Must use the context _somewhere_ in a contextual table op") {
+  test("Must use the context _somewhere_ in a contextual table op") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select text as t, num*2 as n"),
@@ -1153,7 +1153,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     val Left(SoQLAnalyzerError.FromForbidden(_)) = analyzer(ft, UserParameters.empty)
   }
 
-   test("May refer to the parent by name") {
+  test("May refer to the parent by name") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber)
     )
@@ -1169,7 +1169,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement must be (isomorphicTo(expectedAnalysis.statement))
   }
 
-   test("May not ignore the parent") {
+  test("May not ignore the parent") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "ds2") -> D("text" -> TestText, "num" -> TestNumber)
@@ -1179,7 +1179,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     val Left(SoQLAnalyzerError.FromForbidden(_)) = analyzer(ft, UserParameters.empty)
   }
 
-   test("hints get piped through - originating in a table") {
+  test("hints get piped through - originating in a table") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber).withOutputColumnHints("num" -> j"true"),
       (0, "q") -> Q(0, "ds", "select num as a, num*2 as b"),
@@ -1192,7 +1192,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement.schema.values.map(_.hint).toSeq must be (Seq(Some(j"true"), None, None, None))
   }
 
-   test("hints directly on a table") {
+  test("hints directly on a table") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber).withOutputColumnHints("num" -> j"true")
     )
@@ -1203,7 +1203,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement.schema.values.map(_.hint).toSeq must be (Seq(None, Some(j"true")))
   }
 
-   test("hints get piped through - originating in a query") {
+  test("hints get piped through - originating in a query") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select num as a, num*2 as b").withOutputColumnHints("b" -> j"true"),
@@ -1216,7 +1216,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement.schema.values.map(_.hint).toSeq must be (Seq(None, Some(j"true"), None, None))
   }
 
-   test("hints can be overridden") {
+  test("hints can be overridden") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber).withOutputColumnHints("num" -> j"true"),
       (0, "q") -> Q(0, "ds", "select num as a, num*2 as b").withOutputColumnHints("a" -> j"false"),
@@ -1229,7 +1229,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis.statement.schema.values.map(_.hint).toSeq must be (Seq(Some(j"false"), None, None, None))
   }
 
-   test("errors in anonymous soql have an anonymous source") {
+  test("errors in anonymous soql have an anonymous source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select num as a, num*2 as b")
@@ -1244,7 +1244,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-   test("errors in saved soql referenced by anonymous soql have a saved source") {
+  test("errors in saved soql referenced by anonymous soql have a saved source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select not_found")
@@ -1259,7 +1259,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-   test("errors in saved soql referenced by saved soql have a saved source") {
+  test("errors in saved soql referenced by saved soql have a saved source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select not_found"),
@@ -1275,7 +1275,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-   test("errors in saved subselect soql referenced directly have a saved source") {
+  test("errors in saved subselect soql referenced directly have a saved source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select 1 join (select not_found from @single_row) as x on true")
@@ -1290,7 +1290,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-   test("errors in a parameterless udf soql referenced directly have a saved source") {
+  test("errors in a parameterless udf soql referenced directly have a saved source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "udf") -> U(0, "select not_found from @single_row"),
@@ -1306,7 +1306,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-   test("errors in a parametered udf soql referenced directly have a saved source") {
+  test("errors in a parametered udf soql referenced directly have a saved source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "udf") -> U(0, "select not_found from @single_row", "x" -> TestNumber),
@@ -1322,7 +1322,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-   test("errors in a udf parameter have the right source") {
+  test("errors in a udf parameter have the right source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "udf") -> U(0, "select ?x from @single_row", "x" -> TestNumber),
@@ -1338,7 +1338,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-   test("errors on the left hand side of a a pipe have the right source") {
+  test("errors on the left hand side of a a pipe have the right source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select not_found |> select *")
@@ -1353,7 +1353,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-   test("errors on the right hand side of a a pipe have the right source") {
+  test("errors on the right hand side of a a pipe have the right source") {
     val tf = tableFinder(
       (0, "ds") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds", "select * |> select not_found")
@@ -1368,7 +1368,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     }
   }
 
-   test("An ON clause can reference output columns which only include references to tables here or left of here") {
+  test("An ON clause can reference output columns which only include references to tables here or left of here") {
     val tf = tableFinder(
       (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "ds2") -> D("hello" -> TestText, "world" -> TestNumber),
@@ -1379,7 +1379,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     val Right(_) = analyzer(ft, UserParameters.empty)
   }
 
-   test("An ON clause can NOT reference output columns which include references to tables right of here") {
+  test("An ON clause can NOT reference output columns which include references to tables right of here") {
     val tf = tableFinder(
       (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "ds2") -> D("hello" -> TestText, "world" -> TestNumber),
@@ -1391,7 +1391,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     badColName must equal(cn("t"))
   }
 
-   test("An explicit LATERAL on a UDF call is ignored if it's not required") {
+  test("An explicit LATERAL on a UDF call is ignored if it's not required") {
     val tf = tableFinder(
       (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "ds2") -> D("another_text" -> TestText, "another_num" -> TestNumber),
@@ -1407,7 +1407,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     from.lateral must be (false)
   }
 
-   test("An absent LATERAL on a UDF call is provided if it is required") {
+  test("An absent LATERAL on a UDF call is provided if it is required") {
     val tf = tableFinder(
       (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "ds2") -> D("another_text" -> TestText, "another_num" -> TestNumber),
@@ -1423,7 +1423,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     from.lateral must be (true)
   }
 
-   test("Hidden columns get removed from primary-key sets during analysis") {
+  test("Hidden columns get removed from primary-key sets during analysis") {
     val tf = tableFinder(
       (0, "ds1") -> D(":id" -> TestNumber, "text" -> TestText, "num" -> TestNumber).withHiddenColumns("text").withPrimaryKey(":id").withPrimaryKey("text")
     )
@@ -1437,7 +1437,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     fromTable.primaryKeys must be (Seq(Seq(DatabaseColumnName(":id"))))
   }
 
-   test("base dataset wrapping query") {
+  test("base dataset wrapping query") {
     val tf1 = tableFinder(
       (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber).withWrappingQuery(0, "select * where num > 5")
     )
@@ -1455,7 +1455,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-   test("a wrapping query can access a parameterized view's parameters") {
+  test("a wrapping query can access a parameterized view's parameters") {
     val tf1 = tableFinder(
       (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "q") -> Q(0, "ds1", "select * where text = param('t')", "t" -> TestText)
@@ -1477,7 +1477,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-   test("a wrapping query can access a table function's parameters") {
+  test("a wrapping query can access a table function's parameters") {
     val tf1 = tableFinder(
       (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber),
       (0, "ds2") -> D("text2" -> TestText, "num2" -> TestNumber),
@@ -1523,7 +1523,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-   test("type errors in wrapping queries are marked as having synthetic sources") {
+  test("type errors in wrapping queries are marked as having synthetic sources") {
      val tf = tableFinder(
        (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber).withWrappingQuery(0, "select * where num > 'hello'")
      )
@@ -1534,7 +1534,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
      source must be (Source.Synthetic)
   }
 
-   test("Ordering is preserved through a wrapping query on a table") {
+  test("Ordering is preserved through a wrapping query on a table") {
     val tf1 = tableFinder(
       (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber)
         .withOrdering("text")
@@ -1555,7 +1555,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     analysis1.statement must be (isomorphicTo(analysis2.statement))
   }
 
-   test("Ordering is preserved through a wrapping query on a query, up to the query itself") {
+  test("Ordering is preserved through a wrapping query on a query, up to the query itself") {
     val tf1 = tableFinder(
       (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber)
         .withOrdering("text"),

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/TestTypeInfo.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/TestTypeInfo.scala
@@ -26,19 +26,19 @@ class TestTypeInfo[MT <: MetaTypes with ({ type ColumnType = TestType; type Colu
   def literalBoolean(b: Boolean, source: Source): Expr =
     LiteralValue[MT](TestBoolean(b))(new AtomicPositionInfo(source))
 
-  def potentialExprs(l: ast.Literal, source: Option[ScopedResourceName], currentPrimaryTable: Option[Provenance]): Seq[Expr] =
+  def potentialExprs(l: ast.Literal, toSource: Position => Source, currentPrimaryTable: Option[Provenance]): Seq[Expr] =
     l match {
       case ast.StringLiteral(s) =>
         val asInt =
           try {
-            Some(LiteralValue[MT](TestNumber(s.toInt))(new AtomicPositionInfo(Source.nonSynthetic(source, l.position))))
+            Some(LiteralValue[MT](TestNumber(s.toInt))(new AtomicPositionInfo(toSource(l.position))))
           } catch {
             case _ : NumberFormatException => None
           }
-        Seq(LiteralValue[MT](TestText(s))(new AtomicPositionInfo(Source.nonSynthetic(source, l.position)))) ++ asInt
-      case ast.NumberLiteral(n) => Seq(LiteralValue[MT](TestNumber(n.toInt))(new AtomicPositionInfo(Source.nonSynthetic(source, l.position))))
-      case ast.BooleanLiteral(b) => Seq(LiteralValue[MT](TestBoolean(b))(new AtomicPositionInfo(Source.nonSynthetic(source, l.position))))
-      case ast.NullLiteral() => typeParameterUniverse.iterator.map(NullLiteral[MT](_)(new AtomicPositionInfo(Source.nonSynthetic(source, l.position)))).toVector
+        Seq(LiteralValue[MT](TestText(s))(new AtomicPositionInfo(toSource(l.position)))) ++ asInt
+      case ast.NumberLiteral(n) => Seq(LiteralValue[MT](TestNumber(n.toInt))(new AtomicPositionInfo(toSource(l.position))))
+      case ast.BooleanLiteral(b) => Seq(LiteralValue[MT](TestBoolean(b))(new AtomicPositionInfo(toSource(l.position))))
+      case ast.NullLiteral() => typeParameterUniverse.iterator.map(NullLiteral[MT](_)(new AtomicPositionInfo(toSource(l.position)))).toVector
     }
 
   def updateProvenance(v: CV)(f: Provenance => Provenance) = v

--- a/soql-sqlizer/src/test/scala/com/socrata/soql/sqlizer/TestTypeInfo.scala
+++ b/soql-sqlizer/src/test/scala/com/socrata/soql/sqlizer/TestTypeInfo.scala
@@ -21,7 +21,7 @@ object TestTypeInfo extends TypeInfo2[TestHelper.TestMT] {
   def literalBoolean(b: Boolean, source: Source): Expr =
     LiteralValue[MT](TestBoolean(b))(new AtomicPositionInfo(source))
 
-  def potentialExprs(l: ast.Literal, source: Option[ScopedResourceName], currentPrimaryTable: Option[Provenance]): Seq[Expr] =
+  def potentialExprs(l: ast.Literal, toSource: Position => Source, currentPrimaryTable: Option[Provenance]): Seq[Expr] =
     l match {
       case ast.StringLiteral(s) =>
         val asInt: Option[CV] =
@@ -32,10 +32,10 @@ object TestTypeInfo extends TypeInfo2[TestHelper.TestMT] {
           }
         val asCompound = tryAsCompound(s)
         val asID = tryAsID(s, currentPrimaryTable)
-        Seq[Option[CV]](Some(TestText(s)), asInt, asCompound, asID).flatten.map(LiteralValue[MT](_)(new AtomicPositionInfo(Source.nonSynthetic(source, l.position))))
-      case ast.NumberLiteral(n) => Seq(LiteralValue[MT](TestNumber(n.toInt))(new AtomicPositionInfo(Source.nonSynthetic(source, l.position))))
-      case ast.BooleanLiteral(b) => Seq(LiteralValue[MT](TestBoolean(b))(new AtomicPositionInfo(Source.nonSynthetic(source, l.position))))
-      case ast.NullLiteral() => typeParameterUniverse.iterator.map(NullLiteral[MT](_)(new AtomicPositionInfo(Source.nonSynthetic(source, l.position)))).toVector
+        Seq[Option[CV]](Some(TestText(s)), asInt, asCompound, asID).flatten.map(LiteralValue[MT](_)(new AtomicPositionInfo(toSource(l.position))))
+      case ast.NumberLiteral(n) => Seq(LiteralValue[MT](TestNumber(n.toInt))(new AtomicPositionInfo(toSource(l.position))))
+      case ast.BooleanLiteral(b) => Seq(LiteralValue[MT](TestBoolean(b))(new AtomicPositionInfo(toSource(l.position))))
+      case ast.NullLiteral() => typeParameterUniverse.iterator.map(NullLiteral[MT](_)(new AtomicPositionInfo(toSource(l.position)))).toVector
     }
 
   private def tryAsID(s: String, currentPrimaryTable: Option[Provenance]): Option[CV] = {

--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLTypeInfo.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLTypeInfo.scala
@@ -37,18 +37,18 @@ sealed trait SoQLTypeInfoCommon extends TypeInfoCommon[SoQLType, SoQLValue] {
 }
 
 final class SoQLTypeInfo2[MT <: analyzer2.MetaTypes with ({ type ColumnType = SoQLType; type ColumnValue = SoQLValue })] extends TypeInfo2[MT] with SoQLTypeInfoCommon with analyzer2.StatementUniverse[MT] {
-  override def potentialExprs(l: ast.Literal, sourceName: Option[analyzer2.types.ScopedResourceName[MT]], primaryTable: Option[Provenance]) =
+  override def potentialExprs(l: ast.Literal, toSource: Position => Source, primaryTable: Option[Provenance]) =
     l match {
-      case ast.NullLiteral() => typeParameterUniverse.iterator.map(analyzer2.NullLiteral[MT](_)(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, l.position)))).toVector
-      case ast.BooleanLiteral(b) => Seq(analyzer2.LiteralValue[MT](SoQLBoolean(b))(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, l.position))))
+      case ast.NullLiteral() => typeParameterUniverse.iterator.map(analyzer2.NullLiteral[MT](_)(new analyzer2.AtomicPositionInfo(toSource(l.position)))).toVector
+      case ast.BooleanLiteral(b) => Seq(analyzer2.LiteralValue[MT](SoQLBoolean(b))(new analyzer2.AtomicPositionInfo(toSource(l.position))))
       case ast.NumberLiteral(n) =>
-        val baseNumber = analyzer2.LiteralValue[MT](SoQLNumber(n.bigDecimal))(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, l.position)))
+        val baseNumber = analyzer2.LiteralValue[MT](SoQLNumber(n.bigDecimal))(new analyzer2.AtomicPositionInfo(toSource(l.position)))
         Seq(
           baseNumber,
           analyzer2.FunctionCall[MT](SoQLTypeInfo.numberToDoubleFunc, Seq(baseNumber))(new analyzer2.FuncallPositionInfo(Source.Synthetic, NoPosition))
         )
       case ast.StringLiteral(s) =>
-        val baseString = analyzer2.LiteralValue[MT](SoQLText(s))(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, l.position)))
+        val baseString = analyzer2.LiteralValue[MT](SoQLText(s))(new analyzer2.AtomicPositionInfo(toSource(l.position)))
         val results = Seq.newBuilder[analyzer2.Expr[MT]]
         results += baseString
         for {
@@ -56,7 +56,7 @@ final class SoQLTypeInfo2[MT <: analyzer2.MetaTypes with ({ type ColumnType = So
           v <- conversion.test(s)
           expr <- conversion.exprs[MT]
         } {
-          results += expr(v, sourceName, l.position, primaryTable).asInstanceOf[analyzer2.Expr[MT]] // SAFETY: CT and CV are the same, and that's all this cares about
+          results += expr(v, toSource(l.position), primaryTable).asInstanceOf[analyzer2.Expr[MT]] // SAFETY: CT and CV are the same, and that's all this cares about
         }
         results += analyzer2.FunctionCall[MT](SoQLTypeInfo.textToBlobFunc, Seq(baseString))(new analyzer2.FuncallPositionInfo(Source.Synthetic, NoPosition))
         results += analyzer2.FunctionCall[MT](SoQLTypeInfo.textToPhotoFunc, Seq(baseString))(new analyzer2.FuncallPositionInfo(Source.Synthetic, NoPosition))
@@ -98,45 +98,45 @@ object SoQLTypeInfo extends TypeInfo[SoQLType, SoQLValue] with SoQLTypeInfoCommo
   // functions don't _all_ need to have the generic parameter attached
   // to them.
   private class ExprHelper[MT <: analyzer2.MetaTypes with ({type ColumnType = SoQLType; type ColumnValue = SoQLValue})] extends analyzer2.StatementUniverse[MT] {
-    def funcExpr(f: MonomorphicFunction) = { (t: SoQLValue, sourceName: Option[ScopedResourceName], pos: Position) =>
-      analyzer2.FunctionCall[MT](f, Seq(analyzer2.LiteralValue[MT](t)(new AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))))(new FuncallPositionInfo(Source.Synthetic, NoPosition))
+    def funcExpr(f: MonomorphicFunction) = { (t: SoQLValue, source: Source) =>
+      analyzer2.FunctionCall[MT](f, Seq(analyzer2.LiteralValue[MT](t)(new AtomicPositionInfo(source))))(new FuncallPositionInfo(Source.Synthetic, NoPosition))
     }
 
-    def textToFixedTimestampExpr(dt: DateTime, sourceName: Option[ScopedResourceName], pos: Position) =
-      analyzer2.LiteralValue[MT](SoQLFixedTimestamp(dt))(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))
-    def textToFloatingTimestampExpr(ldt: LocalDateTime, sourceName: Option[ScopedResourceName], pos: Position) =
-      analyzer2.LiteralValue[MT](SoQLFloatingTimestamp(ldt))(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))
-    def textToDateExpr(d: LocalDate, sourceName: Option[ScopedResourceName], pos: Position) =
-      analyzer2.LiteralValue[MT](SoQLDate(d))(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))
-    def textToTimeExpr(t: LocalTime, sourceName: Option[ScopedResourceName], pos: Position) =
-      analyzer2.LiteralValue[MT](SoQLTime(t))(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))
-    def textToIntervalExpr(p: Period, sourceName: Option[ScopedResourceName], pos: Position) =
-      analyzer2.LiteralValue[MT](SoQLInterval(p))(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))
-    def textToNumberExpr(s: SoQLText, sourceName: Option[ScopedResourceName], pos: Position) =
-      analyzer2.LiteralValue[MT](SoQLNumber(new java.math.BigDecimal(s.value)))(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))
-    def textToUrlExpr(url: SoQLUrl, sourceName: Option[ScopedResourceName], pos: Position) =
-      analyzer2.LiteralValue[MT](url)(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))
-    def textToPointExpr(p: Point, sourceName: Option[ScopedResourceName], pos: Position) =
-      analyzer2.LiteralValue[MT](SoQLPoint(p))(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))
-    def textToMultiPointExpr(mp: MultiPoint, sourceName: Option[ScopedResourceName], pos: Position) =
-      analyzer2.LiteralValue[MT](SoQLMultiPoint(mp))(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))
-    def textToLineExpr(l: LineString, sourceName: Option[ScopedResourceName], pos: Position) =
-      analyzer2.LiteralValue[MT](SoQLLine(l))(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))
-    def textToMultiLineExpr(ml: MultiLineString, sourceName: Option[ScopedResourceName], pos: Position) =
-      analyzer2.LiteralValue[MT](SoQLMultiLine(ml))(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))
-    def textToPolygonExpr(p: Polygon, sourceName: Option[ScopedResourceName], pos: Position) =
-      analyzer2.LiteralValue[MT](SoQLPolygon(p))(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))
-    def textToMultiPolygonExpr(mp: MultiPolygon, sourceName: Option[ScopedResourceName], pos: Position) =
-      analyzer2.LiteralValue[MT](SoQLMultiPolygon(mp))(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))
-    def textToRowIdExpr(rid: SoQLID, sourceName: Option[ScopedResourceName], pos: Position, primaryTable: Option[Provenance]) = {
+    def textToFixedTimestampExpr(dt: DateTime, source: Source) =
+      analyzer2.LiteralValue[MT](SoQLFixedTimestamp(dt))(new analyzer2.AtomicPositionInfo(source))
+    def textToFloatingTimestampExpr(ldt: LocalDateTime, source: Source) =
+      analyzer2.LiteralValue[MT](SoQLFloatingTimestamp(ldt))(new analyzer2.AtomicPositionInfo(source))
+    def textToDateExpr(d: LocalDate, source: Source) =
+      analyzer2.LiteralValue[MT](SoQLDate(d))(new analyzer2.AtomicPositionInfo(source))
+    def textToTimeExpr(t: LocalTime, source: Source) =
+      analyzer2.LiteralValue[MT](SoQLTime(t))(new analyzer2.AtomicPositionInfo(source))
+    def textToIntervalExpr(p: Period, source: Source) =
+      analyzer2.LiteralValue[MT](SoQLInterval(p))(new analyzer2.AtomicPositionInfo(source))
+    def textToNumberExpr(s: SoQLText, source: Source) =
+      analyzer2.LiteralValue[MT](SoQLNumber(new java.math.BigDecimal(s.value)))(new analyzer2.AtomicPositionInfo(source))
+    def textToUrlExpr(url: SoQLUrl, source: Source) =
+      analyzer2.LiteralValue[MT](url)(new analyzer2.AtomicPositionInfo(source))
+    def textToPointExpr(p: Point, source: Source) =
+      analyzer2.LiteralValue[MT](SoQLPoint(p))(new analyzer2.AtomicPositionInfo(source))
+    def textToMultiPointExpr(mp: MultiPoint, source: Source) =
+      analyzer2.LiteralValue[MT](SoQLMultiPoint(mp))(new analyzer2.AtomicPositionInfo(source))
+    def textToLineExpr(l: LineString, source: Source) =
+      analyzer2.LiteralValue[MT](SoQLLine(l))(new analyzer2.AtomicPositionInfo(source))
+    def textToMultiLineExpr(ml: MultiLineString, source: Source) =
+      analyzer2.LiteralValue[MT](SoQLMultiLine(ml))(new analyzer2.AtomicPositionInfo(source))
+    def textToPolygonExpr(p: Polygon, source: Source) =
+      analyzer2.LiteralValue[MT](SoQLPolygon(p))(new analyzer2.AtomicPositionInfo(source))
+    def textToMultiPolygonExpr(mp: MultiPolygon, source: Source) =
+      analyzer2.LiteralValue[MT](SoQLMultiPolygon(mp))(new analyzer2.AtomicPositionInfo(source))
+    def textToRowIdExpr(rid: SoQLID, source: Source, primaryTable: Option[Provenance]) = {
       val newRID = rid.copy()
       newRID.provenance = primaryTable
-      analyzer2.LiteralValue[MT](newRID)(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))
+      analyzer2.LiteralValue[MT](newRID)(new analyzer2.AtomicPositionInfo(source))
     }
-    def textToRowVersionExpr(rv: SoQLVersion, sourceName: Option[ScopedResourceName], pos: Position, primaryTable: Option[Provenance]) = {
+    def textToRowVersionExpr(rv: SoQLVersion, source: Source, primaryTable: Option[Provenance]) = {
       val newRV = rv.copy()
       newRV.provenance = primaryTable
-      analyzer2.LiteralValue[MT](newRV)(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))
+      analyzer2.LiteralValue[MT](newRV)(new analyzer2.AtomicPositionInfo(source))
     }
   }
 
@@ -175,10 +175,10 @@ object SoQLTypeInfo extends TypeInfo[SoQLType, SoQLValue] with SoQLTypeInfoCommo
   }
 
   private val booleanRx = "(?i)(true|false|1|0)".r
-  private def textToBooleanExpr[MT <: analyzer2.MetaTypes with ({type ColumnType = SoQLType; type ColumnValue = SoQLValue})](s: SoQLText, sourceName: Option[ScopedResourceName[MT#ResourceNameScope]], pos: Position) =
+  private def textToBooleanExpr[MT <: analyzer2.MetaTypes with ({type ColumnType = SoQLType; type ColumnValue = SoQLValue})](s: SoQLText, source: Source[MT#ResourceNameScope]) =
     s.value.toLowerCase match { // this function could be part of ExprHelper, but I want this match close to the definition of booleanRx
-      case "true"|"1" => analyzer2.LiteralValue[MT](SoQLBoolean(true))(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))
-      case "false"|"0" => analyzer2.LiteralValue[MT](SoQLBoolean(false))(new analyzer2.AtomicPositionInfo(Source.nonSynthetic(sourceName, pos)))
+      case "true"|"1" => analyzer2.LiteralValue[MT](SoQLBoolean(true))(new analyzer2.AtomicPositionInfo(source))
+      case "false"|"0" => analyzer2.LiteralValue[MT](SoQLBoolean(false))(new analyzer2.AtomicPositionInfo(source))
     }
   private def isBooleanLiteral(s: String) = try {
     s match {
@@ -214,7 +214,7 @@ object SoQLTypeInfo extends TypeInfo[SoQLType, SoQLValue] with SoQLTypeInfoCommo
     // value for the target type given the positive result from the
     // test.  It sometimes will produce a runtime cast, but more
     // frequently will produce a Literal node.
-    def exprs[MT <: analyzer2.MetaTypes with ({type ColumnType = SoQLType; type ColumnValue = SoQLValue})]: Seq[(TestResult, Option[ScopedResourceName[MT#ResourceNameScope]], Position, Option[Provenance]) => analyzer2.Expr[MT]]
+    def exprs[MT <: analyzer2.MetaTypes with ({type ColumnType = SoQLType; type ColumnValue = SoQLValue})]: Seq[(TestResult, Source[MT#ResourceNameScope], Option[Provenance]) => analyzer2.Expr[MT]]
   }
 
   private object Conversions {
@@ -222,9 +222,9 @@ object SoQLTypeInfo extends TypeInfo[SoQLType, SoQLValue] with SoQLTypeInfoCommo
     sealed abstract class Unprovenanced[T] extends Conversions {
       type TestResult = T
 
-      def es[MT <: analyzer2.MetaTypes with ({type ColumnType = SoQLType; type ColumnValue = SoQLValue})]: Seq[(T, Option[analyzer2.types.ScopedResourceName[MT]], Position) => analyzer2.Expr[MT]]
+      def es[MT <: analyzer2.MetaTypes with ({type ColumnType = SoQLType; type ColumnValue = SoQLValue})]: Seq[(T, Source[analyzer2.types.ResourceNameScope[MT]]) => analyzer2.Expr[MT]]
       final def exprs[MT <: analyzer2.MetaTypes with ({type ColumnType = SoQLType; type ColumnValue = SoQLValue})] =
-        es[MT].map { ef => (t: T, sourceName: Option[analyzer2.types.ScopedResourceName[MT]], pos: Position, prov: Option[Provenance]) => ef(t, sourceName, pos) }
+        es[MT].map { ef => (t: T, source: Source[analyzer2.types.ResourceNameScope[MT]], prov: Option[Provenance]) => ef(t, source) }
     }
 
     // A conversion type specialized to types for which the
@@ -235,9 +235,9 @@ object SoQLTypeInfo extends TypeInfo[SoQLType, SoQLValue] with SoQLTypeInfoCommo
       def tst(s: String): Boolean
       final def test(s: String) = if(tst(s)) Some(s) else None
 
-      def es[MT <: analyzer2.MetaTypes with ({type ColumnType = SoQLType; type ColumnValue = SoQLValue})]: Seq[(SoQLText, Option[analyzer2.types.ScopedResourceName[MT]], Position) => analyzer2.Expr[MT]]
+      def es[MT <: analyzer2.MetaTypes with ({type ColumnType = SoQLType; type ColumnValue = SoQLValue})]: Seq[(SoQLText, Source[analyzer2.types.ResourceNameScope[MT]]) => analyzer2.Expr[MT]]
       final def exprs[MT <: analyzer2.MetaTypes with ({type ColumnType = SoQLType; type ColumnValue = SoQLValue})] =
-        es[MT].map { ef => (s: String, sourceName: Option[analyzer2.types.ScopedResourceName[MT]], pos: Position, prov: Option[Provenance]) => ef(SoQLText(s), sourceName, pos) }
+        es[MT].map { ef => (s: String, source: Source[analyzer2.types.ResourceNameScope[MT]], prov: Option[Provenance]) => ef(SoQLText(s), source) }
     }
 
     // A conversion type specialized to provenanced types
@@ -333,7 +333,7 @@ object SoQLTypeInfo extends TypeInfo[SoQLType, SoQLValue] with SoQLTypeInfoCommo
     new Conversions.Simple {
       override def tst(s: String) = isBooleanLiteral(s)
       override val functions = Seq(textToBooleanFunc)
-      override def es[MT <: analyzer2.MetaTypes with ({type ColumnType = SoQLType; type ColumnValue = SoQLValue})] = Seq(textToBooleanExpr _)
+      override def es[MT <: analyzer2.MetaTypes with ({type ColumnType = SoQLType; type ColumnValue = SoQLValue})] = Seq(textToBooleanExpr[MT] _)
     }
   )
 


### PR DESCRIPTION
Adds the ability for a tablefinder to wrap any found table (dataset, view, udf) in an auxiliary query that can process its output before being consumed downstream.  Views and UDFs' wrapped queries have access to parameters if they want them.

A lot of this is touching places where we convert Positions to Sources, in order to allow things that were never dealing with synthetic queries before to produce synthetic Sources.  Really, AST nodes should have Sources directly, but they don't because soda2 still exists.