### PR TITLE
Ensure wrapping queries do not affect column hints

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/ColumnHint.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/ColumnHint.scala
@@ -1,0 +1,64 @@
+package com.socrata.soql.analyzer2
+
+import com.rojoma.json.v3.ast.JValue
+
+import com.socrata.soql.serialize.{Readable, ReadBuffer, Writable, WriteBuffer, Version}
+
+sealed abstract class ColumnHint {
+  def orInherited(other: => ColumnHint): ColumnHint
+}
+
+object ColumnHint {
+  case object Inherited extends ColumnHint {
+    def orInherited(other: => ColumnHint) = other
+  }
+
+  sealed trait DefiniteHint extends ColumnHint {
+    def orInherited(other: => ColumnHint) = this
+  }
+  case object Absent extends DefiniteHint
+  case class Present(value: JValue) extends DefiniteHint
+
+  def fromSourceOption(hint: Option[JValue]): ColumnHint =
+    hint match {
+      case None => ColumnHint.Inherited
+      case Some(v) => ColumnHint.Present(v)
+    }
+
+  def fromAnalyzedOption(hint: Option[JValue]): ColumnHint =
+    hint match {
+      case None => ColumnHint.Absent
+      case Some(v) => ColumnHint.Present(v)
+    }
+
+  implicit object Serialize extends Writable[ColumnHint] {
+    def writeTo(buffer: WriteBuffer, hint: ColumnHint): Unit = {
+      hint match {
+        case Inherited =>
+          buffer.write(0)
+        case Present(value) =>
+          buffer.write(1)
+          buffer.write(value)
+        case Absent =>
+          // this is last because columnhints in namedexprs used to be
+          // Option[JValue], where None meant inherit.  Now we have a
+          // new explicit Absent case.
+          buffer.write(2)
+      }
+    }
+  }
+
+  implicit object Deserialize extends Readable[ColumnHint] {
+    def readFrom(buffer: ReadBuffer): ColumnHint =
+      buffer.read[Int]() match {
+        case 0 =>
+          Inherited
+        case 1 =>
+          Present(buffer.read[JValue]())
+        case 2 =>
+          Absent
+        case other =>
+          fail(s"Invalid tag for column hint: ${other}")
+      }
+  }
+}

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Labels.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Labels.scala
@@ -41,16 +41,9 @@ object LabelProvider {
     def readFrom(buffer: ReadBuffer): LabelProvider = {
       val result = new LabelProvider
 
-      buffer.version match {
-        case Version.V6 =>
-          result.tables = buffer.read[Int]()
-          result.columns = buffer.read[Int]()
-          result.ctes = 0
-        case Version.V7 =>
-          result.tables = buffer.read[Int]()
-          result.columns = buffer.read[Int]()
-          result.ctes = buffer.read[Int]()
-      }
+      result.tables = buffer.read[Int]()
+      result.columns = buffer.read[Int]()
+      result.ctes = buffer.read[Int]()
 
       result
     }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/NamedExpr.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/NamedExpr.scala
@@ -5,7 +5,7 @@ import com.rojoma.json.v3.ast.JValue
 import com.socrata.soql.environment.ColumnName
 import com.socrata.soql.serialize.{Readable, ReadBuffer, Writable, WriteBuffer, Version}
 
-case class NamedExpr[MT <: MetaTypes](expr: Expr[MT], name: ColumnName, hint: Option[JValue], isSynthetic: Boolean) extends LabelUniverse[MT] {
+case class NamedExpr[MT <: MetaTypes](expr: Expr[MT], name: ColumnName, hint: ColumnHint, isSynthetic: Boolean) extends LabelUniverse[MT] {
   private[analyzer2] def doRewriteDatabaseNames[MT2 <: MetaTypes](state: RewriteDatabaseNamesState[MT2]) =
     this.copy(expr = expr.doRewriteDatabaseNames(state))
 
@@ -31,7 +31,7 @@ object NamedExpr {
         expr = buffer.read[Expr[MT]](),
         name = buffer.read[ColumnName](),
         isSynthetic = buffer.read[Boolean](),
-        hint = buffer.read[Option[JValue]]()
+        hint = buffer.read[ColumnHint]()
       )
     }
   }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/SoQLAnalyzer.scala
@@ -241,14 +241,14 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
         case from: FromTable =>
           selectFromFrom(
             from.columns.map { case (label, FromTable.ColumnInfo(name, typ, _hint)) =>
-              labelProvider.columnLabel() -> NamedExpr(PhysicalColumn[MT](from.label, from.tableName, label, typ)(AtomicPositionInfo.Synthetic), name, None, isSynthetic = false)
+              labelProvider.columnLabel() -> NamedExpr(PhysicalColumn[MT](from.label, from.tableName, label, typ)(AtomicPositionInfo.Synthetic), name, ColumnHint.Inherited, isSynthetic = false)
             },
             from
           )
         case from: FromCTE =>
           selectFromFrom(
             from.basedOn.schema.map { case (label, se) =>
-              labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](from.label, label, se.typ)(AtomicPositionInfo.Synthetic), se.name, None, isSynthetic = false)
+              labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](from.label, label, se.typ)(AtomicPositionInfo.Synthetic), se.name, ColumnHint.Inherited, isSynthetic = false)
             },
             from
           )
@@ -317,7 +317,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 if(desc.wrappingQuery.isEmpty && desc.hiddenColumns(name)) {
                   None
                 } else {
-                  Some(outputLabel -> NamedExpr(PhysicalColumn[MT](from.label, from.tableName, dcn, typ)(AtomicPositionInfo.Synthetic), name, hint = None, isSynthetic = false))
+                  Some(outputLabel -> NamedExpr(PhysicalColumn[MT](from.label, from.tableName, dcn, typ)(AtomicPositionInfo.Synthetic), name, hint = ColumnHint.Inherited, isSynthetic = false))
                 }
               },
               from,
@@ -349,31 +349,34 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
             if(dci.hidden) Set(dci.name)
             else None
           }.toSet
