### PR TITLE
Add a "type assertion" pseudo-operator

### DIFF
--- a/soql-standalone-parser/src/main/jflex/SoQLLexer.flex
+++ b/soql-standalone-parser/src/main/jflex/SoQLLexer.flex
@@ -118,6 +118,7 @@ TableIdentifier = "@" ("-" | [:jletterdigit:])+
   // Misc expression-y stuf
   "||"  { return token(new PIPEPIPE()); }
   "::"  { return token(new COLONCOLON()); }
+  ":!"  { return token(new COLONBANG()); }
   "("   { return token(new LPAREN()); }
   ")"   { return token(new RPAREN()); }
 

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Expression.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/ast/Expression.scala
@@ -50,6 +50,7 @@ object Expression {
         case FunctionCall(SpecialFunctions.Operator(op), Seq(arg1, arg2), _, _) => findIdentsAndLiterals(arg1) ++ Vector(op) ++ findIdentsAndLiterals(arg2)
         case FunctionCall(SpecialFunctions.Operator(_), _, _, _) => sys.error("Found a non-unary, non-binary operator: " + fc)
         case FunctionCall(SpecialFunctions.Cast(typ), Seq(arg), _, _) => findIdentsAndLiterals(arg) :+ typ.name
+        case FunctionCall(SpecialFunctions.TypeAssert(typ), Seq(arg), _, _) => findIdentsAndLiterals(arg) :+ typ.name
         case FunctionCall(SpecialFunctions.Cast(_), _, _, _) => sys.error("Found a non-unary cast: " + fc)
         case FunctionCall(SpecialFunctions.IsNull, args, _, _) => args.flatMap(findIdentsAndLiterals) ++ Vector("is", "null")
         case FunctionCall(SpecialFunctions.IsNotNull, args, _, _) => args.flatMap(findIdentsAndLiterals) ++ Vector("is", "not", "null")
@@ -169,6 +170,15 @@ object SpecialFunctions {
       case _ => None
     }
     val Regex = """^cast\$(.*)$""".r
+  }
+
+  object TypeAssert {
+    def apply(op: TypeName) = FunctionName("typeassert$" + op.name)
+    def unapply(f: FunctionName) = f.name match {
+      case Regex(x) => Some(TypeName(x))
+      case _ => None
+    }
+    val Regex = """^typeassert\$(.*)$""".r
   }
 }
 
@@ -341,6 +351,8 @@ case class FunctionCall(functionName: FunctionName, parameters: Seq[Expression],
         sys.error("Found a non-unary, non-binary operator: " + op + " at " + position)
       case SpecialFunctions.Cast(typ) if parameters.size == 1 =>
         d"${opArg(parameters(0), parenLowerOnly = true)} :: ${typ.toString}"
+      case SpecialFunctions.TypeAssert(typ) if parameters.size == 1 =>
+        d"${opArg(parameters(0), parenLowerOnly = true)} :! ${typ.toString}"
       case SpecialFunctions.Between =>
         Seq(opArg(parameters(0)), d"BETWEEN ${opArg(parameters(1))}", d"AND ${opArg(parameters(2))}").sep.hang(2)
       case SpecialFunctions.NotBetween =>

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/RecursiveDescentParser.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/parsing/RecursiveDescentParser.scala
@@ -216,7 +216,7 @@ object RecursiveDescentParser {
   private val FILTER_SET = s(FILTER())
   private val DOT_LBRACKET_SET = s(DOT(), LBRACKET())
 
-  private val COLONCOLON_SET = s(COLONCOLON())
+  private val CAST_SET = s(COLONCOLON(), COLONBANG())
 
   // These are all collapsed into "an operator" for ease of
   // interpretation by an end-user instead of getting a bunch of
@@ -1560,8 +1560,11 @@ abstract class RecursiveDescentParser(parameters: AbstractParser.Parameters = Ab
       case op@COLONCOLON() =>
         val ParseResult(r2, (ident, identPos)) = simpleIdentifier(reader.rest)
         cast_!(r2, FunctionCall(SpecialFunctions.Cast(TypeName(ident)), Seq(arg), None)(arg.position, identPos))
+      case op@COLONBANG() =>
+        val ParseResult(r2, (ident, identPos)) = simpleIdentifier(reader.rest)
+        cast_!(r2, FunctionCall(SpecialFunctions.TypeAssert(TypeName(ident)), Seq(arg), None)(arg.position, identPos))
       case _ =>
-        reader.addAlternates(COLONCOLON_SET)
+        reader.addAlternates(CAST_SET)
         ParseResult(reader, arg)
     }
   }

--- a/soql-standalone-parser/src/main/scala/com/socrata/soql/tokens/Tokens.scala
+++ b/soql-standalone-parser/src/main/scala/com/socrata/soql/tokens/Tokens.scala
@@ -85,6 +85,7 @@ case class PERCENT() extends FormattedToken("%")
 // Misc expression-y stuff
 case class PIPEPIPE() extends FormattedToken("||")
 case class COLONCOLON() extends FormattedToken("::")
+case class COLONBANG() extends FormattedToken(":!")
 case class LPAREN() extends FormattedToken("(")
 case class RPAREN() extends FormattedToken(")")
 

--- a/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
+++ b/soql-stdlib/src/main/scala/com/socrata/soql/functions/SoQLFunctions.scala
@@ -798,6 +798,13 @@ object SoQLFunctions {
   }
   val castIdentities = castIdentitiesByType.valuesIterator.toVector
 
+  val typeAssertionsByType = OrderedMap() ++ SoQLType.typesByName.iterator.map { case (n, t) =>
+    t -> mf(":!" + n.caseFolded, SpecialFunctions.TypeAssert(n), Seq(t), Seq.empty, t)(
+      NoDocs
+    )
+  }
+  val typeAssertions = typeAssertionsByType.valuesIterator.toVector
+
   val NumberToText = mf("number to text", SpecialFunctions.Cast(SoQLText.name), Seq(SoQLNumber), Seq.empty, SoQLText)(
     NoDocs
   )
@@ -957,7 +964,7 @@ object SoQLFunctions {
       method <- getClass.getMethods
       if Modifier.isPublic(method.getModifiers) && method.getParameterTypes.length == 0 && method.getReturnType == classOf[Function[_]]
     } yield method.invoke(this).asInstanceOf[Function[SoQLType]]
-    castIdentities ++ reflectedFunctions
+    castIdentities ++ typeAssertions ++ reflectedFunctions
   }
 
   val functionsByIdentity = allFunctions.map { f => f.identity -> f }.toMap


### PR DESCRIPTION
This is exactly like a cast, but it's _only_ defined for same-type conversions.  As a result using `expr :! fixed_timestamp` (for example) will only typecheck if `expr` is a valid fixed_timestamp expression, whereas using `::` would insert a runtime conversion if `expr` checks to text.  More concretely:

```
"2001-01-01T00:00:00Z" :: fixed_timestamp -- works, is a fixed_timestamp literal
"2001-01-01T00:00:00Z" :! fixed_timestamp -- ditto
"hello" :: fixed_timestamp -- typechecks, fails at runtime
"hello" :! fixed_timestamp -- fails to typecheck
```