### PR TITLE
Handle type assertions in the analyzer

### DIFF
--- a/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Typechecker.scala
+++ b/soql-analyzer/src/main/scala/com/socrata/soql/analyzer2/Typechecker.scala
@@ -5,7 +5,7 @@ import scala.util.parsing.input.{Position, NoPosition}
 
 import com.socrata.soql.ast
 import com.socrata.soql.collection.{OrderedMap, CovariantSet}
-import com.socrata.soql.environment.{ColumnName, HoleName, ResourceName, Source, TableName, FunctionName, Provenance}
+import com.socrata.soql.environment.{ColumnName, HoleName, ResourceName, Source, TableName, FunctionName, Provenance, TypeName}
 import com.socrata.soql.functions.FunctionType
 import com.socrata.soql.typechecker.{TypeInfo2, FunctionInfo, FunctionCallTypechecker, Passed, TypeMismatchFailure}
 
@@ -88,6 +88,10 @@ class Typechecker[MT <: MetaTypes](
     Right(acc.valuesIterator.toVector)
   }
 
+  private object NamedType {
+    def unapply(name: TypeName): Option[CT] = typeInfo.typeFor(name)
+  }
+
   private def check(expr: ast.Expression): Either[Error, Seq[Expr]] = {
     expr match {
       case ast.FunctionCall(ast.SpecialFunctions.Parens, Seq(param), None, None) =>
@@ -150,6 +154,8 @@ class Typechecker[MT <: MetaTypes](
           case (Some(checked), Left(_)) => Right(checked)
           case (None, other) => other
         }
+      case ast.FunctionCall(ast.SpecialFunctions.TypeAssert(NamedType(typ)), Seq(param), None, None) =>
+        check(param).flatMap(disambiguate(_, Some(typ), param.position)).map(Seq(_))
       case fc: ast.FunctionCall =>
         checkFuncall(fc).flatMap(squash(_, fc.position))
       case col@ast.ColumnOrAliasRef(None, name) =>

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/SoQLAnalyzerTest.scala
@@ -1741,4 +1741,30 @@ class SoQLAnalyzerTest extends FunSuite with MustMatchers with TestHelper {
     val Right(ft2) = tf2.findTables(0, rn("ds1"), "select a, c", Map.empty)
     val Right(analysis2) = analyzer(ft2, UserParameters.empty)
   }
+
+  test("Type assertions disappear in analysis") {
+    val tf = tableFinder()
+    val Right(ft1) = tf.findTables(0, "SELECT 'hello' :! text from @single_row", Map.empty)
+    val Right(analysis1) = analyzer(ft1, UserParameters.empty)
+    val Right(ft2) = tf.findTables(0, "SELECT 'hello' from @single_row", Map.empty)
+    val Right(analysis2) = analyzer(ft2, UserParameters.empty)
+    analysis1.statement must be (isomorphicTo (analysis2.statement))
+  }
+
+  test("Incorrect assertions result in a type error") {
+    // type assertions are normal functions in the AST, but they're
+    // treated specially by the typechecker, so ensure that the
+    // failure case returns the correct error.
+    val tf = tableFinder()
+    val Right(ft) = tf.findTables(0, "SELECT true :! text from @single_row", Map.empty)
+    analyzer(ft, UserParameters.empty) match {
+      case Left(SoQLAnalyzerError.TypecheckError.TypeMismatch(_, expected, got)) =>
+        expected must equal (Set(TestText.name))
+        got must equal (TestBoolean.name)
+      case Right(_) =>
+        fail("Analysis should have failed")
+      case Left(err) =>
+        fail("Analysis failed with the wrong error: " + err)
+    }
+  }
 }

--- a/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/TestFunctions.scala
+++ b/soql-analyzer/src/test/scala/com/socrata/soql/analyzer2/TestFunctions.scala
@@ -74,6 +74,11 @@ object TestFunctions {
   }
   val castIdentities = castIdentitiesByType.valuesIterator.toVector
 
+  val typeAssertionsByType = OrderedMap() ++ TestType.typesByName.iterator.map { case (n, t) =>
+    t -> mf(":!" + n.caseFolded, SpecialFunctions.TypeAssert(n), Seq(t), Seq.empty, t)
+  }
+  val typeAssertions = typeAssertionsByType.valuesIterator.toVector
+
   def potentialAccessors = for {
     method <- getClass.getMethods
     if Modifier.isPublic(method.getModifiers) && method.getParameterTypes.length == 0
@@ -88,7 +93,7 @@ object TestFunctions {
       method <- getClass.getMethods
       if Modifier.isPublic(method.getModifiers) && method.getParameterTypes.length == 0 && method.getReturnType == classOf[Function[_]]
     } yield method.invoke(this).asInstanceOf[Function[TestType]]
-    castIdentities ++ reflectedFunctions
+    castIdentities ++ typeAssertions ++ reflectedFunctions
   }
 
   val functionsByIdentity = allFunctions.foldLeft(Map.empty[String, Function[TestType]]) { (acc, func) =>


### PR DESCRIPTION
This makes them disappear completely from the analysis (which makes rollup passes able to treat a type-asserted expression as "simple", for things like inlining UDF parameters or creating select list references)