-          wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(srn), None, primaryTableName(srn), Environment.empty, Map.empty, hiddenColumns, Map.empty, true), wq.parsed, ImplicitFrom.Required(withoutWrapper, Some(srn.name), requiredSchema = Some(schemaOf(withoutWrapper)))), withoutWrapper.label, srn)
+          finalizeWrapping(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(srn), None, primaryTableName(srn), Environment.empty, Map.empty, hiddenColumns, Map.empty, true), wq.parsed, ImplicitFrom.Required(withoutWrapper, Some(srn.name), requiredSchema = Some(schemaOf(withoutWrapper)))), withoutWrapper, srn)
       }
     }
 
-    def wrappedOrdering[F <: AtomicFrom](from: F, wrappedLabel: AutoTableLabel, activeResource: ScopedResourceName): F = {
-      from match {
-        case fs: FromStatement =>
-          // we want to stop when we leave the wrapped query - either
-          // when we reach the wrapped query, or when the wrapping
-          // query reaches some other resource.
-          //
-          // This isn't _completely_ ideal - if the wrapping query is
-          // complex, it will preserve ordering within the wrapping
-          // query where such preservation isn't necessary, but most
-          // wrapping queries are expected to be simple filters, so it
-          // should work.
-          def stop(otherFrom: FromStatement): Boolean = {
-            otherFrom.label == wrappedLabel || otherFrom.resourceName != Some(activeResource)
-          }
+    def finalizeWrapping(wrappingFrom: FromStatement, wrappedFrom: AtomicFrom, activeResource: ScopedResourceName): FromStatement = {
+      // we want to stop when we leave the wrapped query - either
+      // when we reach the wrapped query, or when the wrapping
+      // query reaches some other resource.
+      //
+      // This isn't _completely_ ideal - if the wrapping query is
+      // complex, it will preserve ordering within the wrapping
+      // query where such preservation isn't necessary, but most
+      // wrapping queries are expected to be simple filters, so it
+      // should work.
 
-          fs.copy(statement = rewrite.PreserveOrdering.bounded(labelProvider, fs.statement, stop))
-            .asInstanceOf[F] // ick.  Is there a better way to do this?  (this will work only as long as there are no subclasses of FromStatement)
-        case _ =>
-          from
+      def stop(otherFrom: FromStatement): Boolean = {
+        otherFrom.label == wrappedFrom.label || otherFrom.resourceName != Some(activeResource)
       }
+
+      // Preserve the hints from the wrappedFrom.
+      val hints = wrappedFrom.schema.iterator.map { se =>
+        se.name -> ColumnHint.fromAnalyzedOption(se.hint)
+      }.toMap
+
+      wrappingFrom.copy(
+        statement = rewrite.PreserveOrdering.bounded(labelProvider, wrappingFrom.statement, stop)
+          .withHints(labelProvider, hints)
+      )
     }
 
     def analyzeForFrom(toSource: Position => Source, name: ScopedResourceName, canonicalName: Option[CanonicalName], position: Position): AtomicFrom = {
@@ -396,7 +399,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
               case None =>
                 middle
               case Some(wq) =>
-                wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, hiddenColumns, Map.empty, true), wq.parsed, ImplicitFrom.Required(middle, Some(name.name), requiredSchema = Some(schemaOf(middle)))), middle.label, name)
+                finalizeWrapping(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(name), Some(canonicalName), primaryTableName(ScopedResourceName(scope, basedOn)), Environment.empty, Map.empty, hiddenColumns, Map.empty, true), wq.parsed, ImplicitFrom.Required(middle, Some(name.name), requiredSchema = Some(schemaOf(middle)))), middle, name)
             }
           case TableDescription.TableFunction(_, _, _, _, _, _, _) =>
             parameterlessTableFunction(toSource(position), name.name)
@@ -582,7 +585,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
               if(ctx.hiddenColumns(name)) {
                 None
               } else {
-                Some(labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](fromCombined.label, label, typ)(AtomicPositionInfo.Synthetic), name, hint, isSynthetic))
+                Some(labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](fromCombined.label, label, typ)(AtomicPositionInfo.Synthetic), name, ColumnHint.fromSourceOption(hint), isSynthetic))
               }
             },
             fromCombined,
@@ -645,10 +648,10 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                   None
                 } else if(select.isAggregated) {
                   aggregateMerger(name, column).map { newExpr =>
-                    labelProvider.columnLabel() -> NamedExpr(newExpr, name, hint = None, isSynthetic = true)
+                    labelProvider.columnLabel() -> NamedExpr(newExpr, name, hint = ColumnHint.Inherited, isSynthetic = true)
                   }
                 } else {
-                  Some(labelProvider.columnLabel() -> NamedExpr(column, name, hint = None, isSynthetic = true))
+                  Some(labelProvider.columnLabel() -> NamedExpr(column, name, hint = ColumnHint.Inherited, isSynthetic = true))
                 }
               }
               select.copy(selectList = newSelectList)
@@ -797,7 +800,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
 
       val selectList = OrderedMap() ++ aliasAnalysis.expressions.keysIterator.map { cn =>
         val expr = finalState.allNamedExprs(cn)
-        labelProvider.columnLabel() -> NamedExpr(expr, cn, ctx.outputColumnHints.get(cn), isSynthetic = false)
+        labelProvider.columnLabel() -> NamedExpr(expr, cn, ColumnHint.fromSourceOption(ctx.outputColumnHints.get(cn)), isSynthetic = false)
       }
 
       val stmtPossiblyWrongOrder = addSystemColumnsIfDesired(Select(
@@ -1172,7 +1175,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
             case Some(typecheckedNamesAndExprs) =>
               val outOfLineParamsQuery = Select(
                 Distinctiveness.Indistinct(),
-                OrderedMap() ++ typecheckedNamesAndExprs.iterator.map { case (holeName, expr) => labelProvider.columnLabel() -> NamedExpr(expr, ColumnName(holeName.name), hint = None, isSynthetic = true) },
+                OrderedMap() ++ typecheckedNamesAndExprs.iterator.map { case (holeName, expr) => labelProvider.columnLabel() -> NamedExpr(expr, ColumnName(holeName.name), hint = ColumnHint.Inherited, isSynthetic = true) },
                 FromSingleRow(labelProvider.tableLabel(), None),
                 None, Nil, None, Nil, None, None, None,
                 Set.empty
@@ -1201,14 +1204,14 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 case None =>
                   unwrappedUseQuery
                 case Some(wq) =>
-                  wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, innerUdfParams, hiddenColumns, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name), requiredSchema = Some(schemaOf(unwrappedUseQuery)))), unwrappedUseQuery.label, udfScopedResourceName)
+                  finalizeWrapping(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, innerUdfParams, hiddenColumns, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name), requiredSchema = Some(schemaOf(unwrappedUseQuery)))), unwrappedUseQuery, udfScopedResourceName)
               }
 
               FromStatement(
                 Select(
                   Distinctiveness.Indistinct(),
                   OrderedMap() ++ useQuery.statement.schema.iterator.map { case (label, Statement.SchemaEntry(name, typ, hint, isSynthetic)) =>
-                    labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](useQuery.label, label, typ)(AtomicPositionInfo.Synthetic), name, None, isSynthetic = isSynthetic)
+                    labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](useQuery.label, label, typ)(AtomicPositionInfo.Synthetic), name, ColumnHint.Inherited, isSynthetic = isSynthetic)
                   },
                   Join(
                     JoinType.Inner,
@@ -1254,7 +1257,7 @@ class SoQLAnalyzer[MT <: MetaTypes] private (
                 case None =>
                   unwrappedUseQuery
                 case Some(wq) =>
-                  wrappedOrdering(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, Map.empty, hiddenColumns, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name), requiredSchema = Some(schemaOf(unwrappedUseQuery)))), unwrappedUseQuery.label, udfScopedResourceName)
+                  finalizeWrapping(analyzeStatement(Ctx(wq.scope, _ => Source.Synthetic, Some(udfScopedResourceName), None, udfCtx.primaryTableName, Environment.empty, Map.empty, hiddenColumns, Map.empty, callerCtx.attemptToPreserveSystemColumns), wq.parsed, ImplicitFrom.Required(unwrappedUseQuery, Some(udfScopedResourceName.name), requiredSchema = Some(schemaOf(unwrappedUseQuery)))), unwrappedUseQuery, udfScopedResourceName)
               }
           }
         case _ =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Statement.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Statement.scala
@@ -23,6 +23,7 @@ sealed abstract class Statement[MT <: MetaTypes] extends LabelUniverse[MT] {
   val schema: OrderedMap[AutoColumnLabel, Statement.SchemaEntry[MT]]
 
   private[analyzer2] def ensureSchema(labelProvider: LabelProvider, schema: Seq[(ColumnName, CT)]): Option[Statement[MT]]
+  private[analyzer2] def withHints(labelProvider: LabelProvider, hints: Map[ColumnName, ColumnHint]): Statement[MT]
 
   // See the comment in From for an explanation of this.  It's just
   // labels here because, as a Statement, we don't have enough

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromStatement.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromStatement.scala
@@ -110,23 +110,12 @@ trait OFromStatementImpl { this: FromStatement.type =>
   implicit def deserialize[MT <: MetaTypes](implicit rnsReadable: Readable[MT#ResourceNameScope], ctReadable: Readable[MT#ColumnType], exprReadable: Readable[Expr[MT]], dtnReadable: Readable[MT#DatabaseTableNameImpl], dcnReadable: Readable[MT#DatabaseColumnNameImpl]): Readable[FromStatement[MT]] =
     new Readable[FromStatement[MT]] with MetaTypeHelper[MT] {
       def readFrom(buffer: ReadBuffer): FromStatement[MT] =
-        buffer.version match {
-          case Version.V6 =>
-            FromStatement(
-              statement = buffer.read[Statement[MT]](),
-              label = buffer.read[AutoTableLabel](),
-              resourceName = buffer.read[Option[ScopedResourceName[RNS]]](),
-              canonicalName = None,
-              alias = buffer.read[Option[ResourceName]]()
-            )
-          case Version.V7 =>
-            FromStatement(
-              statement = buffer.read[Statement[MT]](),
-              label = buffer.read[AutoTableLabel](),
-              resourceName = buffer.read[Option[ScopedResourceName[RNS]]](),
-              canonicalName = buffer.read[Option[CanonicalName]](),
-              alias = buffer.read[Option[ResourceName]]()
-            )
-        }
+        FromStatement(
+          statement = buffer.read[Statement[MT]](),
+          label = buffer.read[AutoTableLabel](),
+          resourceName = buffer.read[Option[ScopedResourceName[RNS]]](),
+          canonicalName = buffer.read[Option[CanonicalName]](),
+          alias = buffer.read[Option[ResourceName]]()
+        )
     }
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/from/FromTable.scala
@@ -158,28 +158,15 @@ trait OFromTableImpl { this: FromTable.type =>
 
   implicit def deserialize[MT <: MetaTypes](implicit rnsReadable: Readable[MT#ResourceNameScope], ctReadable: Readable[MT#ColumnType], exprReadable: Readable[Expr[MT]], dtnReadable: Readable[MT#DatabaseTableNameImpl], dcnReadable: Readable[MT#DatabaseColumnNameImpl]): Readable[FromTable[MT]] = new Readable[FromTable[MT]] with LabelUniverse[MT] {
     def readFrom(buffer: ReadBuffer): FromTable[MT] = {
-      buffer.version match {
-        case Version.V6 =>
-          FromTable(
-            tableName = buffer.read[DatabaseTableName](),
-            definiteResourceName = buffer.read[ScopedResourceName](),
-            definiteCanonicalName = CanonicalName("invalid - this is only (at time of migration) used by MaterializeNamedQueries, which will not happen in a V6 serialization"),
-            alias = buffer.read[Option[ResourceName]](),
-            label = buffer.read[AutoTableLabel](),
-            columns = buffer.read[OrderedMap[DatabaseColumnName, ColumnInfo[MT]]](),
-            primaryKeys = buffer.read[Seq[Seq[DatabaseColumnName]]]()
-          )
-        case Version.V7 =>
-            FromTable(
-              tableName = buffer.read[DatabaseTableName](),
-              definiteResourceName = buffer.read[ScopedResourceName](),
-              definiteCanonicalName = buffer.read[CanonicalName](),
-              alias = buffer.read[Option[ResourceName]](),
-              label = buffer.read[AutoTableLabel](),
-              columns = buffer.read[OrderedMap[DatabaseColumnName, ColumnInfo[MT]]](),
-              primaryKeys = buffer.read[Seq[Seq[DatabaseColumnName]]]()
-            )
-      }
+      FromTable(
+        tableName = buffer.read[DatabaseTableName](),
+        definiteResourceName = buffer.read[ScopedResourceName](),
+        definiteCanonicalName = buffer.read[CanonicalName](),
+        alias = buffer.read[Option[ResourceName]](),
+        label = buffer.read[AutoTableLabel](),
+        columns = buffer.read[OrderedMap[DatabaseColumnName, ColumnInfo[MT]]](),
+        primaryKeys = buffer.read[Seq[Seq[DatabaseColumnName]]]()
+      )
     }
   }
 }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/AddLimitOffset.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/AddLimitOffset.scala
@@ -12,7 +12,7 @@ class AddLimitOffset[MT <: MetaTypes] private (labelProvider: LabelProvider) ext
         Select(
           Distinctiveness.Indistinct(),
           OrderedMap() ++ stmt.schema.iterator.map { case (colLabel, Statement.SchemaEntry(name, typ, hint, isSynthetic)) =>
-            labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](newTableLabel, colLabel, typ)(AtomicPositionInfo.Synthetic), name, hint = None, isSynthetic = isSynthetic)
+            labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](newTableLabel, colLabel, typ)(AtomicPositionInfo.Synthetic), name, hint = ColumnHint.Inherited, isSynthetic = isSynthetic)
           },
           FromStatement(stmt, newTableLabel, None, None, None),
           None,

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/ImposeOrdering.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/ImposeOrdering.scala
@@ -37,7 +37,7 @@ class ImposeOrdering[MT <: MetaTypes] private (labelProvider: LabelProvider, isO
         Select(
           Distinctiveness.Indistinct(),
           OrderedMap() ++ ct.schema.iterator.map { case (columnLabel, Statement.SchemaEntry(name, typ, hint, isSynthetic)) =>
-            labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](newTableLabel, columnLabel, typ)(AtomicPositionInfo.Synthetic), name, hint = None, isSynthetic = isSynthetic)
+            labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](newTableLabel, columnLabel, typ)(AtomicPositionInfo.Synthetic), name, hint = ColumnHint.Inherited, isSynthetic = isSynthetic)
           },
           FromStatement(ct, newTableLabel, None, None, None),
           None,

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/InlineTrivialParameters.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/InlineTrivialParameters.scala
@@ -200,7 +200,7 @@ class InlineTrivialParameters[MT <: MetaTypes] private (isLiteralTrue: Expr[MT] 
                       Select(
                         Distinctiveness.Indistinct(),
                         OrderedMap() ++ newValuesLabels.lazyZip(newValuesExprs.toSeq).map { case (label, (expr, name)) =>
-                          (label, NamedExpr(expr, name, hint = None, isSynthetic = true))
+                          (label, NamedExpr(expr, name, hint = ColumnHint.Inherited, isSynthetic = true))
                         },
                         from,
                         None, Nil, None, Nil, None, None, None, Set.empty

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/LimitIfUnlimited.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/LimitIfUnlimited.scala
@@ -39,7 +39,7 @@ class LimitIfUnlimited[MT <: MetaTypes] private (labelProvider: LabelProvider) e
           Select(
             Distinctiveness.Indistinct(),
             OrderedMap() ++ stmt.schema.iterator.map { case (colLabel, Statement.SchemaEntry(name, typ, hint, isSynthetic)) =>
-              labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](newTableLabel, colLabel, typ)(AtomicPositionInfo.Synthetic), name, hint = None, isSynthetic = isSynthetic)
+              labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](newTableLabel, colLabel, typ)(AtomicPositionInfo.Synthetic), name, hint = ColumnHint.Inherited, isSynthetic = isSynthetic)
             },
             FromStatement(stmt, newTableLabel, None, None, None),
             None,

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/Merger.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/Merger.scala
@@ -241,29 +241,8 @@ class Merger[MT <: MetaTypes](and: MonomorphicFunction[MT#ColumnType]) extends S
       // statement's output column labels.
       select.copy(
         selectList = OrderedMap() ++ select.selectList.iterator.map { case (label, namedExpr) =>
-          val originalUninheritedHint = b.selectList(label).hint
-
-          val originalInheritedHint =
-            b.selectList(label).expr match {
-              // see the comment in Select#schema for why the .get here
-              case c: Column => b.from.schemaByTableColumn.get((c.table, c.column)).flatMap(_.hint)
-              case _ => None
-            }
-
-          val newUninheritedHint = namedExpr.hint
-          val newInheritedHint =
-            namedExpr.expr match {
-              // see the comment in Select#schema for why the .get here
-              case c: Column => select.from.schemaByTableColumn.get((c.table, c.column)).flatMap(_.hint)
-              case _ => None
-            }
-
-          val newHint = originalUninheritedHint orElse newUninheritedHint orElse {
-            if(originalInheritedHint != newInheritedHint) originalInheritedHint
-            else None
-          }
-
-          label -> namedExpr.copy(hint = newHint)
+          val hint = ColumnHint.fromAnalyzedOption(b.schema(label).hint)
+          label -> namedExpr.copy(hint = hint)
         }
       )
     }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveOrdering.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveOrdering.scala
@@ -95,7 +95,7 @@ class PreserveOrdering[MT <: MetaTypes] private (provider: LabelProvider, stop: 
             selectList.find { case (label, NamedExpr(e, _, _, _)) => expr == e } match {
               case None =>
                 val columnLabel = provider.columnLabel()
-                (Some(columnLabel -> NamedExpr(expr, freshName("order"), hint = None, isSynthetic = true)), (columnLabel, expr.typ, asc, nullLast))
+                (Some(columnLabel -> NamedExpr(expr, freshName("order"), hint = ColumnHint.Absent, isSynthetic = true)), (columnLabel, expr.typ, asc, nullLast))
               case Some((columnLabel, NamedExpr(existingExpr, _, _, _))) =>
                 (None, (columnLabel, existingExpr.typ, asc, nullLast))
             }

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveUnique.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/PreserveUnique.scala
@@ -68,7 +68,7 @@ class PreserveUnique[MT <: MetaTypes] private (provider: LabelProvider) extends 
               }
             }
             val newColumns = additional.result().map { col =>
-              provider.columnLabel() -> NamedExpr(col, freshName("unique"), hint = None, isSynthetic = true)
+              provider.columnLabel() -> NamedExpr(col, freshName("unique"), hint = ColumnHint.Absent, isSynthetic = true)
             }
             select.copy(selectList = selectList ++ newColumns, from = newFrom)
           } else {

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/RemoveOutputColumns.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/RemoveOutputColumns.scala
@@ -16,7 +16,7 @@ private[rewrite] class RemoveOutputColumns[MT <: MetaTypes] (labelProvider: Labe
               if(toRemove(v)) {
                 None
               } else {
-                Some(labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](newFrom.label, k, v.typ)(AtomicPositionInfo.Synthetic), v.name, v.hint, isSynthetic = v.isSynthetic))
+                Some(labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](newFrom.label, k, v.typ)(AtomicPositionInfo.Synthetic), v.name, ColumnHint.fromAnalyzedOption(v.hint), isSynthetic = v.isSynthetic))
               }
             },
             newFrom,
@@ -44,7 +44,7 @@ private[rewrite] class RemoveOutputColumns[MT <: MetaTypes] (labelProvider: Labe
               if(toRemove(v)) {
                 None
               } else {
-                Some(labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](newFrom.label, k, v.typ)(AtomicPositionInfo.Synthetic), v.name, v.hint, isSynthetic = v.isSynthetic))
+                Some(labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](newFrom.label, k, v.typ)(AtomicPositionInfo.Synthetic), v.name, ColumnHint.fromAnalyzedOption(v.hint), isSynthetic = v.isSynthetic))
               }
             },
             newFrom,

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/RemoveTrivialSelects.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rewrite/RemoveTrivialSelects.scala
@@ -67,7 +67,7 @@ class RemoveTrivialSelects[MT <: MetaTypes] private () extends StatementUniverse
                     NamedExpr(
                       parentSE.expr,
                       se.name,
-                      se.hint orElse parentSE.hint,
+                      se.hint orInherited parentSE.hint,
                       se.isSynthetic
                     )
                   case _ : Column =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rollup/RollupRewriter.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/rollup/RollupRewriter.scala
@@ -54,7 +54,7 @@ class RollupRewriter[MT <: MetaTypes, RollupId](
                   sourceLabel -> NamedExpr(
                     PhysicalColumn[MT](from.label, from.tableName, rollupCol, sourceEnt.typ)(AtomicPositionInfo.Synthetic),
                     sourceEnt.name,
-                    sourceEnt.hint,
+                    ColumnHint.fromAnalyzedOption(sourceEnt.hint),
                     sourceEnt.isSynthetic
                   )
               },
@@ -221,7 +221,7 @@ class RollupRewriter[MT <: MetaTypes, RollupId](
     }.toMap
 
     val computedSelectList = OrderedMap() ++ orderedDemandedColumns.iterator.zipWithIndex.map { case ((col, typ), idx) =>
-      columnMap(col).column -> NamedExpr(col.at(typ, AtomicPositionInfo.Synthetic), ColumnName(s"column_$idx"), None, isSynthetic = true)
+      columnMap(col).column -> NamedExpr(col.at(typ, AtomicPositionInfo.Synthetic), ColumnName(s"column_$idx"), ColumnHint.Absent, isSynthetic = true)
     }
 
     val target =

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CTE.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CTE.scala
@@ -141,6 +141,9 @@ trait CTEImpl[MT <: MetaTypes] { this: CTE[MT] =>
   private[analyzer2] override def ensureSchema(labelProvider: LabelProvider, schema: Seq[(ColumnName, CT)]): Option[Self[MT]] = {
     useQuery.ensureSchema(labelProvider, schema).map(CTE(definitions, _))
   }
+
+  private[analyzer2] override def withHints(labelProvider: LabelProvider, hints: Map[ColumnName, ColumnHint]) =
+    copy(useQuery = useQuery.withHints(labelProvider, hints))
 }
 
 trait OCTEImpl { this: CTE.type =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CombinedTables.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/CombinedTables.scala
@@ -162,6 +162,9 @@ trait CombinedTablesImpl[MT <: MetaTypes] { this: CombinedTables[MT] =>
       CombinedTables(op, newLeft, newRight)
     }
   }
+
+  private[analyzer2] override def withHints(labelProvider: LabelProvider, hints: Map[ColumnName, ColumnHint]) =
+    copy(left = left.withHints(labelProvider, hints))
 }
 
 trait OCombinedTablesImpl { this: CombinedTables.type =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Select.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Select.scala
@@ -95,17 +95,23 @@ trait SelectImpl[MT <: MetaTypes] { this: Select[MT] =>
 
   lazy val schema = locally {
     selectList.withValuesMapped { case NamedExpr(expr, name, hint, isSynthetic) =>
-      def inheritedHint: Option[JValue] =
-        expr match {
-          // Why the .get here?  Because just because we have a column
-          // ref, it does not _necessarily_ come from a table in our
-          // FROM - it could come from a sibling table via a lateral
-          // join.  In that case we just won't inherit.
-          case c: Column[MT] => from.schemaByTableColumn.get((c.table, c.column)).flatMap(_.hint)
-          case _ => None
-        }
+      val materializedHint = hint match {
+        case ColumnHint.Absent =>
+          None
+        case ColumnHint.Present(v) =>
+          Some(v)
+        case ColumnHint.Inherited =>
+          expr match {
+            // Why the .get here?  Because just because we have a
+            // column ref, it does not _necessarily_ come from a table
+            // in our FROM - it could come from a sibling table via a
+            // lateral join.  In that case we just won't inherit.
+            case c: Column[MT] => from.schemaByTableColumn.get((c.table, c.column)).flatMap(_.hint)
+            case _ => None
+          }
+      }
 
-      Statement.SchemaEntry[MT](name, expr.typ, hint.orElse(inheritedHint), isSynthetic = isSynthetic)
+      Statement.SchemaEntry[MT](name, expr.typ, materializedHint, isSynthetic = isSynthetic)
     }
   }
 
@@ -449,6 +455,18 @@ trait SelectImpl[MT <: MetaTypes] { this: Select[MT] =>
       )
     }
   }
+
+  private[analyzer2] override def withHints(labelProvider: LabelProvider, hints: Map[ColumnName, ColumnHint]) =
+    copy(
+      selectList = selectList.withValuesMapped { ne =>
+        hints.get(ne.name) match {
+          case None =>
+            ne
+          case Some(hint) =>
+            ne.copy(hint = hint)
+        }
+      }
+    )
 }
 
 trait OSelectImpl { this: Select.type =>

--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Values.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/statement/Values.scala
@@ -160,13 +160,28 @@ trait ValuesImpl[MT <: MetaTypes] { this: Values[MT] =>
         Distinctiveness.Indistinct(),
         OrderedMap() ++ ordering.iterator.map { sourceLabel =>
           val sourceEnt = schema(sourceLabel)
-          labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](myLabel, sourceLabel, sourceEnt.typ)(new AtomicPositionInfo(Source.Synthetic)), sourceEnt.name, sourceEnt.hint, sourceEnt.isSynthetic)
+          labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](myLabel, sourceLabel, sourceEnt.typ)(new AtomicPositionInfo(Source.Synthetic)), sourceEnt.name, ColumnHint.Inherited, sourceEnt.isSynthetic)
         },
         FromStatement(this, myLabel, None, None, None),
         None, Nil, None, Nil, None, None, None, Set.empty
       )
     }
   }
+
+  private[analyzer2] override def withHints(labelProvider: LabelProvider, hints: Map[ColumnName, ColumnHint]) =
+    if(hints.nonEmpty) {
+      val myLabel = labelProvider.tableLabel()
+      Select(
+        Distinctiveness.Indistinct(),
+        OrderedMap() ++ schema.iterator.map { case (sourceLabel, sourceEnt) =>
+          labelProvider.columnLabel() -> NamedExpr(VirtualColumn[MT](myLabel, sourceLabel, sourceEnt.typ)(new AtomicPositionInfo(Source.Synthetic)), sourceEnt.name, hints.getOrElse(sourceEnt.name, ColumnHint.Inherited), sourceEnt.isSynthetic)
+        },
+        FromStatement(this, myLabel, None, None, None),
+        None, Nil, None, Nil, None, None, None, Set.empty
+      )
+    } else {
+      this
+    }
 }
 
 trait OValuesImpl { this: Values.type =>

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
@@ -67,7 +67,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
             )
           )(FuncallPositionInfo.Synthetic),
           cn("_5_7"),
-          None,
+          ColumnHint.Inherited,
           false
         ),
         c(2) -> NamedExpr(
@@ -79,7 +79,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
             )
           )(FuncallPositionInfo.Synthetic),
           cn("hello_world"),
-          None,
+          ColumnHint.Inherited,
           false
         ),
         c(3) -> NamedExpr(
@@ -91,7 +91,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
             )
           )(FuncallPositionInfo.Synthetic),
           cn("_1_2"),
-          None,
+          ColumnHint.Inherited,
           false
         )
       )
@@ -127,7 +127,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
         c(1) -> NamedExpr(
           PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.Synthetic),
           cn("t"),
-          None,
+          ColumnHint.Inherited,
           false
         ),
         c(2) -> NamedExpr(
@@ -139,7 +139,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
             )
           )(FuncallPositionInfo.Synthetic),
           cn("num_num"),
-          None,
+          ColumnHint.Inherited,
           false
         )
       )
@@ -189,7 +189,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
         c(1) -> NamedExpr(
           LiteralValue[TestMT](TestText("Hello world"))(AtomicPositionInfo.Synthetic),
           cn("param_gnu"),
-          None,
+          ColumnHint.Inherited,
           false
         )
       )
@@ -218,7 +218,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
         c(1) -> NamedExpr(
           LiteralValue[TestMT](TestText("Hello world"))(AtomicPositionInfo.Synthetic),
           cn("param_gnu"),
-          None,
+          ColumnHint.Inherited,
           false
         )
       )
@@ -246,7 +246,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
         c(1) -> NamedExpr(
           LiteralValue[TestMT](TestText("Hello world"))(AtomicPositionInfo.Synthetic),
           cn("param_gnu"),
-          None,
+          ColumnHint.Inherited,
           false
         )
       )
@@ -269,8 +269,8 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
       Select[TestMT](
         Distinctiveness.Indistinct(),
         OrderedMap(
-          c(1) -> NamedExpr(PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.Synthetic), cn("text"), None, false),
-          c(2) -> NamedExpr(PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.Synthetic), cn("num"), None, false)
+          c(1) -> NamedExpr(PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.Synthetic), cn("text"), ColumnHint.Inherited, false),
+          c(2) -> NamedExpr(PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.Synthetic), cn("num"), ColumnHint.Inherited, false)
         ),
         FromTable[TestMT](
           dtn("aaaa-aaaa"),
@@ -310,15 +310,15 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
       Select[TestMT](
         Distinctiveness.Indistinct(),
         OrderedMap(
-          c(3) -> NamedExpr(VirtualColumn[TestMT](t(2),c(1),TestText)(AtomicPositionInfo.Synthetic),cn("text"),None,false),
-          c(4) -> NamedExpr(VirtualColumn[TestMT](t(2),c(2),TestNumber)(AtomicPositionInfo.Synthetic),cn("num"),None,false)
+          c(3) -> NamedExpr(VirtualColumn[TestMT](t(2),c(1),TestText)(AtomicPositionInfo.Synthetic),cn("text"),ColumnHint.Inherited,false),
+          c(4) -> NamedExpr(VirtualColumn[TestMT](t(2),c(2),TestNumber)(AtomicPositionInfo.Synthetic),cn("num"),ColumnHint.Inherited,false)
         ),
         FromStatement[TestMT](
           Select[TestMT](
             Distinctiveness.Indistinct(),
             OrderedMap(
-              c(1) -> NamedExpr(PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.Synthetic), cn("text"),None,false),
-              c(2) -> NamedExpr(PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.Synthetic), cn("num"),None,false)
+              c(1) -> NamedExpr(PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.Synthetic), cn("text"),ColumnHint.Inherited,false),
+              c(2) -> NamedExpr(PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.Synthetic), cn("num"),ColumnHint.Inherited,false)
             ),
             FromTable[TestMT](
               dtn("aaaa-aaaa"),
@@ -402,13 +402,13 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
         c(4) -> NamedExpr(
           PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.Synthetic),
           cn("text"),
-          None,
+          ColumnHint.Inherited,
           false
         ),
         c(5) -> NamedExpr(
           PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.Synthetic),
           cn("num"),
-          None,
+          ColumnHint.Inherited,
           false
         )
       )
@@ -430,7 +430,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
           Select[TestMT](
             Distinctiveness.Indistinct(),
             OrderedMap(
-              c(3) -> NamedExpr(VirtualColumn[TestMT](t(5),c(2),TestNumber)(AtomicPositionInfo.Synthetic), cn("_1"),None,false)
+              c(3) -> NamedExpr(VirtualColumn[TestMT](t(5),c(2),TestNumber)(AtomicPositionInfo.Synthetic), cn("_1"),ColumnHint.Inherited,false)
             ),
             Join[TestMT](
               JoinType.Inner,
@@ -438,7 +438,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
               FromStatement[TestMT](
                 Select[TestMT](
                   Distinctiveness.Indistinct(),
-                  OrderedMap(c(1) -> NamedExpr(LiteralValue[TestMT](TestText("bob"))(AtomicPositionInfo.Synthetic), cn("user"), None, true)),
+                  OrderedMap(c(1) -> NamedExpr(LiteralValue[TestMT](TestText("bob"))(AtomicPositionInfo.Synthetic), cn("user"), ColumnHint.Inherited, true)),
                   FromSingleRow(t(2), None),
                   None, Nil, None, Nil, None, None, None, Set.empty
                 ),
@@ -448,7 +448,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
                 Select[TestMT](
                   Distinctiveness.Indistinct(),
                   OrderedMap(
-                    c(2) -> NamedExpr(LiteralValue[TestMT](TestNumber(1))(AtomicPositionInfo.Synthetic),cn("_1"),None,false)
+                    c(2) -> NamedExpr(LiteralValue[TestMT](TestNumber(1))(AtomicPositionInfo.Synthetic),cn("_1"),ColumnHint.Inherited,false)
                   ),
                   FromTable[TestMT](
                     dtn("bbbb-bbbb"), ScopedResourceName(0, rn("bbbb-bbbb")), CanonicalName("b"), Some(rn("bbbb-bbbb")),
@@ -509,13 +509,13 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
         c(4) -> NamedExpr(
           PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.Synthetic),
           cn("text"),
-          None,
+          ColumnHint.Inherited,
           false
         ),
         c(5) -> NamedExpr(
           PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.Synthetic),
           cn("num"),
-          None,
+          ColumnHint.Inherited,
           false
         )
       )
@@ -537,7 +537,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
           Select[TestMT](
             Distinctiveness.Indistinct(),
             OrderedMap(
-              c(3) -> NamedExpr(VirtualColumn[TestMT](t(5),c(2),TestNumber)(AtomicPositionInfo.Synthetic), cn("_1"),None,false)
+              c(3) -> NamedExpr(VirtualColumn[TestMT](t(5),c(2),TestNumber)(AtomicPositionInfo.Synthetic), cn("_1"),ColumnHint.Inherited,false)
             ),
             Join[TestMT](
               JoinType.Inner,
@@ -545,7 +545,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
               FromStatement[TestMT](
                 Select[TestMT](
                   Distinctiveness.Indistinct(),
-                  OrderedMap(c(1) -> NamedExpr(PhysicalColumn[TestMT](t(1),dtn("aaaa-aaaa"),dcn("text"),TestText)(AtomicPositionInfo.Synthetic), cn("user"), None, true)),
+                  OrderedMap(c(1) -> NamedExpr(PhysicalColumn[TestMT](t(1),dtn("aaaa-aaaa"),dcn("text"),TestText)(AtomicPositionInfo.Synthetic), cn("user"), ColumnHint.Inherited, true)),
                   FromSingleRow(t(2), None),
                   None, Nil, None, Nil, None, None, None, Set.empty
                 ),
@@ -555,7 +555,7 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
                 Select[TestMT](
                   Distinctiveness.Indistinct(),
                   OrderedMap(
-                    c(2) -> NamedExpr(LiteralValue[TestMT](TestNumber(1))(AtomicPositionInfo.Synthetic),cn("_1"),None,false)
+                    c(2) -> NamedExpr(LiteralValue[TestMT](TestNumber(1))(AtomicPositionInfo.Synthetic),cn("_1"),ColumnHint.Inherited,false)
                   ),
                   FromTable[TestMT](
                     dtn("bbbb-bbbb"), ScopedResourceName(0, rn("bbbb-bbbb")), CanonicalName("b"), Some(rn("bbbb-bbbb")),
@@ -615,13 +615,13 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
         c(13) -> NamedExpr(
           PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.Synthetic),
           cn("text"),
-          None,
+          ColumnHint.Inherited,
           false
         ),
         c(14) -> NamedExpr(
           PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), dcn("num"), TestNumber)(AtomicPositionInfo.Synthetic),
           cn("num"),
-          None,
+          ColumnHint.Inherited,
           false
         )
       )
@@ -643,10 +643,10 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
           Select[TestMT](
             Distinctiveness.Indistinct(),
             OrderedMap(
-              c(9) -> NamedExpr(VirtualColumn[TestMT](t(5), c(5), TestText)(AtomicPositionInfo.Synthetic), cn("a"), None, false),
-              c(10) -> NamedExpr(VirtualColumn[TestMT](t(5), c(6), TestBoolean)(AtomicPositionInfo.Synthetic), cn("b"), None, false),
-              c(11) -> NamedExpr(VirtualColumn[TestMT](t(5), c(7), TestNumber)(AtomicPositionInfo.Synthetic), cn("c"), None, false),
-              c(12) -> NamedExpr(VirtualColumn[TestMT](t(5), c(8), TestText)(AtomicPositionInfo.Synthetic), cn("d"), None, false)
+              c(9) -> NamedExpr(VirtualColumn[TestMT](t(5), c(5), TestText)(AtomicPositionInfo.Synthetic), cn("a"), ColumnHint.Inherited, false),
+              c(10) -> NamedExpr(VirtualColumn[TestMT](t(5), c(6), TestBoolean)(AtomicPositionInfo.Synthetic), cn("b"), ColumnHint.Inherited, false),
+              c(11) -> NamedExpr(VirtualColumn[TestMT](t(5), c(7), TestNumber)(AtomicPositionInfo.Synthetic), cn("c"), ColumnHint.Inherited, false),
+              c(12) -> NamedExpr(VirtualColumn[TestMT](t(5), c(8), TestText)(AtomicPositionInfo.Synthetic), cn("d"), ColumnHint.Inherited, false)
             ),
             Join[TestMT](
               JoinType.Inner,
@@ -661,13 +661,13 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
                         Seq(LiteralValue[TestMT](TestText("hello"))(AtomicPositionInfo.Synthetic))
                       )(FuncallPositionInfo.Synthetic),
                       cn("d"),
-                      None,
+                      ColumnHint.Inherited,
                       true
                     ),
                     c(2) -> NamedExpr(
                       LiteralValue[TestMT](TestNumber(5))(AtomicPositionInfo.Synthetic),
                       cn("c"),
-                      None,
+                      ColumnHint.Inherited,
                       true
                     ),
                     c(3) -> NamedExpr(
@@ -676,13 +676,13 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
                         Seq(LiteralValue[TestMT](TestBoolean(true))(AtomicPositionInfo.Synthetic))
                       )(FuncallPositionInfo.Synthetic),
                       cn("b"),
-                      None,
+                      ColumnHint.Inherited,
                       true
                     ),
                     c(4) -> NamedExpr(
                       PhysicalColumn[TestMT](t(1), dtn("aaaa-aaaa"), dcn("text"), TestText)(AtomicPositionInfo.Synthetic),
                       cn("a"),
-                      None,
+                      ColumnHint.Inherited,
                       true
                     )
                   ),
@@ -695,10 +695,10 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
                 Select[TestMT](
                   Distinctiveness.Indistinct(),
                   OrderedMap(
-                    c(5) -> NamedExpr(VirtualColumn[TestMT](t(3),c(4),TestText)(AtomicPositionInfo.Synthetic), cn("a"), None, false),
-                    c(6) -> NamedExpr(VirtualColumn[TestMT](t(3),c(3),TestBoolean)(AtomicPositionInfo.Synthetic), cn("b"), None, false),
-                    c(7) -> NamedExpr(VirtualColumn[TestMT](t(3),c(2),TestNumber)(AtomicPositionInfo.Synthetic), cn("c"), None, false),
-                    c(8) -> NamedExpr(VirtualColumn[TestMT](t(3),c(1),TestText)(AtomicPositionInfo.Synthetic), cn("d"), None, false)
+                    c(5) -> NamedExpr(VirtualColumn[TestMT](t(3),c(4),TestText)(AtomicPositionInfo.Synthetic), cn("a"), ColumnHint.Inherited, false),
+                    c(6) -> NamedExpr(VirtualColumn[TestMT](t(3),c(3),TestBoolean)(AtomicPositionInfo.Synthetic), cn("b"), ColumnHint.Inherited, false),
+                    c(7) -> NamedExpr(VirtualColumn[TestMT](t(3),c(2),TestNumber)(AtomicPositionInfo.Synthetic), cn("c"), ColumnHint.Inherited, false),
+                    c(8) -> NamedExpr(VirtualColumn[TestMT](t(3),c(1),TestText)(AtomicPositionInfo.Synthetic), cn("d"), ColumnHint.Inherited, false)
                   ),
                   FromSingleRow(t(4), Some(rn("single_row"))),
                   None,Nil,None,Nil,None,None,None,Set()
@@ -1227,6 +1227,33 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     val Right(analysis) = analyzer(ft, UserParameters.empty)
 
     analysis.statement.schema.values.map(_.hint).toSeq must be (Seq(Some(j"false"), None, None, None))
+  }
+
+  test("hints are attached to wrapping queries' columns even if they aren't simple column references") {
+    val tf = tableFinder(
+      (0, "ds") -> D("text" -> TestText, "num" -> TestNumber).withOutputColumnHints("num" -> j"true")
+        .withWrappingQuery(0, "select null::text as text, null::number as num")
+    )
+
+    val Right(ft) = tf.findTables(0, rn("ds"))
+    val Right(analysis) = analyzer(ft, UserParameters.empty)
+
+    analysis.statement.schema.values.map(_.hint).toSeq must be (Seq(None, Some(j"true")))
+  }
+
+  test("a column with no hint retains no hint when wrapped, even if the wrapping query on its own would provide one") {
+    val tf = tableFinder(
+      (0, "ds1") -> D("text" -> TestText, "num" -> TestNumber)
+        .withWrappingQuery(0, "select @ds2.text, @ds2.num join @ds2 on true"),
+      (0, "ds2") -> D("text" -> TestText, "num" -> TestNumber)
+        .withOutputColumnHints("text" -> j"1", "num" -> j"2"),
+      (0, "ds3") -> D("text" -> TestText, "num" -> TestNumber)
+    )
+
+    val Right(ft) = tf.findTables(0, rn("ds1"))
+    val Right(analysis) = analyzer(ft, UserParameters.empty)
+
+    analysis.statement.schema.values.map(_.hint).toSeq must be (Seq(None, None))
   }
 
   test("errors in anonymous soql have an anonymous source") {

--- a/soql-serialize/src/main/scala/com/socrata/soql/serialize/Buffer.scala
+++ b/soql-serialize/src/main/scala/com/socrata/soql/serialize/Buffer.scala
@@ -11,7 +11,6 @@ object Version {
   // Things that care about version-evolvability will match on these;
   // delete them when they're obsolete in order to find places that
   // are still using them!
-  case object V6 extends Version
   case object V7 extends Version
 
   val current = V7
@@ -29,7 +28,6 @@ class WriteBuffer private (val version: Version) {
 
   private def writeTo(stream: CodedOutputStream): Unit = {
     val tag = version match {
-      case Version.V6 => 6
       case Version.V7 => 7
     }
     stream.writeUInt32NoTag(tag)
@@ -63,9 +61,8 @@ class ReadBuffer private (stream: CodedInputStream) {
 
   val version =
     stream.readUInt32() match {
-      case other@(0|1|2|3|4|5) =>
+      case other if other >= 0 && other <= 6 =>
         throw new IOException(s"Obsolete version: $other")
-      case 6 => Version.V6
       case 7 => Version.V7
       case other =>
         throw new IOException(s"Invalid version: $other")


### PR DESCRIPTION
This is a fairly major refector, because column hints previously conflated "no hint" and "inherit hint".

Also gets rid of serialization version 6; I thought this was going to need a new serialization rev, but it turned out not to.